### PR TITLE
Fix removing 'serviceTokenFactoryImpl' from node cache in unit tests

### DIFF
--- a/src/test/common/security/serviceTokenFactory.ts
+++ b/src/test/common/security/serviceTokenFactory.ts
@@ -1,5 +1,4 @@
 /* tslint:disable:no-unused-expression */
-import { ServiceAuthTokenFactoryImpl } from 'common/security/serviceTokenFactoryImpl'
 import * as chai from 'chai'
 import * as spies from 'sinon-chai'
 import * as sinon from 'sinon'
@@ -7,7 +6,10 @@ import * as sinon from 'sinon'
 import ServiceAuthToken from 'idam/serviceAuthToken'
 import IdamClient from 'idam/idamClient'
 
-delete require.cache[require.resolve('@hmcts/draft-store-client')]
+import { RequireUtils } from '../../requireUtils'
+
+RequireUtils.removeModuleFromCache('common/security/serviceTokenFactoryImpl')
+import { ServiceAuthTokenFactoryImpl } from 'common/security/serviceTokenFactoryImpl'
 
 chai.use(spies)
 

--- a/src/test/requireUtils.ts
+++ b/src/test/requireUtils.ts
@@ -1,0 +1,7 @@
+export class RequireUtils {
+  static removeModuleFromCache (module: string): void {
+    const findModule = (key: string): boolean => key.includes(module)
+    const moduleCacheKey = Object.keys(require.cache).find(findModule)
+    delete require.cache[moduleCacheKey]
+  }
+}


### PR DESCRIPTION
### JIRA link ###

None

### Change description ###

That should fix master build. I have no good idea why it worked before and stopped working. Maybe node started handling this differently.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```