### PR TITLE
Apply party type to their-details and check-and-send CCJ pages

### DIFF
--- a/src/main/features/ccj/routes/check-and-send.ts
+++ b/src/main/features/ccj/routes/check-and-send.ts
@@ -7,6 +7,7 @@ import { Declaration } from 'ccj/form/models/declaration'
 function prepareUrls (externalId: string): object {
   return {
     addressUrl: Paths.theirDetailsPage.evaluateUri({ externalId: externalId }),
+    dateOfBirthUrl: Paths.dateOfBirthPage.evaluateUri({ externalId: externalId }),
     paidAmountUrl: Paths.paidAmountPage.evaluateUri({ externalId: externalId })
   }
 }

--- a/src/main/features/ccj/views/check-and-send.njk
+++ b/src/main/features/ccj/views/check-and-send.njk
@@ -2,6 +2,7 @@
 {% from "includes/macros/table.njk" import tableStart, tableEnd, row, rowWithMultipleValue %}
 {% from "includes/macros/form.njk" import csrfProtection, submitButton, errorSummary, checkboxGroup %}
 {% from "includes/macros/statement-of-truth.njk" import statementOfTruth %}
+{% from "includes/macros/partyDetails.njk" import partyDetailsSummaryFragment %}
 
 {% set title = t("Money claim") %}
 {% set heading = t("Check your answers") %}
@@ -11,14 +12,15 @@
     {{ csrfProtection(csrf) }}
 
     {{ tableStart("theirDetails", "Their details") }}
-    {{ row('Full name:', user.claim.claimData.defendant.name) }}
     {{
-      rowWithMultipleValue("Address:", [
-        details.defendant.partyDetails.address.line1,
-        details.defendant.partyDetails.address.line2,
-        details.defendant.partyDetails.address.city,
-        details.defendant.partyDetails.address.postcode
-      ], addressUrl)
+      partyDetailsSummaryFragment(
+        partyDetails = user.ccjDraft.defendant.partyDetails,
+        showCorrespondenceAddressSection = false,
+        changeLinks = {
+          partyDetails: addressUrl,
+          dateOfBirth: dateOfBirthUrl
+        }
+      )
     }}
     {{ row("Email:", user.claim.claimData.defendant.email) }}
     {{ tableEnd() }}

--- a/src/main/features/ccj/views/check-and-send.njk
+++ b/src/main/features/ccj/views/check-and-send.njk
@@ -17,7 +17,7 @@
         partyDetails = user.ccjDraft.defendant.partyDetails,
         showCorrespondenceAddressSection = false,
         changeLinks = {
-          partyDetails: addressUrl,
+          address: addressUrl,
           dateOfBirth: dateOfBirthUrl
         }
       )

--- a/src/main/features/ccj/views/their-details.njk
+++ b/src/main/features/ccj/views/their-details.njk
@@ -59,7 +59,9 @@
           )
         }}
 
-        {{ readOnlyField(label = 'Email address', value = claim.claimData.defendant.email) }}
+        {% if claim.claimData.defendant.email %}
+          {{ readOnlyField(label = 'Email address', value = claim.claimData.defendant.email) }}
+        {% endif %}
 
         {{ saveAndContinueButton() }}
       </form>

--- a/src/main/features/ccj/views/their-details.njk
+++ b/src/main/features/ccj/views/their-details.njk
@@ -2,8 +2,9 @@
 
 {% set title = 'Money claim' %}
 
-{% from "includes/macros/form.njk" import saveAndContinueButton, csrfProtection, errorSummary %}
+{% from "includes/macros/form.njk" import readOnlyField, saveAndContinueButton, csrfProtection, errorSummary %}
 {% from "includes/macros/address.njk" import addressFragment %}
+{% from "includes/macros/partyDetails.njk" import partyDetailsFragment %}
 
 {% block content %}
   <div class="grid-row">
@@ -17,18 +18,50 @@
         </h1>
 
         <p>{{ t('Check their address is right. You can correct or update address.') }}</p>
-        <div>
-          <h2 class="heading-medium">{{ t('Full name') }}</h2>
-          <p>{{ claim.claimData.defendant.name }}</p>
+        {% if claim.claimData.defendant.type == 'individual' %}
+          {%
+            set props = [
+              { label: 'Full name', value: claim.claimData.defendant.name, readOnly: true }
+            ]
+          %}
+        {% elseif claim.claimData.defendant.type == 'soleTrader' %}
+          {%
+            set props = [
+              { label: 'Full name', value: claim.claimData.defendant.name, readOnly: true },
+              { label: 'Business name', value: claim.claimData.defendant.businessName, readOnly: true }
+            ]
+          %}
+        {% elseif claim.claimData.defendant.type == 'company' %}
+          {%
+            set props = [
+              { label: 'Company name', value: claim.claimData.defendant.name, readOnly: true },
+              { label: 'Contact person', value: claim.claimData.defendant.contactPerson, readOnly: true }
+            ]
+          %}
+        {% elseif claim.claimData.defendant.type == 'organisation' %}
+          {%
+            set props = [
+              { label: 'Organisation name', value: claim.claimData.defendant.name, readOnly: true },
+              { label: 'Contact person', value: claim.claimData.defendant.contactPerson, readOnly: true }
+            ]
+          %}
+        {% endif %}
 
-          <h2 class="heading-medium">{{ t('Their address') }}</h2>
-          {{ addressFragment(form) }}
+        {{
+          partyDetailsFragment(
+            form,
+            props = props,
+            address = {
+              heading: 'Their address',
+              name: undefined
+            },
+            showCorrespondenceAddress = false
+          )
+        }}
 
-          <h2 class="heading-medium">{{ t('Email address') }}</h2>
-          <p>{{ claim.claimData.defendant.email }}</p>
+        {{ readOnlyField(label = 'Email address', value = claim.claimData.defendant.email) }}
 
-          {{ saveAndContinueButton() }}
-        </div>
+        {{ saveAndContinueButton() }}
       </form>
     </div>
   </div>

--- a/src/main/features/ccj/views/their-details.njk
+++ b/src/main/features/ccj/views/their-details.njk
@@ -20,27 +20,27 @@
         <p>{{ t('Check their address is right. You can correct or update address.') }}</p>
         {% if claim.claimData.defendant.type == 'individual' %}
           {%
-            set props = [
+            set fields = [
               { label: 'Full name', value: claim.claimData.defendant.name, readOnly: true }
             ]
           %}
         {% elseif claim.claimData.defendant.type == 'soleTrader' %}
           {%
-            set props = [
+            set fields = [
               { label: 'Full name', value: claim.claimData.defendant.name, readOnly: true },
               { label: 'Business name', value: claim.claimData.defendant.businessName, readOnly: true }
             ]
           %}
         {% elseif claim.claimData.defendant.type == 'company' %}
           {%
-            set props = [
+            set fields = [
               { label: 'Company name', value: claim.claimData.defendant.name, readOnly: true },
               { label: 'Contact person', value: claim.claimData.defendant.contactPerson, readOnly: true }
             ]
           %}
         {% elseif claim.claimData.defendant.type == 'organisation' %}
           {%
-            set props = [
+            set fields = [
               { label: 'Organisation name', value: claim.claimData.defendant.name, readOnly: true },
               { label: 'Contact person', value: claim.claimData.defendant.contactPerson, readOnly: true }
             ]
@@ -50,12 +50,12 @@
         {{
           partyDetailsFragment(
             form,
-            props = props,
-            address = {
+            fields = fields,
+            addressSection = {
               heading: 'Their address',
               name: undefined
             },
-            showCorrespondenceAddress = false
+            showCorrespondenceAddressSection = false
           )
         }}
 

--- a/src/main/features/claim/views/check-and-send.njk
+++ b/src/main/features/claim/views/check-and-send.njk
@@ -2,75 +2,31 @@
 {% from "includes/macros/table.njk" import tableStart,tableEnd, row, rowWithMultipleValue %}
 {% from "includes/macros/form.njk" import csrfProtection, submitButton, errorSummary, checkboxGroup %}
 {% from "includes/macros/statement-of-truth.njk" import statementOfTruth %}
+{% from "includes/macros/partyDetails.njk" import partyDetailsSummaryFragment %}
 
 {% set title = t("Money claim") %}
 {% set heading = t("Check your answers before submitting your claim") %}
-{% set partyType = draftClaim.claimant.partyDetails.type %}
-{% set claimantPartyType = draftClaim.claimant.partyDetails.type %}
-{% set defendantPartyType = draftClaim.defendant.partyDetails.type %}
-
-{% if draftClaim.claimant.partyDetails.hasCorrespondenceAddress %}
-  {% set correspondenceAddressLines = [
-    draftClaim.claimant.partyDetails.correspondenceAddress.line1,
-    draftClaim.claimant.partyDetails.correspondenceAddress.line2,
-    draftClaim.claimant.partyDetails.correspondenceAddress.city,
-    draftClaim.claimant.partyDetails.correspondenceAddress.postcode
-  ] %}
-{% else %}
-  {% set correspondenceAddressLines = [t('Same as address')] %}
-{% endif %}
 
 {% block content %}
   <form novalidate method="post">
     {{ csrfProtection(csrf) }}
 
     {{ tableStart("yourDetails", "Your details") }}
-    {{ row("Name:", draftClaim.claimant.partyDetails.name) }}
-    {% if (partyType === 'company' or partyType === 'organisation') %}
-      {% if (contactPerson) %}
-        {{ row("Contact Name:", contactPerson) }}
-      {% endif %}
-    {% endif %}
-    {% if (partyType === 'soleTrader') %}
-      {{ row("Business name:", 'Trading as ' + businessName ) }}
-    {% endif %}
     {{
-      rowWithMultipleValue(
-        label = "Address:",
-        values = [draftClaim.claimant.partyDetails.address.line1,
-          draftClaim.claimant.partyDetails.address.line2,
-          draftClaim.claimant.partyDetails.address.city,
-          draftClaim.claimant.partyDetails.address.postcode],
-        bottomBorder = false
+      partyDetailsSummaryFragment(
+        partyDetails = draftClaim.claimant.partyDetails
       )
     }}
-    {{
-      rowWithMultipleValue(
-        label = "Correspondence address:",
-        values = correspondenceAddressLines
-      )
-    }}
-    {% if (partyType === 'individual') %}
-      {{ row("Date of birth:", dateOfBirth.date.asString() | date) }}
-    {% endif %}
     {{ row("Phone:", draftClaim.claimant.mobilePhone.number) }}
     {{ tableEnd() }}
 
     {{ tableStart("theirDetails", "Their details") }}
-    {{ row('Name:', draftClaim.defendant.partyDetails.name) }}
-    {% if (defendantPartyType === 'company' or defendantPartyType === 'organisation') %}
-      {% if (defendantContactPerson) %}
-        {{ row("Contact Name:", defendantContactPerson) }}
-      {% endif %}
-    {% endif %}
-    {% if (defendantPartyType === 'soleTrader') %}
-      {{ row("Business name:", 'Trading as ' + defendantBusinessName ) }}
-    {% endif %}
-    {{ rowWithMultipleValue("Address:", [
-    draftClaim.defendant.partyDetails.address.line1,
-    draftClaim.defendant.partyDetails.address.line2,
-    draftClaim.defendant.partyDetails.address.city,
-    draftClaim.defendant.partyDetails.address.postcode]) }}
+    {{
+      partyDetailsSummaryFragment(
+        partyDetails = draftClaim.defendant.partyDetails,
+        showCorrespondenceAddressSection = false
+      )
+    }}
     {{ row("Email:", draftClaim.defendant.email.address) }}
     {{ tableEnd() }}
 

--- a/src/main/features/claim/views/claimant-company-details.njk
+++ b/src/main/features/claim/views/claimant-company-details.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
 {% from "includes/macros/form.njk" import csrfProtection, saveAndContinueButton, errorSummary %}
-{% from "includes/macros/partyDetails.njk" import companyDetailsFragment %}
+{% from "includes/macros/partyDetails.njk" import partyDetailsFragment %}
 
 {% set title = t('Money claim') %}
 {% set heading = t('Company details') %}
@@ -12,13 +12,18 @@
         {{ csrfProtection(csrf) }}
 
         {{
-          companyDetailsFragment(
+          partyDetailsFragment(
             form,
-            nameLabel = 'Company name',
-            contactPersonLabel = 'Contact person',
-            addressHeading = "Company address",
-            addressHint = "Enter the company’s registered office or a company address that has a connection with the claim.",
-            hasCorrespondenceAddress = true
+            fields = [
+              { label: 'Company name', name: 'name' },
+              { label: 'Contact person', name: 'contactPerson' }
+            ],
+            addressSection = {
+              heading: 'Company address',
+              hint: "Enter the company's registered office or a company address that has a connection with the claim.",
+              name: 'address'
+            },
+            showCorrespondenceAddressSection = true
           )
         }}
 

--- a/src/main/features/claim/views/claimant-company-details.njk
+++ b/src/main/features/claim/views/claimant-company-details.njk
@@ -20,7 +20,7 @@
             ],
             addressSection = {
               heading: 'Company address',
-              hint: "Enter the company's registered office or a company address that has a connection with the claim.",
+              hint: "Enter the company’s registered office or a company address that has a connection with the claim.",
               name: 'address'
             },
             showCorrespondenceAddressSection = true

--- a/src/main/features/claim/views/claimant-company-details.njk
+++ b/src/main/features/claim/views/claimant-company-details.njk
@@ -20,7 +20,7 @@
             ],
             addressSection = {
               heading: 'Company address',
-              hint: "Enter the company’s registered office or a company address that has a connection with the claim.",
+              hint: 'Enter the company’s registered office or a company address that has a connection with the claim.',
               name: 'address'
             },
             showCorrespondenceAddressSection = true

--- a/src/main/features/claim/views/claimant-individual-details.njk
+++ b/src/main/features/claim/views/claimant-individual-details.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
 {% from "includes/macros/form.njk" import csrfProtection, saveAndContinueButton, errorSummary %}
-{% from "includes/macros/partyDetails.njk" import individualDetailsFragment %}
+{% from "includes/macros/partyDetails.njk" import partyDetailsFragment %}
 
 {% set title = t('Money claim') %}
 {% set heading = t('Your details') %}
@@ -12,12 +12,17 @@
         {{ csrfProtection(csrf) }}
 
         {{
-          individualDetailsFragment(
+          partyDetailsFragment(
             form,
-            nameLabel = 'Full name',
-            addressHeading = "Your residential address",
-            addressHint = "This must be the address where you live.",
-            hasCorrespondenceAddress = true
+            fields = [
+              { label: 'Full name', name: 'name' }
+            ],
+            addressSection = {
+              heading: 'Your residential address',
+              hint: 'This must be the address where you live.',
+              name: 'address'
+            },
+            showCorrespondenceAddressSection = true
           )
         }}
 

--- a/src/main/features/claim/views/claimant-organisation-details.njk
+++ b/src/main/features/claim/views/claimant-organisation-details.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
 {% from "includes/macros/form.njk" import csrfProtection, saveAndContinueButton, errorSummary %}
-{% from "includes/macros/partyDetails.njk" import organisationDetailsFragment %}
+{% from "includes/macros/partyDetails.njk" import partyDetailsFragment %}
 
 {% set title = t('Money claim') %}
 {% set heading = t('Organisation details') %}
@@ -12,13 +12,18 @@
         {{ csrfProtection(csrf) }}
 
         {{
-          organisationDetailsFragment(
+          partyDetailsFragment(
             form,
-            nameLabel = 'Organisation name',
-            contactPersonLabel = 'Contact person',
-            addressHeading = "Organisation address",
-            addressHint = "Enter the organisation's main office or an organisation's address that has a connection with the claim.",
-            hasCorrespondenceAddress = true
+            fields = [
+              { label: 'Organisation name', name: 'name' },
+              { label: 'Contact person', name: 'contactPerson' }
+            ],
+            addressSection = {
+              heading: 'Organisation address',
+              hint: "Enter the organisation's main office or an organisation's address that has a connection with the claim.",
+              name: 'address'
+            },
+            showCorrespondenceAddressSection = true
           )
         }}
 

--- a/src/main/features/claim/views/claimant-organisation-details.njk
+++ b/src/main/features/claim/views/claimant-organisation-details.njk
@@ -20,7 +20,7 @@
             ],
             addressSection = {
               heading: 'Organisation address',
-              hint: "Enter the organisation's main office or an organisation's address that has a connection with the claim.",
+              hint: "Enter the organisation’s main office or an organisation’s address that has a connection with the claim.",
               name: 'address'
             },
             showCorrespondenceAddressSection = true

--- a/src/main/features/claim/views/claimant-organisation-details.njk
+++ b/src/main/features/claim/views/claimant-organisation-details.njk
@@ -20,7 +20,7 @@
             ],
             addressSection = {
               heading: 'Organisation address',
-              hint: "Enter the organisation’s main office or an organisation’s address that has a connection with the claim.",
+              hint: 'Enter the organisation’s main office or an organisation’s address that has a connection with the claim.',
               name: 'address'
             },
             showCorrespondenceAddressSection = true

--- a/src/main/features/claim/views/claimant-sole-trader-details.njk
+++ b/src/main/features/claim/views/claimant-sole-trader-details.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
 {% from "includes/macros/form.njk" import csrfProtection, saveAndContinueButton, errorSummary %}
-{% from "includes/macros/partyDetails.njk" import soleTraderDetailsFragment %}
+{% from "includes/macros/partyDetails.njk" import partyDetailsFragment %}
 
 {% set title = t('Money claim') %}
 {% set heading = t('Your details') %}
@@ -12,12 +12,18 @@
         {{ csrfProtection(csrf) }}
 
         {{
-          soleTraderDetailsFragment(
+          partyDetailsFragment(
             form,
-            nameLabel = 'Full name',
-            addressHeading = "Your address",
-            addressHint = "This must be the address where you live or trade.",
-            hasCorrespondenceAddress = true
+            fields = [
+              { label: 'Full name', name: 'name' },
+              { label: 'Business name (optional)', name: 'businessName' }
+            ],
+            addressSection = {
+              heading: 'Your address',
+              hint: 'This must be the address where you live or trade.',
+              name: 'address'
+            },
+            showCorrespondenceAddressSection = true
           )
         }}
 

--- a/src/main/features/claim/views/defendant-company-details.njk
+++ b/src/main/features/claim/views/defendant-company-details.njk
@@ -20,7 +20,7 @@
             ],
             addressSection = {
               heading: 'Company address',
-              hint: "Enter the company's registered office or a company address that has a connection with the claim.",
+              hint: "Enter the company’s registered office or a company address that has a connection with the claim.",
               name: 'address'
             },
             showCorrespondenceAddressSection = false

--- a/src/main/features/claim/views/defendant-company-details.njk
+++ b/src/main/features/claim/views/defendant-company-details.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
 {% from "includes/macros/form.njk" import csrfProtection, saveAndContinueButton, errorSummary %}
-{% from "includes/macros/partyDetails.njk" import companyDetailsFragment %}
+{% from "includes/macros/partyDetails.njk" import partyDetailsFragment %}
 
 {% set title = t('Money claim') %}
 {% set heading = t('Company details') %}
@@ -12,13 +12,18 @@
         {{ csrfProtection(csrf) }}
 
         {{
-          companyDetailsFragment(
+          partyDetailsFragment(
             form,
-            nameLabel = 'Company name',
-            contactPersonLabel = 'Contact person (optional)',
-            addressHeading = "Company address",
-            addressHint = "Enter the company’s registered office or a company address that has a connection with the claim.",
-            hasCorrespondenceAddress = false
+            fields = [
+              { label: 'Company name', name: 'name' },
+              { label: 'Contact person (optional)', name: 'contactPerson' }
+            ],
+            addressSection = {
+              heading: 'Company address',
+              hint: "Enter the company's registered office or a company address that has a connection with the claim.",
+              name: 'address'
+            },
+            showCorrespondenceAddressSection = false
           )
         }}
 

--- a/src/main/features/claim/views/defendant-company-details.njk
+++ b/src/main/features/claim/views/defendant-company-details.njk
@@ -20,7 +20,7 @@
             ],
             addressSection = {
               heading: 'Company address',
-              hint: "Enter the company’s registered office or a company address that has a connection with the claim.",
+              hint: 'Enter the company’s registered office or a company address that has a connection with the claim.',
               name: 'address'
             },
             showCorrespondenceAddressSection = false

--- a/src/main/features/claim/views/defendant-individual-details.njk
+++ b/src/main/features/claim/views/defendant-individual-details.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
 {% from "includes/macros/form.njk" import csrfProtection, saveAndContinueButton, errorSummary %}
-{% from "includes/macros/partyDetails.njk" import individualDetailsFragment %}
+{% from "includes/macros/partyDetails.njk" import partyDetailsFragment %}
 
 {% set title = t('Money claim') %}
 {% set heading = t('Their details') %}
@@ -12,12 +12,17 @@
         {{ csrfProtection(csrf) }}
 
         {{
-          individualDetailsFragment(
+          partyDetailsFragment(
             form,
-            nameLabel = "Full name",
-            addressHeading = "Their residential address",
-            addressHint = "You must enter the defendant's residential address to make a claim against them.",
-            hasCorrespondenceAddress = false
+            fields = [
+              { label: 'Full name', name: 'name' }
+            ],
+            addressSection = {
+              heading: 'Their residential address',
+              hint: "You must enter the defendant's residential address to make a claim against them.",
+              name: 'address'
+            },
+            showCorrespondenceAddressSection = false
           )
         }}
 

--- a/src/main/features/claim/views/defendant-individual-details.njk
+++ b/src/main/features/claim/views/defendant-individual-details.njk
@@ -19,7 +19,7 @@
             ],
             addressSection = {
               heading: 'Their residential address',
-              hint: "You must enter the defendant’s residential address to make a claim against them.",
+              hint: 'You must enter the defendant’s residential address to make a claim against them.',
               name: 'address'
             },
             showCorrespondenceAddressSection = false

--- a/src/main/features/claim/views/defendant-individual-details.njk
+++ b/src/main/features/claim/views/defendant-individual-details.njk
@@ -19,7 +19,7 @@
             ],
             addressSection = {
               heading: 'Their residential address',
-              hint: "You must enter the defendant's residential address to make a claim against them.",
+              hint: "You must enter the defendant’s residential address to make a claim against them.",
               name: 'address'
             },
             showCorrespondenceAddressSection = false

--- a/src/main/features/claim/views/defendant-organisation-details.njk
+++ b/src/main/features/claim/views/defendant-organisation-details.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
 {% from "includes/macros/form.njk" import csrfProtection, saveAndContinueButton, errorSummary %}
-{% from "includes/macros/partyDetails.njk" import organisationDetailsFragment %}
+{% from "includes/macros/partyDetails.njk" import partyDetailsFragment %}
 
 {% set title = t('Money claim') %}
 {% set heading = t('Organisation details') %}
@@ -12,13 +12,18 @@
         {{ csrfProtection(csrf) }}
 
         {{
-          organisationDetailsFragment(
+          partyDetailsFragment(
             form,
-            nameLabel = 'Organisation name',
-            contactPersonLabel = 'Contact person (optional)',
-            addressHeading = "Organisation address",
-            addressHint = "Enter the organisation's main office or a organisation's address that has a connection with the claim.",
-            hasCorrespondenceAddress = false
+            fields = [
+              { label: 'Organisation name', name: 'name' },
+              { label: 'Contact person (optional)', name: 'contactPerson' }
+            ],
+            addressSection = {
+              heading: 'Organisation address',
+              hint: "Enter the organisation's main office or a organisation's address that has a connection with the claim.",
+              name: 'address'
+            },
+            showCorrespondenceAddressSection = false
           )
         }}
 

--- a/src/main/features/claim/views/defendant-organisation-details.njk
+++ b/src/main/features/claim/views/defendant-organisation-details.njk
@@ -20,7 +20,7 @@
             ],
             addressSection = {
               heading: 'Organisation address',
-              hint: "Enter the organisation’s main office or a organisation’s address that has a connection with the claim.",
+              hint: 'Enter the organisation’s main office or a organisation’s address that has a connection with the claim.',
               name: 'address'
             },
             showCorrespondenceAddressSection = false

--- a/src/main/features/claim/views/defendant-organisation-details.njk
+++ b/src/main/features/claim/views/defendant-organisation-details.njk
@@ -20,7 +20,7 @@
             ],
             addressSection = {
               heading: 'Organisation address',
-              hint: "Enter the organisation's main office or a organisation's address that has a connection with the claim.",
+              hint: "Enter the organisation’s main office or a organisation’s address that has a connection with the claim.",
               name: 'address'
             },
             showCorrespondenceAddressSection = false

--- a/src/main/features/claim/views/defendant-sole-trader-details.njk
+++ b/src/main/features/claim/views/defendant-sole-trader-details.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
 {% from "includes/macros/form.njk" import csrfProtection, saveAndContinueButton, errorSummary %}
-{% from "includes/macros/partyDetails.njk" import soleTraderDetailsFragment %}
+{% from "includes/macros/partyDetails.njk" import partyDetailsFragment %}
 
 {% set title = t('Money claim') %}
 {% set heading = t('Their details') %}
@@ -12,12 +12,18 @@
         {{ csrfProtection(csrf) }}
 
         {{
-          soleTraderDetailsFragment(
+          partyDetailsFragment(
             form,
-            nameLabel = "Full name",
-            addressHeading = "Their address",
-            addressHint = "You must enter the defendant's residential or trade address to make a claim against them.",
-            hasCorrespondenceAddress = false
+            fields = [
+              { label: 'Full name', name: 'name' },
+              { label: 'Business name (optional)', name: 'businessName' }
+            ],
+            addressSection = {
+              heading: 'Their address',
+              hint: "You must enter the defendant's residential or trade address to make a claim against them.",
+              name: 'address'
+            },
+            showCorrespondenceAddressSection = false
           )
         }}
 

--- a/src/main/features/claim/views/defendant-sole-trader-details.njk
+++ b/src/main/features/claim/views/defendant-sole-trader-details.njk
@@ -20,7 +20,7 @@
             ],
             addressSection = {
               heading: 'Their address',
-              hint: "You must enter the defendant’s residentials or trade address to make a claim against them.",
+              hint: 'You must enter the defendant’s residentials or trade address to make a claim against them.',
               name: 'address'
             },
             showCorrespondenceAddressSection = false

--- a/src/main/features/claim/views/defendant-sole-trader-details.njk
+++ b/src/main/features/claim/views/defendant-sole-trader-details.njk
@@ -20,7 +20,7 @@
             ],
             addressSection = {
               heading: 'Their address',
-              hint: "You must enter the defendant's residential or trade address to make a claim against them.",
+              hint: "You must enter the defendant’s residentials or trade address to make a claim against them.",
               name: 'address'
             },
             showCorrespondenceAddressSection = false

--- a/src/main/features/response/views/check-and-send.njk
+++ b/src/main/features/response/views/check-and-send.njk
@@ -2,59 +2,25 @@
 {% from "includes/macros/table.njk" import tableStart, tableEnd, row, rowWithMultipleValue %}
 {% from "includes/macros/form.njk" import csrfProtection, submitButton, errorSummary, checkboxGroup %}
 {% from "includes/macros/statement-of-truth.njk" import statementOfTruth %}
+{% from "includes/macros/partyDetails.njk" import partyDetailsSummaryFragment %}
 
 {% set title = t("Money claim") %}
 {% set heading = t("Check your answers before submitting your response") %}
-
-{% if draft.defendantDetails.partyDetails.hasCorrespondenceAddress  %}
-  {% set correspondenceAddressLines = [
-    draft.defendantDetails.partyDetails.correspondenceAddress.line1,
-    draft.defendantDetails.partyDetails.correspondenceAddress.line2,
-    draft.defendantDetails.partyDetails.correspondenceAddress.city,
-    draft.defendantDetails.partyDetails.correspondenceAddress.postcode
-  ] %}
-{% else %}
-  {% set correspondenceAddressLines = [t('Same as address')] %}
-{% endif %}
 
 {% block content %}
   <form novalidate method="post">
     {{ csrfProtection(csrf) }}
 
     {{ tableStart("yourDetails", "Your details") }}
-
-    {{ row("Name:", draft.defendantDetails.partyDetails.name, paths.defendantYourDetailsPage.uri) }}
-
-    {% if draft.defendantDetails.partyDetails.type === 'company' or draft.defendantDetails.partyDetails.type === 'organisation' %}
-      {% if draft.defendantDetails.partyDetails.contactPerson %}
-        {{ row("Contact name:", draft.defendantDetails.partyDetails.contactPerson, paths.defendantYourDetailsPage.uri) }}
-      {% endif %}
-    {% endif %}
-
-    {% if draft.defendantDetails.partyDetails.type === 'soleTrader' %}
-      {{ row("Business name:", 'Trading as ' + draft.defendantDetails.partyDetails.businessName ) }}
-    {% endif %}
-
     {{
-      rowWithMultipleValue(
-        label = "Address:",
-        values = [ draft.defendantDetails.partyDetails.address.line1, draft.defendantDetails.partyDetails.address.line2, draft.defendantDetails.partyDetails.address.city, draft.defendantDetails.partyDetails.address.postcode ],
-        changeLink = paths.defendantYourDetailsPage.uri,
-        bottomBorder = false
+      partyDetailsSummaryFragment(
+        partyDetails = draft.defendantDetails.partyDetails,
+        changeLinks = {
+          partyDetails: paths.defendantYourDetailsPage.uri,
+          dateOfBirth: paths.defendantDateOfBirthPage.uri
+        }
       )
     }}
-
-    {{
-      rowWithMultipleValue(
-        label = "Correspondence address:",
-        values = correspondenceAddressLines
-      )
-    }}
-
-    {% if draft.defendantDetails.partyDetailspartyType === 'individual' %}
-      {{ row("Date of birth:", draft.defendantDetails.partyDetails.dateOfBirth.date.toMoment() | date, paths.defendantDateOfBirthPage.uri) }}
-    {% endif %}
-
     {{ row("Phone:", draft.defendantDetails.mobilePhone.number, paths.defendantMobilePage.uri) }}
 
     {{ tableEnd() }}

--- a/src/main/features/response/views/your-details.njk
+++ b/src/main/features/response/views/your-details.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
 {% from "includes/macros/form.njk" import csrfProtection, textInput, radioGroup, saveAndContinueButton, errorSummary %}
-{% from "includes/macros/partyDetails.njk" import individualDetailsFragment, soleTraderDetailsFragment, companyDetailsFragment, organisationDetailsFragment %}
+{% from "includes/macros/partyDetails.njk" import partyDetailsFragment %}
 
 {% set title = t('Money claim') %}
 {% set heading = t('Confirm your details') %}
@@ -13,44 +13,49 @@
         <input type="hidden" name="type" value="{{ form.model.type }}">
 
         {% if form.model.type == 'individual' %}
-          {{
-            individualDetailsFragment(
-              form,
-              nameLabel = "Your full name",
-              addressHeading = "Your address",
-              hasCorrespondenceAddress = true
-            )
-          }}
+          {%
+            set fields = [
+              { label: 'Your full name', name: 'name' }
+            ]
+          %}
+          {% set addressSectionHeading = 'Your address' %}
         {% elif form.model.type == 'soleTrader' %}
-          {{
-            soleTraderDetailsFragment(
-              form,
-              nameLabel = "Your full name",
-              addressHeading = "Your address",
-              hasCorrespondenceAddress = true
-            )
-          }}
+          {%
+            set fields = [
+              { label: 'Your full name', name: 'name' },
+              { label: 'Business name (optional)', name: 'businessName' }
+            ]
+          %}
+          {% set addressSectionHeading = 'Your address' %}
         {% elif form.model.type == 'company' %}
-          {{
-            companyDetailsFragment(
-              form,
-              nameLabel = "Company name",
-              contactPersonLabel = 'Contact person (optional)',
-              addressHeading = "Company address",
-              hasCorrespondenceAddress = true
-              )
-            }}
+          {%
+            set fields = [
+              { label: 'Company name', name: 'name' },
+              { label: 'Contact person (optional)', name: 'contactPerson' }
+            ]
+          %}
+          {% set addressSectionHeading = 'Company address' %}
         {% elif form.model.type == 'organisation' %}
-          {{
-            organisationDetailsFragment(
-              form,
-              nameLabel = "Organisation name",
-              contactPersonLabel = 'Contact person (optional)',
-              addressHeading = "Organisation address",
-              hasCorrespondenceAddress = true
-            )
-          }}
+          {%
+            set fields = [
+              { label: 'Organisation name', name: 'name' },
+              { label: 'Contact person (optional)', name: 'contactPerson' }
+            ]
+          %}
+          {% set addressSectionHeading = 'Organisation address' %}
         {% endif %}
+
+        {{
+          partyDetailsFragment(
+            form,
+            fields = fields,
+            addressSection = {
+              heading: addressSectionHeading,
+              name: 'address'
+            },
+            showCorrespondenceAddressSection = true
+          )
+        }}
 
         {{ saveAndContinueButton() }}
       </form>

--- a/src/main/views/includes/macros/form.njk
+++ b/src/main/views/includes/macros/form.njk
@@ -189,3 +189,8 @@
 {% macro nameInput(label = 'Your full name', form) %}
   {{ textInput(t(label), 'name', form, autocomplete='name') }}
 {% endmacro %}
+
+{% macro readOnlyField(label, value) %}
+  <h2 class="heading-medium">{{ t(label) }}</h2>
+  <p>{{ value }}</p>
+{% endmacro %}

--- a/src/main/views/includes/macros/partyDetails.njk
+++ b/src/main/views/includes/macros/partyDetails.njk
@@ -1,5 +1,27 @@
-{% from "includes/macros/form.njk" import csrfProtection, textInput, radioGroup, saveAndContinueButton %}
+{% from "includes/macros/form.njk" import readOnlyField, csrfProtection, textInput, radioGroup, saveAndContinueButton %}
 {% from "includes/macros/address.njk" import addressFragment, correspondenceAddressFragment %}
+
+{% macro partyDetailsFragment(form, props, address, showCorrespondenceAddress = false) %}
+  {% for prop in props %}
+    {% if prop.readOnly %}
+      {{ readOnlyField(prop.label, prop.value) }}
+    {% else %}
+      {{ textInput(form, label = t(prop.label), name = prop.name, autocomplete = prop.autocomplete) }}
+    {% endif %}
+  {% endfor %}
+
+  {% if address %}
+    <h2 class="heading-medium">{{ t(address.heading) }}</h2>
+    {% if address.hint %}
+      <p>{{ t(address.hint) }}</p>
+    {% endif %}
+    {{ addressFragment(form, name = address.name) }}
+  {% endif %}
+
+  {% if showCorrespondenceAddress == true %}
+    {{ correspondenceAddressFragment(form) }}
+  {% endif %}
+{% endmacro %}
 
 {% macro individualDetailsFragment(form, nameLabel = 'Full name', addressHeading = 'Address', addressHint, hasCorrespondenceAddress = false) %}
   {{ textInput(t(nameLabel), 'name', form, autocomplete = 'name') }}

--- a/src/main/views/includes/macros/partyDetails.njk
+++ b/src/main/views/includes/macros/partyDetails.njk
@@ -1,83 +1,24 @@
 {% from "includes/macros/form.njk" import readOnlyField, csrfProtection, textInput, radioGroup, saveAndContinueButton %}
 {% from "includes/macros/address.njk" import addressFragment, correspondenceAddressFragment %}
 
-{% macro partyDetailsFragment(form, props, address, showCorrespondenceAddress = false) %}
-  {% for prop in props %}
-    {% if prop.readOnly %}
-      {{ readOnlyField(prop.label, prop.value) }}
+{% macro partyDetailsFragment(form, fields, addressSection, showCorrespondenceAddressSection = false) %}
+  {% for field in fields %}
+    {% if field.readOnly %}
+      {{ readOnlyField(field.label, field.value) }}
     {% else %}
-      {{ textInput(form, label = t(prop.label), name = prop.name, autocomplete = prop.autocomplete) }}
+      {{ textInput(form = form, label = t(field.label), name = field.name, autocomplete = field.autocomplete) }}
     {% endif %}
   {% endfor %}
 
-  {% if address %}
-    <h2 class="heading-medium">{{ t(address.heading) }}</h2>
-    {% if address.hint %}
-      <p>{{ t(address.hint) }}</p>
+  {% if addressSection %}
+    <h2 class="heading-medium">{{ t(addressSection.heading) }}</h2>
+    {% if addressSection.hint %}
+      <p>{{ t(addressSection.hint) }}</p>
     {% endif %}
-    {{ addressFragment(form, name = address.name) }}
+    {{ addressFragment(form = form, name = addressSection.name) }}
   {% endif %}
 
-  {% if showCorrespondenceAddress == true %}
-    {{ correspondenceAddressFragment(form) }}
-  {% endif %}
-{% endmacro %}
-
-{% macro individualDetailsFragment(form, nameLabel = 'Full name', addressHeading = 'Address', addressHint, hasCorrespondenceAddress = false) %}
-  {{ textInput(t(nameLabel), 'name', form, autocomplete = 'name') }}
-
-  <h2 class="heading-medium">{{ t(addressHeading) }}</h2>
-  {% if addressHint %}
-    <p>{{ t(addressHint) }}</p>
-  {% endif %}
-  {{ addressFragment(form, name = 'address') }}
-
-  {% if hasCorrespondenceAddress == true %}
-    {{ correspondenceAddressFragment(form) }}
-  {% endif %}
-{% endmacro %}
-
-{% macro soleTraderDetailsFragment(form, nameLabel = 'Full name', addressHeading = 'Address', addressHint, hasCorrespondenceAddress = false) %}
-  {{ textInput(t(nameLabel), 'name', form, autocomplete = 'name') }}
-  {{ textInput(t('Business name (optional)'), 'businessName', form) }}
-
-  <h2 class="heading-medium">{{ t(addressHeading) }}</h2>
-  {% if addressHint %}
-    <p>{{ t(addressHint) }}</p>
-  {% endif %}
-  {{ addressFragment(form, name = 'address') }}
-
-  {% if hasCorrespondenceAddress == true %}
-    {{ correspondenceAddressFragment(form) }}
-  {% endif %}
-{% endmacro %}
-
-{% macro companyDetailsFragment(form, nameLabel = 'Company name', contactPersonLabel = 'Contact person', addressHeading = 'Company address', addressHint, hasCorrespondenceAddress = false) %}
-  {{ textInput(t(nameLabel), 'name', form, autocomplete = 'companyName') }}
-  {{ textInput(t(contactPersonLabel), 'contactPerson', form) }}
-
-  <h2 class="heading-medium">{{ t(addressHeading) }}</h2>
-  {% if addressHint %}
-    <p>{{ t(addressHint) }}</p>
-  {% endif %}
-  {{ addressFragment(form, name = 'address') }}
-
-  {% if hasCorrespondenceAddress == true %}
-    {{ correspondenceAddressFragment(form) }}
-  {% endif %}
-{% endmacro %}
-
-{% macro organisationDetailsFragment(form, nameLabel = 'Organisation name', contactPersonLabel = 'Contact person', addressHeading = 'Organisation address', addressHint, hasCorrespondenceAddress = false) %}
-  {{ textInput(t(nameLabel), 'name', form) }}
-  {{ textInput(t(contactPersonLabel), 'contactPerson', form) }}
-
-  <h2 class="heading-medium">{{ t(addressHeading) }}</h2>
-  {% if addressHint %}
-    <p>{{ t(addressHint) }}</p>
-  {% endif %}
-  {{ addressFragment(form, name = 'address') }}
-
-  {% if hasCorrespondenceAddress == true %}
+  {% if showCorrespondenceAddressSection == true %}
     {{ correspondenceAddressFragment(form) }}
   {% endif %}
 {% endmacro %}

--- a/src/main/views/includes/macros/partyDetails.njk
+++ b/src/main/views/includes/macros/partyDetails.njk
@@ -1,5 +1,6 @@
 {% from "includes/macros/form.njk" import readOnlyField, csrfProtection, textInput, radioGroup, saveAndContinueButton %}
 {% from "includes/macros/address.njk" import addressFragment, correspondenceAddressFragment %}
+{% from "includes/macros/table.njk" import tableStart,tableEnd, row, rowWithMultipleValue %}
 
 {% macro partyDetailsFragment(form, fields, addressSection, showCorrespondenceAddressSection = false) %}
   {% for field in fields %}
@@ -20,5 +21,61 @@
 
   {% if showCorrespondenceAddressSection == true %}
     {{ correspondenceAddressFragment(form) }}
+  {% endif %}
+{% endmacro %}
+
+{% macro partyDetailsSummaryFragment(partyDetails, showCorrespondenceAddressSection = true, changeLinks = {}) %}
+  {{ row("Name:", partyDetails.name, changeLinks.partyDetails) }}
+
+  {% if (partyDetails.type === 'company' or partyDetails.type === 'organisation') %}
+    {% if partyDetails.contactPerson %}
+      {{ row("Contact person:", partyDetails.contactPerson, changeLinks.partyDetails) }}
+    {% endif %}
+  {% endif %}
+
+  {% if (partyDetails.type === 'soleTrader') %}
+    {% if partyDetails.businessName %}
+      {{ row("Business name:", 'Trading as ' + partyDetails.businessName, changeLinks.partyDetails) }}
+    {% endif %}
+  {% endif %}
+
+  {{
+    rowWithMultipleValue(
+      label = "Address:",
+      values = [
+        partyDetails.address.line1,
+        partyDetails.address.line2,
+        partyDetails.address.city,
+        partyDetails.address.postcode
+      ],
+      bottomBorder = not showCorrespondenceAddressSection,
+      changeLink = changeLinks.partyDetails
+    )
+  }}
+
+  {% if showCorrespondenceAddressSection %}
+    {% if partyDetails.hasCorrespondenceAddress %}
+      {%
+        set correspondenceAddressLines = [
+          partyDetails.correspondenceAddress.line1,
+          partyDetails.correspondenceAddress.line2,
+          partyDetails.correspondenceAddress.city,
+          partyDetails.correspondenceAddress.postcode
+        ]
+      %}
+    {% else %}
+      {% set correspondenceAddressLines = [t('Same as address')] %}
+    {% endif %}
+    {{
+      rowWithMultipleValue(
+        label = "Correspondence address:",
+        values = correspondenceAddressLines,
+        changeLink = changeLinks.partyDetails
+      )
+    }}
+  {% endif %}
+
+  {% if (partyDetails.type === 'individual' and partyDetails.dateOfBirth) %}
+    {{ row("Date of birth:", partyDetails.dateOfBirth.date.toMoment() | date, changeLinks.dateOfBirth) }}
   {% endif %}
 {% endmacro %}

--- a/src/main/views/includes/macros/partyDetails.njk
+++ b/src/main/views/includes/macros/partyDetails.njk
@@ -25,17 +25,17 @@
 {% endmacro %}
 
 {% macro partyDetailsSummaryFragment(partyDetails, showCorrespondenceAddressSection = true, changeLinks = {}) %}
-  {{ row("Name:", partyDetails.name, changeLinks.partyDetails) }}
+  {{ row("Name:", partyDetails.name, changeLinks.partyDetails or changeLinks.name) }}
 
   {% if (partyDetails.type === 'company' or partyDetails.type === 'organisation') %}
     {% if partyDetails.contactPerson %}
-      {{ row("Contact person:", partyDetails.contactPerson, changeLinks.partyDetails) }}
+      {{ row("Contact person:", partyDetails.contactPerson, changeLinks.partyDetails or changeLinks.contactPerson) }}
     {% endif %}
   {% endif %}
 
   {% if (partyDetails.type === 'soleTrader') %}
     {% if partyDetails.businessName %}
-      {{ row("Business name:", 'Trading as ' + partyDetails.businessName, changeLinks.partyDetails) }}
+      {{ row("Business name:", 'Trading as ' + partyDetails.businessName, changeLinks.partyDetails or changeLinks.businessName) }}
     {% endif %}
   {% endif %}
 
@@ -49,7 +49,7 @@
         partyDetails.address.postcode
       ],
       bottomBorder = not showCorrespondenceAddressSection,
-      changeLink = changeLinks.partyDetails
+      changeLink = changeLinks.partyDetails or changeLinks.address
     )
   }}
 
@@ -69,8 +69,7 @@
     {{
       rowWithMultipleValue(
         label = "Correspondence address:",
-        values = correspondenceAddressLines,
-        changeLink = changeLinks.partyDetails
+        values = correspondenceAddressLines
       )
     }}
   {% endif %}

--- a/src/main/views/includes/macros/table.njk
+++ b/src/main/views/includes/macros/table.njk
@@ -10,7 +10,7 @@
   </fieldset>
 {% endmacro %}
 
-{% macro row( label, value, changeLink = '' ) %}
+{% macro row( label, value, changeLink ) %}
   <div class="bottom-border">
     <div class="column-one-third">
       <span>{{ t( label ) }}</span>
@@ -18,7 +18,7 @@
     <div class="column-one-third">
       <span>{{ value }}</span>
     </div>
-    {% if changeLink !== '' %}
+    {% if changeLink !== undefined %}
     <div class="column-one-third change-link-column">
       <a href="{{ changeLink | safe }}" class="bold">{{ t('Change') }}</a>
     </div>
@@ -26,7 +26,7 @@
   </div>
 {% endmacro %}
 
-{% macro rowWithMultipleValue( label, values, changeLink = '', bottomBorder = true) %}
+{% macro rowWithMultipleValue( label, values, changeLink, bottomBorder = true) %}
   <div class="{% if bottomBorder %}bottom-border{% else %}no-bottom-border{% endif %}">
     <div class="column-one-third">
       <span class="">{{ t( label ) }}</span>
@@ -36,7 +36,7 @@
         <span class="block">{{ value }}</span>
        {% endfor %}
     </div>
-    {% if changeLink !== '' %}
+    {% if changeLink !== undefined %}
     <div class="column-one-third change-link-column">
       <a href="{{ changeLink | safe }}" class="bold">{{ t('Change') }}</a>
     </div>

--- a/src/main/views/includes/macros/table.njk
+++ b/src/main/views/includes/macros/table.njk
@@ -18,7 +18,7 @@
     <div class="column-one-third">
       <span>{{ value }}</span>
     </div>
-    {% if changeLink !== undefined %}
+    {% if changeLink %}
     <div class="column-one-third change-link-column">
       <a href="{{ changeLink | safe }}" class="bold">{{ t('Change') }}</a>
     </div>
@@ -36,7 +36,7 @@
         <span class="block">{{ value }}</span>
        {% endfor %}
     </div>
-    {% if changeLink !== undefined %}
+    {% if changeLink %}
     <div class="column-one-third change-link-column">
       <a href="{{ changeLink | safe }}" class="bold">{{ t('Change') }}</a>
     </div>


### PR DESCRIPTION
### JIRA link ###


https://tools.hmcts.net/jira/browse/ROC-2044

### Change description ###

Adds more party details to the 'their details page' depending on party type + displays party details on the check & send page.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[n] No
```