### PR TITLE
Add js-base64 to regular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "i18next-express-middleware": "^1.0.2",
     "i18next-sprintf-postprocessor": "^0.2.2",
     "jquery": "3.0.0",
+    "js-base64": "^2.3.2",
     "mime": "^2.0.3",
     "moment": "^2.18.1",
     "morgan": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3155,7 +3155,7 @@ jquery@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.0.0.tgz#95a2a9541291a9f819e016f85ba247116d03e4ab"
 
-js-base64@^2.1.8:
+js-base64@^2.1.8, js-base64@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.3.2.tgz#a79a923666372b580f8e27f51845c6f7e8fbfbaf"
 


### PR DESCRIPTION
js-base64 was a transitive dependency of a devDependency
Which don't get bundled into what gets deployed.
```
$ yarn why js-base64
yarn why v1.1.0
[1/4] 🤔  Why do we have the module "js-base64"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
info This module exists because "gulp-sass#node-sass#sass-graph#scss-tokenizer" depends on it.
info Disk size without dependencies: "68kB"
info Disk size with unique dependencies: "68kB"
info Disk size with transitive dependencies: "68kB"
info Number of shared dependencies: 0
``