### PR TITLE
Make 'must be over 18' validation error message generic

### DIFF
--- a/src/main/app/forms/models/dateOfBirth.ts
+++ b/src/main/app/forms/models/dateOfBirth.ts
@@ -1,8 +1,13 @@
-import { ValidateNested, IsDefined, ValidateIf } from 'class-validator'
+import { IsDefined, ValidateIf, ValidateNested } from 'class-validator'
+import * as i18next from 'i18next'
+import { Moment } from 'moment'
 
 import { IsValidLocalDate } from 'forms/validation/validators/isValidLocalDate'
 import { MaximumAgeValidator } from 'forms/validation/validators/maximumAgeValidator'
 import { MinimumAgeValidator } from 'forms/validation/validators/minimumAgeValidator'
+
+import { MomentFactory } from 'common/momentFactory'
+import { MomentFormatter } from 'utils/momentFormatter'
 
 import { Serializable } from 'models/serializable'
 import { LocalDate } from 'forms/models/localDate'
@@ -13,18 +18,26 @@ import * as toBoolean from 'to-boolean'
 export class ValidationErrors {
   static readonly DATE_NOT_VALID: string = 'Please enter a valid date'
   static readonly DATE_INVALID_YEAR: string = 'Enter a 4 digit year'
-  static readonly DATE_UNDER_18: string = 'You must be over 18 to use this service'
+  static readonly DATE_UNDER_18: string = 'Please enter a date of birth before %s'
 }
 
 export default class DateOfBirth implements Serializable<DateOfBirth>, CompletableTask {
-  @IsDefined ({ message: 'Select an option' })
+  @IsDefined({ message: 'Select an option' })
   known: boolean
 
   @ValidateIf(o => o.known === true)
   @ValidateNested()
   @IsValidLocalDate({ message: ValidationErrors.DATE_NOT_VALID })
   @IsValidYearFormat({ message: ValidationErrors.DATE_INVALID_YEAR })
-  @MinimumAgeValidator(18, { message: ValidationErrors.DATE_UNDER_18 })
+  @MinimumAgeValidator(18, {
+    message: () => {
+      const limit: Moment = MomentFactory.currentDate().subtract(18, 'years').add(1, 'day')
+
+      return i18next.t(ValidationErrors.DATE_UNDER_18, {
+        postProcess: 'sprintf', sprintf: [MomentFormatter.formatLongDate(limit)]
+      })
+    }
+  })
   @MaximumAgeValidator(150, { message: ValidationErrors.DATE_NOT_VALID })
   date: LocalDate
 

--- a/src/main/features/ccj/views/date-of-birth.njk
+++ b/src/main/features/ccj/views/date-of-birth.njk
@@ -34,7 +34,7 @@
           }}
 
           <div class="form-group panel panel-border-narrow js-hidden " id="known-true" aria-hidden="false">
-            {{ dateInput('date', form) }}
+            {{ dateInput(form = form, name = 'date', hint = 'You can only request a CCJ against someone who is over 18') }}
           </div>
 
           {{

--- a/src/main/features/claim/views/claimant-dob.njk
+++ b/src/main/features/claim/views/claimant-dob.njk
@@ -12,7 +12,7 @@
         <input type="hidden" name="known" value="true" />
         {{ csrfProtection(csrf) }}
 
-        {{ dateInput('date', form) }}
+        {{ dateInput(form = form, name = 'date', hint = 'You must be over 18 to use this service') }}
 
         {{ saveAndContinueButton() }}
       </form>

--- a/src/main/features/response/views/your-dob.njk
+++ b/src/main/features/response/views/your-dob.njk
@@ -13,7 +13,7 @@
 
         {{ csrfProtection(csrf) }}
 
-        {{ dateInput('date', form) }}
+        {{ dateInput(form = form, name = 'date', hint = 'You must be over 18 to use this service') }}
 
         {{ saveAndContinueButton() }}
       </form>

--- a/src/test/app/forms/models/dateOfBirth.ts
+++ b/src/test/app/forms/models/dateOfBirth.ts
@@ -1,6 +1,10 @@
 /* Allow chai assertions which don't end in a function call, e.g. expect(thing).to.be.undefined */
 /* tslint:disable:no-unused-expression */
 
+import * as i18next from 'i18next'
+import * as postProcessor from 'i18next-sprintf-postprocessor'
+i18next.use(postProcessor).init()
+
 import { expect } from 'chai'
 import * as moment from 'moment'
 import { Validator } from 'class-validator'
@@ -9,6 +13,9 @@ import { expectValidationError } from './validationUtils'
 
 import DateOfBirth, { ValidationErrors } from 'forms/models/dateOfBirth'
 import { LocalDate } from 'forms/models/localDate'
+
+import { MomentFormatter } from 'utils/momentFormatter'
+import { Moment } from 'moment'
 
 describe('DateOfBirth', () => {
   describe('form object deserialization', () => {
@@ -53,7 +60,7 @@ describe('DateOfBirth', () => {
         const errors = validator.validateSync(dateOfBirth(today.year(), today.month() + 1, today.date()))
 
         expect(errors.length).to.equal(1)
-        expectValidationError(errors, ValidationErrors.DATE_UNDER_18)
+        expectValidationError(errors, ValidationErrors.DATE_UNDER_18.replace('%s', MomentFormatter.formatLongDate(ageLimit())))
       })
 
       it('should reject future date', () => {
@@ -62,7 +69,7 @@ describe('DateOfBirth', () => {
         const errors = validator.validateSync(dateOfBirth(tomorrow.year(), tomorrow.month() + 1, tomorrow.date()))
 
         expect(errors.length).to.equal(1)
-        expectValidationError(errors, ValidationErrors.DATE_UNDER_18)
+        expectValidationError(errors, ValidationErrors.DATE_UNDER_18.replace('%s', MomentFormatter.formatLongDate(ageLimit())))
       })
 
       it('should reject date of birth below 18', () => {
@@ -71,7 +78,7 @@ describe('DateOfBirth', () => {
         const errors = validator.validateSync(dateOfBirth(almost18YearsAgo.year(), almost18YearsAgo.month() + 1, almost18YearsAgo.date()))
 
         expect(errors.length).to.equal(1)
-        expectValidationError(errors, ValidationErrors.DATE_UNDER_18)
+        expectValidationError(errors, ValidationErrors.DATE_UNDER_18.replace('%s', MomentFormatter.formatLongDate(ageLimit())))
       })
 
       it('should reject date of birth with age over 150', () => {
@@ -142,4 +149,8 @@ describe('DateOfBirth', () => {
 
 function dateOfBirth (year: number, month: number, day: number): DateOfBirth {
   return new DateOfBirth(true, new LocalDate(year, month, day))
+}
+
+function ageLimit (): Moment {
+  return moment().subtract(18, 'years').add(1, 'day')
 }


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/ROC-2341

### Change description ###

Implementation is based on what I discussed with @BenClancy. If no need to internationalise the application that would be reasonable good solution however with a need for Welsh translation it requires to import `i18next` framework in both `src/main` and `src/test` code.

Also I am not sure the hint is in the right place. There are visually other ways of convey that hint. Would be good to check with @tarik-johnston1 on Monday.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```