### PR TITLE
Remove number assumptions on defendant type

### DIFF
--- a/src/main/app/claims/claimStoreClient.ts
+++ b/src/main/app/claims/claimStoreClient.ts
@@ -32,7 +32,7 @@ export default class ClaimStoreClient {
     })
   }
 
-  static retrieveByClaimantId (claimantId: number): Promise<Claim[]> {
+  static retrieveByClaimantId (claimantId: string): Promise<Claim[]> {
     if (!claimantId) {
       return Promise.reject(new Error('Claimant ID is required'))
     }
@@ -76,7 +76,7 @@ export default class ClaimStoreClient {
       })
   }
 
-  static retrieveByDefendantId (defendantId: number): Promise<Claim[]> {
+  static retrieveByDefendantId (defendantId: string): Promise<Claim[]> {
     if (!defendantId) {
       return Promise.reject('Defendant ID is required')
     }
@@ -86,7 +86,7 @@ export default class ClaimStoreClient {
       .then((claims: object[]) => claims.map(claim => new Claim().deserialize(claim)))
   }
 
-  static linkDefendant (claimId: number, defendantId: number): Promise<Claim> {
+  static linkDefendant (claimId: number, defendantId: string): Promise<Claim> {
     if (!claimId) {
       return Promise.reject('Claim ID is required')
     }

--- a/src/main/app/claims/models/claim.ts
+++ b/src/main/app/claims/models/claim.ts
@@ -12,9 +12,9 @@ import { DefendantResponse } from 'claims/models/defendantResponse'
 
 export default class Claim implements Serializable<Claim> {
   id: number
-  claimantId: number
+  claimantId: string
   externalId: string
-  defendantId: number
+  defendantId: string
   claimNumber: string
   responseDeadline: Moment
   createdAt: Moment

--- a/src/main/app/idam/user.ts
+++ b/src/main/app/idam/user.ts
@@ -5,7 +5,7 @@ import { DraftCCJ } from 'ccj/draft/draftCCJ'
 import { Draft } from 'models/draft'
 
 export default class User {
-  id: number
+  id: string
   email: string
   forename: string
   surname: string
@@ -17,7 +17,7 @@ export default class User {
   responseDraft: Draft<ResponseDraft>
   ccjDraft: Draft<DraftCCJ>
 
-  constructor (id: number,
+  constructor (id: string,
                email: string,
                forename: string,
                surname: string,

--- a/src/main/features/claim/routes/pay.ts
+++ b/src/main/features/claim/routes/pay.ts
@@ -30,11 +30,11 @@ const getReturnURL = (req: express.Request, externalId: string) => {
   return buildURL(req, Paths.finishPaymentReceiver.evaluateUri({ externalId: externalId }))
 }
 
-function logPaymentError (id: number, payment: Payment) {
+function logPaymentError (id: string, payment: Payment) {
   logError(id, payment, 'Payment might have failed, see payment information: ')
 }
 
-function logError (id: number, payment: Payment, message: string) {
+function logError (id: string, payment: Payment, message: string) {
   logger.error(`${message} (User Id : ${id}, Payment: ${JSON.stringify(payment)})`)
 }
 

--- a/src/test/a11y/mocks.ts
+++ b/src/test/a11y/mocks.ts
@@ -6,7 +6,7 @@ import * as draftStoreMock from '../http-mocks/draft-store'
 import * as claimStoreMock from '../http-mocks/claim-store'
 import * as feesMock from '../http-mocks/fees'
 
-idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'letter-holder', 'claimant', 'defendant').persist()
+idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'letter-holder', 'claimant', 'defendant').persist()
 idamServiceMock.resolveRetrieveServiceToken().persist()
 
 draftStoreMock.resolveFindAllDrafts().persist()

--- a/src/test/app/auth/ownershipChecks.ts
+++ b/src/test/app/auth/ownershipChecks.ts
@@ -4,22 +4,22 @@ import OwnershipChecks from 'app/auth/ownershipChecks'
 import User from 'app/idam/user'
 import Claim from 'app/claims/models/claim'
 
-function userWithId (id: number): User {
+function userWithId (id: string): User {
   return { id: id } as User
 }
 
-function claimWithClaimantId (claimantId: number): Claim {
+function claimWithClaimantId (claimantId: string): Claim {
   return { claimantId: claimantId } as Claim
 }
 
 describe('OwnershipChecks', () => {
   describe('checkClaimOwner', () => {
     it('should throw error when the user is not an owner of the claim', () => {
-      expect(() => OwnershipChecks.checkClaimOwner(userWithId(1), claimWithClaimantId(2))).to.throw(Error, 'You are not allowed to access this resource')
+      expect(() => OwnershipChecks.checkClaimOwner(userWithId('1'), claimWithClaimantId('2'))).to.throw(Error, 'You are not allowed to access this resource')
     })
 
     it('should not throw error when the user is owner the claim', () => {
-      expect(() => OwnershipChecks.checkClaimOwner(userWithId(1), claimWithClaimantId(1))).not.to.throw()
+      expect(() => OwnershipChecks.checkClaimOwner(userWithId('1'), claimWithClaimantId('1'))).not.to.throw()
     })
   })
 })

--- a/src/test/features/ccj/routes/ccjGuard.ts
+++ b/src/test/features/ccj/routes/ccjGuard.ts
@@ -19,7 +19,7 @@ describe('CCJ guard', () => {
   describe('on GET', () => {
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       context('should redirect to dashboard when claim not eligible for CCJ', () => {

--- a/src/test/features/ccj/routes/check-and-send.ts
+++ b/src/test/features/ccj/routes/check-and-send.ts
@@ -31,7 +31,7 @@ describe('CCJ: check and send page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       context('when user authorised', () => {
@@ -80,7 +80,7 @@ describe('CCJ: check and send page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       it('should return 500 and render error page when cannot retrieve claim', async () => {

--- a/src/test/features/ccj/routes/confirmation.ts
+++ b/src/test/features/ccj/routes/confirmation.ts
@@ -26,7 +26,7 @@ describe('CCJ: confirmation page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       context('when user authorised', () => {

--- a/src/test/features/ccj/routes/date-of-birth.ts
+++ b/src/test/features/ccj/routes/date-of-birth.ts
@@ -51,7 +51,7 @@ describe('CCJ - defendant date of birth', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       checkAccessGuard(app, 'get')
@@ -94,7 +94,7 @@ describe('CCJ - defendant date of birth', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       checkAccessGuard(app, 'post')

--- a/src/test/features/ccj/routes/paid-amount-summary.ts
+++ b/src/test/features/ccj/routes/paid-amount-summary.ts
@@ -27,7 +27,7 @@ describe('CCJ - paid amount summary page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       it('should return 500 and render error page when cannot retrieve claims', async () => {

--- a/src/test/features/ccj/routes/paid-amount.ts
+++ b/src/test/features/ccj/routes/paid-amount.ts
@@ -35,7 +35,7 @@ describe('CCJ - paid amount page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       it('should return 500 and render error page when cannot retrieve claims', async () => {
@@ -73,7 +73,7 @@ describe('CCJ - paid amount page', () => {
 
       context('when user authorised', () => {
         beforeEach(() => {
-          idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+          idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
         })
 
         context('when middleware failure', () => {

--- a/src/test/features/ccj/routes/pay-by-set-date.ts
+++ b/src/test/features/ccj/routes/pay-by-set-date.ts
@@ -35,7 +35,7 @@ describe('CCJ - Pay by set date', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       it('should return 500 and render error page when cannot retrieve claims', async () => {
@@ -76,7 +76,7 @@ describe('CCJ - Pay by set date', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       it('should return 500 and render error page when cannot retrieve claim', async () => {

--- a/src/test/features/ccj/routes/payment-options.ts
+++ b/src/test/features/ccj/routes/payment-options.ts
@@ -33,7 +33,7 @@ describe('CCJ - payment options', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       context('when service is unhealthy', () => {
@@ -75,7 +75,7 @@ describe('CCJ - payment options', () => {
 
       context('when user authorised', () => {
         beforeEach(() => {
-          idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+          idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
         })
 
         context('when service is unhealthy', () => {

--- a/src/test/features/ccj/routes/repayment-plan.ts
+++ b/src/test/features/ccj/routes/repayment-plan.ts
@@ -28,7 +28,7 @@ describe('CCJ: repayment page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       context('when user authorised', () => {
@@ -81,7 +81,7 @@ describe('CCJ: repayment page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       it('should return 500 and render error page when cannot retrieve claim', async () => {

--- a/src/test/features/claim/routes/amount-exceeded.ts
+++ b/src/test/features/claim/routes/amount-exceeded.ts
@@ -21,7 +21,7 @@ describe('Claim issue: amount exceeded page', () => {
     checkAuthorizationGuards(app, 'get', ClaimErrorPaths.amountExceededPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
 
       await request(app)
         .get(ClaimErrorPaths.amountExceededPage.uri)

--- a/src/test/features/claim/routes/amount.ts
+++ b/src/test/features/claim/routes/amount.ts
@@ -22,7 +22,7 @@ describe('Claim issue: amount page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.amountPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -37,7 +37,7 @@ describe('Claim issue: amount page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       describe('add row action', () => {

--- a/src/test/features/claim/routes/check-and-send.ts
+++ b/src/test/features/claim/routes/check-and-send.ts
@@ -25,7 +25,7 @@ describe('Claim issue: check and send page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should redirect to incomplete submission when not all tasks are completed', async () => {
@@ -64,7 +64,7 @@ describe('Claim issue: check and send page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should redirect to incomplete submission when not all tasks are completed', async () => {

--- a/src/test/features/claim/routes/claimant-company-details.ts
+++ b/src/test/features/claim/routes/claimant-company-details.ts
@@ -29,7 +29,7 @@ describe('claimant as company details page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.claimantCompanyDetailsPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -44,7 +44,7 @@ describe('claimant as company details page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant', 'defendant')
       })
 
       it('should render page with error when claimant name is invalid', async () => {

--- a/src/test/features/claim/routes/claimant-dob.ts
+++ b/src/test/features/claim/routes/claimant-dob.ts
@@ -22,7 +22,7 @@ describe('Claim issue: claimant date of birth page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.claimantDateOfBirthPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -37,7 +37,7 @@ describe('Claim issue: claimant date of birth page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should render page when form is invalid and everything is fine', async () => {

--- a/src/test/features/claim/routes/claimant-individual-details.ts
+++ b/src/test/features/claim/routes/claimant-individual-details.ts
@@ -37,7 +37,7 @@ describe('claimant as individual details page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.claimantIndividualDetailsPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -52,7 +52,7 @@ describe('claimant as individual details page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant', 'defendant')
       })
 
       it('should render page with error when claimant name is invalid', async () => {

--- a/src/test/features/claim/routes/claimant-mobile.ts
+++ b/src/test/features/claim/routes/claimant-mobile.ts
@@ -22,7 +22,7 @@ describe('Claim issue: claimant mobile page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.claimantMobilePage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -37,7 +37,7 @@ describe('Claim issue: claimant mobile page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should render page when form is invalid and everything is fine', async () => {

--- a/src/test/features/claim/routes/claimant-organisation-details.ts
+++ b/src/test/features/claim/routes/claimant-organisation-details.ts
@@ -29,7 +29,7 @@ describe('claimant as organisation details page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.claimantOrganisationDetailsPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -44,7 +44,7 @@ describe('claimant as organisation details page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant', 'defendant')
       })
 
       it('should render page with error when claimant name is invalid', async () => {

--- a/src/test/features/claim/routes/claimant-party-type-selection.ts
+++ b/src/test/features/claim/routes/claimant-party-type-selection.ts
@@ -22,7 +22,7 @@ describe('Claim issue: claimant party type selection page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.claimantPartyTypeSelectionPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -37,7 +37,7 @@ describe('Claim issue: claimant party type selection page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant', 'defendant')
       })
 
       it('should render page with error when form is invalid', async () => {

--- a/src/test/features/claim/routes/claimant-soleTrader-details.ts
+++ b/src/test/features/claim/routes/claimant-soleTrader-details.ts
@@ -29,7 +29,7 @@ describe('claimant as soleTrader details page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.claimantSoleTraderOrSelfEmployedDetailsPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -44,7 +44,7 @@ describe('claimant as soleTrader details page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant', 'defendant')
       })
 
       it('should render page with error when claimant name is invalid', async () => {

--- a/src/test/features/claim/routes/completing-claim.ts
+++ b/src/test/features/claim/routes/completing-claim.ts
@@ -22,7 +22,7 @@ describe('Claim issue: completing claim page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.completingClaimPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -37,7 +37,7 @@ describe('Claim issue: completing claim page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should return 500 and render error page when cannot save draft', async () => {

--- a/src/test/features/claim/routes/confirmation.ts
+++ b/src/test/features/claim/routes/confirmation.ts
@@ -24,7 +24,7 @@ describe('Claim issue: confirmation page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should return 500 and render error page when cannot retrieve claim by external id', async () => {

--- a/src/test/features/claim/routes/defendant-company-details.ts
+++ b/src/test/features/claim/routes/defendant-company-details.ts
@@ -29,7 +29,7 @@ describe('defendant as company details page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.defendantCompanyDetailsPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -44,7 +44,7 @@ describe('defendant as company details page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant', 'defendant')
       })
 
       it('should render page with error when claimant name is invalid', async () => {

--- a/src/test/features/claim/routes/defendant-email.ts
+++ b/src/test/features/claim/routes/defendant-email.ts
@@ -22,7 +22,7 @@ describe('Claim issue: defendant email page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.defendantEmailPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -37,7 +37,7 @@ describe('Claim issue: defendant email page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should render page when form is invalid and everything is fine', async () => {

--- a/src/test/features/claim/routes/defendant-individual-details.ts
+++ b/src/test/features/claim/routes/defendant-individual-details.ts
@@ -37,7 +37,7 @@ describe('defendant as individual details page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.defendantIndividualDetailsPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -52,7 +52,7 @@ describe('defendant as individual details page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant', 'defendant')
       })
 
       it('should render page with error when defendant name is invalid', async () => {

--- a/src/test/features/claim/routes/defendant-soleTrader-details.ts
+++ b/src/test/features/claim/routes/defendant-soleTrader-details.ts
@@ -29,7 +29,7 @@ describe('defendant as soleTrader details page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.defendantSoleTraderOrSelfEmployedDetailsPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -44,7 +44,7 @@ describe('defendant as soleTrader details page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant', 'defendant')
       })
 
       it('should render page with error when claimant name is invalid', async () => {

--- a/src/test/features/claim/routes/defendnat-party-type-selection.ts
+++ b/src/test/features/claim/routes/defendnat-party-type-selection.ts
@@ -22,7 +22,7 @@ describe('Claim issue: defendant party type selection page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.defendantPartyTypeSelectionPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -37,7 +37,7 @@ describe('Claim issue: defendant party type selection page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant', 'defendant')
       })
 
       it('should render page with error when form is invalid', async () => {

--- a/src/test/features/claim/routes/fees.ts
+++ b/src/test/features/claim/routes/fees.ts
@@ -24,7 +24,7 @@ describe('Claim issue: fees page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should return 500 and render error page when cannot calculate issue fee', async () => {
@@ -98,7 +98,7 @@ describe('Claim issue: fees page', () => {
     checkAuthorizationGuards(app, 'post', ClaimPaths.feesPage.uri)
 
     it('should redirect to total page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)

--- a/src/test/features/claim/routes/incomplete-submission.ts
+++ b/src/test/features/claim/routes/incomplete-submission.ts
@@ -19,7 +19,7 @@ describe('Claim issue: incomplete submission page', () => {
 
   describe('on GET', () => {
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)

--- a/src/test/features/claim/routes/interest-date.ts
+++ b/src/test/features/claim/routes/interest-date.ts
@@ -25,7 +25,7 @@ describe('Claim issue: interest date page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.interestDatePage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -42,7 +42,7 @@ describe('Claim issue: interest date page', () => {
     describe('for authorized user', () => {
 
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should render page when form is invalid and everything is fine', async () => {

--- a/src/test/features/claim/routes/interest.ts
+++ b/src/test/features/claim/routes/interest.ts
@@ -23,7 +23,7 @@ describe('Claim issue: interest page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.interestPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -38,7 +38,7 @@ describe('Claim issue: interest page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should render page when form is invalid and everything is fine', async () => {

--- a/src/test/features/claim/routes/pay.ts
+++ b/src/test/features/claim/routes/pay.ts
@@ -103,7 +103,7 @@ describe('Claim issue: initiate payment receiver', () => {
           reason: 'Valid reason'
         } as Reason
       } as DraftClaim
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
     })
 
     it('should return 500 and error page when draft external ID does not exist', async () => {
@@ -257,7 +257,7 @@ describe('Claim issue: post payment callback receiver', () => {
           reason: 'Valid reason'
         } as Reason
       } as DraftClaim
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
     })
 
     function initiatedPayment (): object {

--- a/src/test/features/claim/routes/reason.ts
+++ b/src/test/features/claim/routes/reason.ts
@@ -22,7 +22,7 @@ describe('Claim issue: reason page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.reasonPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -32,7 +32,7 @@ describe('Claim issue: reason page', () => {
     })
 
     it('should render page when everything is fine without a name field', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim', { defendant: undefined })
 
       await request(app)
@@ -47,7 +47,7 @@ describe('Claim issue: reason page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should render page when form is invalid and everything is fine', async () => {

--- a/src/test/features/claim/routes/receipt.ts
+++ b/src/test/features/claim/routes/receipt.ts
@@ -26,7 +26,7 @@ describe('Claim issue: receipt', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should return 500 and render error page when cannot retrieve claim by external id', async () => {

--- a/src/test/features/claim/routes/resolving-this-dispute.ts
+++ b/src/test/features/claim/routes/resolving-this-dispute.ts
@@ -22,7 +22,7 @@ describe('Claim issue: resolving this dispute page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.resolvingThisDisputerPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)
@@ -37,7 +37,7 @@ describe('Claim issue: resolving this dispute page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should return 500 and render error page when cannot save draft', async () => {

--- a/src/test/features/claim/routes/response-copy.ts
+++ b/src/test/features/claim/routes/response-copy.ts
@@ -25,7 +25,7 @@ describe('Defendant response copy', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should return 500 and render error page when cannot download the response copy', async () => {

--- a/src/test/features/claim/routes/start.ts
+++ b/src/test/features/claim/routes/start.ts
@@ -21,7 +21,7 @@ describe('Claim issue: start page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.startPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
 
       await request(app)
         .get(ClaimPaths.startPage.uri)

--- a/src/test/features/claim/routes/task-list.ts
+++ b/src/test/features/claim/routes/task-list.ts
@@ -22,7 +22,7 @@ describe('Claim issue: task list page', () => {
     checkAuthorizationGuards(app, 'get', ClaimPaths.incompleteSubmissionPage.uri)
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       draftStoreServiceMock.resolveFind('claim')
 
       await request(app)

--- a/src/test/features/claim/routes/total.ts
+++ b/src/test/features/claim/routes/total.ts
@@ -24,7 +24,7 @@ describe('Claim issue: total page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should return 500 and render error page when cannot calculate issue fee', async () => {
@@ -54,7 +54,7 @@ describe('Claim issue: total page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
       })
 
       it('should redirect to task list when amount within limit and everything is fine', async () => {

--- a/src/test/features/dashboard/routes/claimant.ts
+++ b/src/test/features/dashboard/routes/claimant.ts
@@ -29,7 +29,7 @@ describe('Dashboard - claimant page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       it('should return 500 and render error page when cannot retrieve claims', async () => {
@@ -60,7 +60,7 @@ describe('Dashboard - claimant page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       describe('when defendant is an individual', () => {

--- a/src/test/features/dashboard/routes/defendant.ts
+++ b/src/test/features/dashboard/routes/defendant.ts
@@ -25,7 +25,7 @@ describe('Dashboard - defendant page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       it('should return 500 and render error page when cannot retrieve claims', async () => {

--- a/src/test/features/dashboard/routes/index.ts
+++ b/src/test/features/dashboard/routes/index.ts
@@ -24,7 +24,7 @@ describe('Dashboard page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       it('should return 500 and render error page when cannot retrieve claims', async () => {
@@ -56,7 +56,7 @@ describe('Dashboard page', () => {
       context('when at least one claim issued', () => {
         beforeEach(() => {
           claimStoreServiceMock.resolveRetrieveByClaimantId()
-          claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', 1)
+          claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1')
         })
 
         it('should render page with continue claim button when everything is fine', async () => {

--- a/src/test/features/first-contact/routes/claim-summary.ts
+++ b/src/test/features/first-contact/routes/claim-summary.ts
@@ -23,7 +23,7 @@ describe('Defendant first contact: claim summary page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'letter-holder')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'letter-holder')
       })
 
       it('should redirect to access denied page when claim reference number does not match', async () => {
@@ -61,7 +61,7 @@ describe('Defendant first contact: claim summary page', () => {
     it('should redirect to registration page when everything is fine', async () => {
       const registrationPagePattern = new RegExp(`${config.get('idam.authentication-web.url')}/login/uplift\\?response_type=code.+&redirect_uri=http://127.0.0.1:[0-9]{1,5}/receiver/link-defendant&jwt=ABC`)
 
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'letter-holder')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'letter-holder')
 
       await request(app)
         .post(Paths.claimSummaryPage.uri)

--- a/src/test/features/response/routes/check-and-send.ts
+++ b/src/test/features/response/routes/check-and-send.ts
@@ -34,7 +34,7 @@ describe('Defendant response: check and send page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', checkAndSendPage)
@@ -79,7 +79,7 @@ describe('Defendant response: check and send page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', checkAndSendPage)

--- a/src/test/features/response/routes/confirmation.ts
+++ b/src/test/features/response/routes/confirmation.ts
@@ -25,7 +25,7 @@ describe('Defendant response: confirmation page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkCountyCourtJudgmentRequestedGuard(app, 'get', pagePath)

--- a/src/test/features/response/routes/counter-claim.ts
+++ b/src/test/features/response/routes/counter-claim.ts
@@ -27,7 +27,7 @@ describe('Defendant response: counter claim page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkCountyCourtJudgmentRequestedGuard(app, 'get', pagePath)

--- a/src/test/features/response/routes/free-mediation.ts
+++ b/src/test/features/response/routes/free-mediation.ts
@@ -28,7 +28,7 @@ describe('Defendant response: free mediation page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', pagePath)
@@ -62,7 +62,7 @@ describe('Defendant response: free mediation page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', pagePath)

--- a/src/test/features/response/routes/full-admission.ts
+++ b/src/test/features/response/routes/full-admission.ts
@@ -27,7 +27,7 @@ describe('Defendant response: full admission page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkCountyCourtJudgmentRequestedGuard(app, 'get', pagePath)

--- a/src/test/features/response/routes/how-much-owed.ts
+++ b/src/test/features/response/routes/how-much-owed.ts
@@ -28,7 +28,7 @@ describe('Defendant response: how much money do you believe you owe', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', defendantHowMuchOwedPage)
@@ -61,7 +61,7 @@ describe('Defendant response: how much money do you believe you owe', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', defendantHowMuchOwedPage)

--- a/src/test/features/response/routes/how-much-paid.ts
+++ b/src/test/features/response/routes/how-much-paid.ts
@@ -27,7 +27,7 @@ describe('Defendant response: how much have you paid', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', defendantHowMuchPaid)
@@ -60,7 +60,7 @@ describe('Defendant response: how much have you paid', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', defendantHowMuchPaid)

--- a/src/test/features/response/routes/incomplete-submission.ts
+++ b/src/test/features/response/routes/incomplete-submission.ts
@@ -25,14 +25,14 @@ describe('Defendant response: incomplete submission page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkCountyCourtJudgmentRequestedGuard(app, 'get', pagePath)
     })
 
     it('should render page when everything is fine', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       draftStoreServiceMock.resolveFind('response')
       claimStoreServiceMock.resolveRetrieveClaimByExternalId()
 

--- a/src/test/features/response/routes/more-time-confirmation.ts
+++ b/src/test/features/response/routes/more-time-confirmation.ts
@@ -28,7 +28,7 @@ describe('Defendant response: more time needed - confirmation page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', pagePath)
@@ -88,7 +88,7 @@ describe('Defendant response: more time needed - confirmation page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', pagePath)

--- a/src/test/features/response/routes/more-time-request.ts
+++ b/src/test/features/response/routes/more-time-request.ts
@@ -29,7 +29,7 @@ describe('Defendant response: more time needed page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', pagePath)
@@ -79,7 +79,7 @@ describe('Defendant response: more time needed page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', pagePath)

--- a/src/test/features/response/routes/partial-admission.ts
+++ b/src/test/features/response/routes/partial-admission.ts
@@ -27,7 +27,7 @@ describe('Defendant response: partial admission page', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkCountyCourtJudgmentRequestedGuard(app, 'get', pagePath)

--- a/src/test/features/response/routes/reject-all-of-claim.ts
+++ b/src/test/features/response/routes/reject-all-of-claim.ts
@@ -34,7 +34,7 @@ describe('Defendant response: full admission options', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', pagePath)
@@ -78,7 +78,7 @@ describe('Defendant response: full admission options', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', pagePath)

--- a/src/test/features/response/routes/reject-part-of-claim.ts
+++ b/src/test/features/response/routes/reject-part-of-claim.ts
@@ -34,7 +34,7 @@ describe('Defendant response: part admission options', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', pagePath)
@@ -78,7 +78,7 @@ describe('Defendant response: part admission options', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', pagePath)

--- a/src/test/features/response/routes/response-receipt.ts
+++ b/src/test/features/response/routes/response-receipt.ts
@@ -27,7 +27,7 @@ describe('Defendant response: receipt', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkCountyCourtJudgmentRequestedGuard(app, 'get', receiptPath)

--- a/src/test/features/response/routes/response-type.ts
+++ b/src/test/features/response/routes/response-type.ts
@@ -29,7 +29,7 @@ describe('Defendant response: response type page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', pagePath)
@@ -57,7 +57,7 @@ describe('Defendant response: response type page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', pagePath)

--- a/src/test/features/response/routes/task-list.ts
+++ b/src/test/features/response/routes/task-list.ts
@@ -28,7 +28,7 @@ describe('Defendant response: task list page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', pagePath)

--- a/src/test/features/response/routes/timeline.ts
+++ b/src/test/features/response/routes/timeline.ts
@@ -27,7 +27,7 @@ describe('Defendant response: timeline', () => {
     context('when user authorised', () => {
 
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', pagePath)
@@ -74,7 +74,7 @@ describe('Defendant response: timeline', () => {
     describe('for authorized user', () => {
 
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', pagePath)

--- a/src/test/features/response/routes/your-defence.ts
+++ b/src/test/features/response/routes/your-defence.ts
@@ -28,7 +28,7 @@ describe('Defendant response: defence page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', defencePage)
@@ -62,7 +62,7 @@ describe('Defendant response: defence page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', defencePage)

--- a/src/test/features/response/routes/your-details.ts
+++ b/src/test/features/response/routes/your-details.ts
@@ -27,7 +27,7 @@ describe('Defendant user details: your name page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', pagePath)
@@ -61,7 +61,7 @@ describe('Defendant user details: your name page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', pagePath)

--- a/src/test/features/response/routes/your-dob.ts
+++ b/src/test/features/response/routes/your-dob.ts
@@ -27,7 +27,7 @@ describe('Defendant user details: your date of birth page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', pagePath)
@@ -55,7 +55,7 @@ describe('Defendant user details: your date of birth page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', pagePath)

--- a/src/test/features/response/routes/your-mobile.ts
+++ b/src/test/features/response/routes/your-mobile.ts
@@ -27,7 +27,7 @@ describe('Defendant user details: your mobile page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'get', pagePath)
@@ -56,7 +56,7 @@ describe('Defendant user details: your mobile page', () => {
 
     context('when user authorised', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant')
       })
 
       checkAlreadySubmittedGuard(app, 'post', pagePath)

--- a/src/test/http-mocks/claim-store.ts
+++ b/src/test/http-mocks/claim-store.ts
@@ -8,9 +8,9 @@ const serviceBaseURL: string = config.get<string>('claim-store.url')
 
 export const sampleClaimObj = {
   id: 1,
-  submitterId: 1,
+  submitterId: '1',
   externalId: '400f4c57-9684-49c0-adb4-4cf46579d6dc',
-  defendantId: 123,
+  defendantId: '123',
   referenceNumber: '000MC000',
   createdAt: '2017-07-25T22:45:51.785',
   issuedOn: '2017-07-25',
@@ -142,7 +142,7 @@ export function rejectIsClaimLinked () {
     .reply(HttpStatus.INTERNAL_SERVER_ERROR, 'Internal server error')
 }
 
-export function resolveRetrieveByLetterHolderId (referenceNumber: string, defendantId?: number): Scope {
+export function resolveRetrieveByLetterHolderId (referenceNumber: string, defendantId?: string): Scope {
   return mock(`${serviceBaseURL}/claims`)
     .get(new RegExp('/letter/[0-9]+'))
     .reply(HttpStatus.OK, { ...sampleClaimObj, referenceNumber: referenceNumber, defendantId: defendantId })
@@ -154,7 +154,7 @@ export function rejectRetrieveByLetterHolderId (reason: string) {
     .reply(HttpStatus.INTERNAL_SERVER_ERROR, reason)
 }
 
-export function resolveRetrieveByDefendantId (referenceNumber: string, defendantId?: number) {
+export function resolveRetrieveByDefendantId (referenceNumber: string, defendantId?: string) {
   mock(`${serviceBaseURL}/claims`)
     .get(new RegExp('/defendant/[0-9]+'))
     .reply(HttpStatus.OK, [{ ...sampleClaimObj, referenceNumber: referenceNumber, defendantId: defendantId }])
@@ -175,7 +175,7 @@ export function rejectRetrieveByDefendantId (reason: string) {
 export function resolveLinkDefendant () {
   mock(`${serviceBaseURL}/claims`)
     .put(new RegExp('/[0-9]+/defendant/[0-9]+'))
-    .reply(HttpStatus.OK, { ...sampleClaimObj, defendantId: 1 })
+    .reply(HttpStatus.OK, { ...sampleClaimObj, defendantId: '1' })
 }
 
 export function rejectLinkDefendant (reason: string) {
@@ -187,7 +187,7 @@ export function rejectLinkDefendant (reason: string) {
 export function resolveSaveResponse () {
   mock(`${serviceBaseURL}/claims`)
     .post(new RegExp('/[0-9]+/defendant/[0-9]+'))
-    .reply(HttpStatus.OK, { ...sampleClaimObj, defendantId: 1 })
+    .reply(HttpStatus.OK, { ...sampleClaimObj, defendantId: '1' })
 }
 
 export function rejectSaveResponse (reason: string) {

--- a/src/test/http-mocks/idam.ts
+++ b/src/test/http-mocks/idam.ts
@@ -7,7 +7,7 @@ const s2sAuthServiceBaseURL = config.get<string>('idam.service-2-service-auth.ur
 
 const defaultServiceAuthToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpZGFtIiwiaWF0IjoxNDgzMjI4ODAwLCJleHAiOjQxMDI0NDQ4MDAsImF1ZCI6ImNtYyIsInN1YiI6ImNtYyJ9.Q9-gf315saUt007Gau0tBUxevcRwhEckLHzC82EVGIM' // valid until 1st Jan 2100
 
-export function resolveRetrieveUserFor (id: number, ...roles: string[]) {
+export function resolveRetrieveUserFor (id: string, ...roles: string[]) {
   return mock(apiServiceBaseURL)
     .get('/details')
     .reply(HttpStatus.OK, { id: id, roles: roles, email: 'user@example.com' })

--- a/src/test/routes/authorization-check.ts
+++ b/src/test/routes/authorization-check.ts
@@ -30,7 +30,7 @@ export function checkAuthorizationGuards (app: any,
 
   it('should redirect to access denied page when user not in required role', async () => {
     mock.cleanAll()
-    idamServiceMock.resolveRetrieveUserFor(1, 'divorce-private-beta')
+    idamServiceMock.resolveRetrieveUserFor('1', 'divorce-private-beta')
 
     await request.agent(app)[method](pagePath)
       .set('Cookie', `${cookieName}=ABC`)

--- a/src/test/routes/home.ts
+++ b/src/test/routes/home.ts
@@ -20,7 +20,7 @@ describe('Home page', () => {
 
   describe('on GET', () => {
     it('should redirect to start claim page', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
 
       await request(app)
         .get(AppPaths.homePage.uri)

--- a/src/test/routes/logout.ts
+++ b/src/test/routes/logout.ts
@@ -20,7 +20,7 @@ describe('Logout receiver', () => {
 
   describe('on GET', () => {
     it('should remove session cookie', async () => {
-      idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'claimant')
+      idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'claimant')
 
       await request(app)
         .get(AppPaths.logoutReceiver.uri)

--- a/src/test/routes/receiver.ts
+++ b/src/test/routes/receiver.ts
@@ -26,7 +26,7 @@ describe('Login receiver', async () => {
   describe('on GET', async () => {
     describe('for authorized user', async () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta')
       })
 
       it('should save bearer token in cookie when auth token is retrieved from idam', async () => {
@@ -79,7 +79,7 @@ describe('Login receiver', async () => {
         it('should redirect to response task-list', async () => {
           draftStoreServiceMock.resolveFindNoDraftFound()
           claimStoreServiceMock.resolveRetrieveByClaimantIdToEmptyList()
-          claimStoreServiceMock.resolveRetrieveByDefendantId('A', 1)
+          claimStoreServiceMock.resolveRetrieveByDefendantId('A')
 
           await request(app)
             .get(AppPaths.receiver.uri)
@@ -150,7 +150,7 @@ describe('Defendant link receiver', () => {
 
     describe('for authorized user', () => {
       beforeEach(() => {
-        idamServiceMock.resolveRetrieveUserFor(1, 'cmc-private-beta', 'defendant', 'letter-1')
+        idamServiceMock.resolveRetrieveUserFor('1', 'cmc-private-beta', 'defendant', 'letter-1')
       })
 
       it('should return 500 and render error page when cannot retrieve claim', async () => {
@@ -166,7 +166,7 @@ describe('Defendant link receiver', () => {
       it('should redirect to task list page when defendant is already set', async () => {
         const token = 'token'
         idamServiceMock.resolveExchangeCode(token)
-        claimStoreServiceMock.resolveRetrieveByLetterHolderId('000MC001', 2)
+        claimStoreServiceMock.resolveRetrieveByLetterHolderId('000MC001', '2')
 
         await request(app)
           .get(`${pagePath}?code=123`)


### PR DESCRIPTION
The type for the IDAM identifier was an implementation detail and should
not have been assumed.

The type is changing soon, to enable testing of the new solution we need
to remove our assumption on the type