### PR TITLE
ROC-2162: added filter default('') in check and send page for evidence description

### DIFF
--- a/src/main/features/response/views/check-and-send.njk
+++ b/src/main/features/response/views/check-and-send.njk
@@ -96,7 +96,7 @@
       {% for row in draft.evidence.rows %}
         {% if row.type %}
           {% set atLeastOneRow = true %}
-          {% set evidenceCode = evidenceCode + '<li><div class="bold">' + row.type.displayValue + '</div>' + row.description + ' </li>' %}
+          {% set evidenceCode = evidenceCode + '<li><div class="bold">' + row.type.displayValue + '</div>' + row.description | default('') + ' </li>' %}
         {% endif %}
       {% endfor %}
       {% set evidenceCode = evidenceCode + '</ul>' %}


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/ROC-2162


### Change description ###
Fix check and send page. Do not display "undefined", but ''.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
