### PR TITLE
Log 404 at debug

### DIFF
--- a/src/main/app/logging/errorLogger.ts
+++ b/src/main/app/logging/errorLogger.ts
@@ -1,3 +1,5 @@
+import * as HttpStatus from 'http-status-codes'
+
 export class ErrorLogger {
   constructor (public logger = require('@hmcts/nodejs-logging').getLogger('errorLogger.js')) {
     this.logger = logger
@@ -5,7 +7,12 @@ export class ErrorLogger {
 
   log (err) {
     if (err) {
-      this.logger.error(`${err.stack || err}`)
+      const logMessage = `${err.stack || err}`
+      if (err.statusCode && err.statusCode === HttpStatus.NOT_FOUND) {
+        this.logger.debug(logMessage)
+      } else {
+        this.logger.error(logMessage)
+      }
     } else {
       this.logger.debug('Received error was blank')
     }


### PR DESCRIPTION
This aligns the citizen frontend with the claim store in how 404s are
logged.
It will also remove the spam in the production logs from webcheck scanning the
system for vulnerabilities