### PR TITLE
ROC-2579: fixed isComplete for claim task list when defendant email f…

### DIFF
--- a/src/main/app/drafts/models/defendant.ts
+++ b/src/main/app/drafts/models/defendant.ts
@@ -48,7 +48,7 @@ export class Defendant implements CompletableTask {
   }
 
   isCompleted (): boolean {
-    const emailCompleted = this.email && this.email.isCompleted()
+    const emailCompleted = !!this.email && this.email.isCompleted()
     if (this.partyDetails && this.partyDetails.type) {
       switch (this.partyDetails.type) {
         case PartyType.INDIVIDUAL.value:

--- a/src/main/app/drafts/models/defendant.ts
+++ b/src/main/app/drafts/models/defendant.ts
@@ -48,7 +48,7 @@ export class Defendant implements CompletableTask {
   }
 
   isCompleted (): boolean {
-    const emailCompleted = this.email ? this.email.isCompleted() : true
+    const emailCompleted = this.email && this.email.isCompleted()
     if (this.partyDetails && this.partyDetails.type) {
       switch (this.partyDetails.type) {
         case PartyType.INDIVIDUAL.value:

--- a/src/test/app/drafts/models/defendant.ts
+++ b/src/test/app/drafts/models/defendant.ts
@@ -5,7 +5,9 @@ import { Defendant } from 'app/drafts/models/defendant'
 /* tslint:disable:no-unused-expression */
 
 describe('Defendant', () => {
+
   describe('constructor', () => {
+
     it('should have undefined email', () => {
       const defendant = new Defendant()
       expect(defendant.email).to.be.undefined
@@ -18,6 +20,7 @@ describe('Defendant', () => {
   })
 
   describe('deserialize', () => {
+
     it('should return a Defendant instance initialised with defaults for undefined', () => {
       expect(new Defendant().deserialize(undefined)).to.eql(new Defendant())
     })
@@ -28,6 +31,7 @@ describe('Defendant', () => {
   })
 
   describe('task state', () => {
+
     const defendant: object = {
       partyDetails: {
         type: 'individual',
@@ -46,17 +50,19 @@ describe('Defendant', () => {
     }
 
     context('is incomplete', () => {
+
       it('when email is defined and invalid', () => {
         const state = new Defendant().deserialize({ ...defendant, email: { address: 'some-text' } })
+        expect(state.isCompleted()).to.be.false
+      })
+
+      it('when email is undefined', () => {
+        const state = new Defendant().deserialize({ ...defendant, email: undefined })
         expect(state.isCompleted()).to.be.false
       })
     })
 
     context('is complete', () => {
-      it('when email is undefined', () => {
-        const state = new Defendant().deserialize({ ...defendant, email: undefined })
-        expect(state.isCompleted()).to.be.true
-      })
 
       it('when email is defined and valid', () => {
         const state = new Defendant().deserialize({ ...defendant, email: { address: 'user@example.com' } })

--- a/src/test/app/forms/models/email.ts
+++ b/src/test/app/forms/models/email.ts
@@ -9,7 +9,9 @@ import { expectValidationError } from './validationUtils'
 import Email, { ValidationErrors } from 'forms/models/email'
 
 describe('Email', () => {
+
   describe('constructor', () => {
+
     it('should set the primitive fields to undefined', () => {
       let email = new Email()
       expect(email.address).to.be.undefined
@@ -17,6 +19,7 @@ describe('Email', () => {
   })
 
   describe('deserialize', () => {
+
     it('should return a Email instance initialised with defaults for undefined', () => {
       expect(new Email().deserialize(undefined)).to.eql(new Email())
     })
@@ -34,6 +37,7 @@ describe('Email', () => {
   })
 
   describe('validation', () => {
+
     const validator: Validator = new Validator()
 
     it('should reject undefined address', () => {
@@ -65,7 +69,9 @@ describe('Email', () => {
   })
 
   describe('task state', () => {
+
     context('is incomplete', () => {
+
       it('when address is undefined', () => {
         const state = new Email(undefined)
         expect(state.isCompleted()).to.be.false
@@ -83,6 +89,7 @@ describe('Email', () => {
     })
 
     context('is complete', () => {
+
       it('when address is valid', () => {
         const state = new Email('user@example.com')
         expect(state.isCompleted()).to.be.true


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/ROC-2579


### Change description ###
Claimant cannot submit claim as long as he hasn't submitted defendant email - even if email is empty.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
