### PR TITLE
Use local ssl certs to setup https for dockertests environment

### DIFF
--- a/config/dockertests.json
+++ b/config/dockertests.json
@@ -1,1 +1,6 @@
-{}
+{
+  "featureToggles": {
+    "testingSupport": true,
+    "countyCourtJudgment": true
+  }
+}

--- a/src/main/routes/health.ts
+++ b/src/main/routes/health.ts
@@ -20,7 +20,7 @@ export default express.Router()
 
 function basicHealthCheck (serviceName) {
   const options = {}
-  if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
+  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'dockertests' || !process.env.NODE_ENV) {
     const sslDirectory = path.join(__dirname, '..', 'resources', 'localhost-ssl')
     options['ca'] = fs.readFileSync(path.join(sslDirectory, 'localhost-ca.crt'))
   }

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -7,7 +7,7 @@ import * as https from 'https'
 
 const port: number = parseInt(process.env.PORT, 10) || 3000
 
-if (app.locals.ENV === 'development') {
+if (app.locals.ENV === 'development' || app.locals.ENV === 'dockertests') {
   const sslDirectory = path.join(__dirname, 'resources', 'localhost-ssl')
   const sslOptions = {
     key: fs.readFileSync(path.join(sslDirectory, 'localhost.key')),


### PR DESCRIPTION
### Change description ###

Enable local ssl certs to setup https for 'dockertests' environment

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
