### PR TITLE
Hotfix/defendant email mapping

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,6 +95,9 @@ timestamps {
           onMaster {
             packager.publishNodeRPM('citizen-frontend')
           }
+          if (env.BRANCH_NAME.startsWith('hotfix')) {
+            packager.publishNodeRPM('citizen-frontend')
+          }
         }
 
 //        commented out only for bug fix. Tested manually

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "citizen-frontend",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "engines": {
     "node": ">=7.10.1"

--- a/src/main/app/claims/claimModelConverter.ts
+++ b/src/main/app/claims/claimModelConverter.ts
@@ -58,8 +58,8 @@ export class ClaimModelConverter {
       delete draftClaim.defendant.mobilePhone
     }
 
-    if (draftClaim.defendant.email && draftClaim.defendant.email.address) {
-      draftClaim.defendant.email = draftClaim.defendant.email.address as any
+    if (draftClaim.defendant.email) {
+      draftClaim.defendant.email = (draftClaim.defendant.email.address || undefined) as any
     }
 
     draftClaim.defendant['type'] = 'individual'

--- a/src/test/app/claims/claimModelConverter.ts
+++ b/src/test/app/claims/claimModelConverter.ts
@@ -1,3 +1,5 @@
+/* tslint:disable:no-unused-expression */
+
 import { expect } from 'chai'
 
 import DraftClaim from 'drafts/models/draftClaim'
@@ -163,9 +165,18 @@ describe('ClaimModelConverter', () => {
       expect(converted.defendants[0].type).to.equal('individual')
     })
 
-    it('should flatten the email address', () => {
+    it('should flatten non blank email address', () => {
+      draftClaim.defendant.email.address = 'j.other@server.net'
+
       let converted = ClaimModelConverter.convert(draftClaim)
       expect(converted.defendants[0].email).to.equal('j.other@server.net')
+    })
+
+    it('should flatten blank email address', () => {
+      draftClaim.defendant.email.address = ''
+
+      let converted = ClaimModelConverter.convert(draftClaim)
+      expect(converted.defendants[0].email).to.be.undefined
     })
   })
 })


### PR DESCRIPTION
### Change description ###
This is bug fix for production.
When (optional) defendant email is not provided our converter was sending invalid data structure to claim API (string expected, object given) that caused 500 internal error on API side.

It's already fixed in the newest version of cmc frontend. This fix is a temporary solution only for currently deployed version of cmc citizen frontend.

The same scenario was tested on the latest version of application and everything works well.


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
