### PR TITLE
BUG: Display an email on 'their details' confirmation page for CCJ

### DIFF
--- a/src/main/features/ccj/views/their-details.njk
+++ b/src/main/features/ccj/views/their-details.njk
@@ -25,7 +25,7 @@
 
 
           <h2 class="heading-medium">{{ t('Email address') }}</h2>
-          <p>{{ claim.claimData.defendant.email.address }}</p>
+          <p>{{ claim.claimData.defendant.email }}</p>
 
           {{ saveAndContinueButton() }}
         </div>


### PR DESCRIPTION
fixed bug - defendant  email on CCJ "their details" confirmation page is displayed