### PR TITLE
Workaround for unaligned response type models

### DIFF
--- a/src/main/app/claims/responseModelConverter.ts
+++ b/src/main/app/claims/responseModelConverter.ts
@@ -13,6 +13,8 @@ import { CompanyDetails } from 'forms/models/companyDetails'
 import { OrganisationDetails } from 'forms/models/organisationDetails'
 import { Defendant } from 'drafts/models/defendant'
 import { StatementOfTruth } from 'claims/models/statementOfTruth'
+import { ResponseType } from 'response/form/models/responseType'
+import { RejectAllOfClaimOption } from 'response/form/models/rejectAllOfClaim'
 
 export class ResponseModelConverter {
 
@@ -25,13 +27,24 @@ export class ResponseModelConverter {
       )
     }
     return new ResponseData(
-      responseDraft.response.type.value,
+      this.inferResponseType(responseDraft),
       responseDraft.defence.text,
       responseDraft.freeMediation === undefined ? undefined : responseDraft.freeMediation.option,
       responseDraft.moreTimeNeeded === undefined ? undefined : responseDraft.moreTimeNeeded.option,
       this.convertPartyDetails(responseDraft.defendantDetails),
       statementOfTruth
     )
+  }
+
+  // TODO A workaround for Claim Store staff notifications logic to work.
+  // Should be removed once partial admission feature is fully done and frontend and backend models are aligned properly.
+  private static inferResponseType (draft: ResponseDraft): string {
+    if (draft.response.type === ResponseType.OWE_NONE
+      && draft.rejectAllOfClaim && draft.rejectAllOfClaim.option === RejectAllOfClaimOption.ALREADY_PAID) {
+      return 'OWE_ALL_PAID_ALL'
+    } else {
+      return draft.response.type.value
+    }
   }
 
   private static convertPartyDetails (defendant: Defendant): Party {


### PR DESCRIPTION
### Change description ###

`OWE_ALL_PAID_ALL` response type has been split into response subtypes. But Claim Store still relies on it to compose a staff notification. This change is to provide a workaround that will fix the broken functionality. Frontend and backend models will be aligned properly as a part of finishing partial admission stories.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
