### PR TITLE
[DO NOT MERGE] FIX: defendant email mapping draft -> claim

### DIFF
--- a/src/main/app/claims/claimModelConverter.ts
+++ b/src/main/app/claims/claimModelConverter.ts
@@ -58,8 +58,8 @@ export class ClaimModelConverter {
       delete draftClaim.defendant.mobilePhone
     }
 
-    if (draftClaim.defendant.email && draftClaim.defendant.email.address) {
-      draftClaim.defendant.email = draftClaim.defendant.email.address as any
+    if (draftClaim.defendant.email) {
+      draftClaim.defendant.email = (draftClaim.defendant.email.address || undefined) as any
     }
 
     draftClaim.defendant['type'] = 'individual'


### PR DESCRIPTION
### Change description ###
This is bug fix for production.
When (optional) defendant email is not provided our converter was sending invalid data structure to claim API (string expected, object given) that caused 500 internal error on API side. 

It's already fixed in the newest version of cmc frontend. This fix is a temporary solution only for currently deployed version of cmc citizen frontend.

The same scenario was tested on the latest version of application and everything works well.


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
