### PR TITLE
Changed double quotes to single ones around displayed text in templates

### DIFF
--- a/src/main/features/ccj/views/check-and-send.njk
+++ b/src/main/features/ccj/views/check-and-send.njk
@@ -5,8 +5,8 @@
 {% from "statement-of-truth.njk" import statementOfTruth %}
 {% from "party/details.njk" import partyDetailsSummaryFragment %}
 
-{% set title = t("Money claim") %}
-{% set heading = t("Check your answers") %}
+{% set title = t('Money claim') %}
+{% set heading = t('Check your answers') %}
 
 {% block content %}
   <form novalidate method="post">
@@ -28,7 +28,7 @@
     {{ tableEnd() }}
 
     {{ tableStart('payment', 'Payment') }}
-    {{ row("Amount to be paid by defendant", amountToBePaid | numeral, changeLink = paidAmountUrl) }}
+    {{ row('Amount to be paid by defendant', amountToBePaid | numeral, changeLink = paidAmountUrl) }}
 
     {% if draft.paymentOption.option.value == 'IMMEDIATELY' %}
       {% set paymentOptionDisplayValue = [draft.paymentOption.option.displayValue] %}

--- a/src/main/features/ccj/views/date-of-birth.njk
+++ b/src/main/features/ccj/views/date-of-birth.njk
@@ -15,9 +15,9 @@
           {{ t('Defendant’s date of birth') }}
         </h1>
 
-        <p>{{ t("We use this to ensure legal proceedings are made against the right person. " +
-        "For example, if there are 2 people living at the same address with the same " +
-        "name.") }}</p>
+        <p>{{ t('We use this to ensure legal proceedings are made against the right person. ' +
+        'For example, if there are 2 people living at the same address with the same ' +
+        'name.') }}</p>
 
         {% set error = form.errorFor('known') %}
 

--- a/src/main/features/ccj/views/paid-amount-summary.njk
+++ b/src/main/features/ccj/views/paid-amount-summary.njk
@@ -6,8 +6,8 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h1 class="heading-large">
-      <span class="heading-secondary">{{ t("County Court Judgment") }}</span>
-      {{ t("Amount to be paid by defendant") }}
+      <span class="heading-secondary">{{ t('County Court Judgment') }}</span>
+      {{ t('Amount to be paid by defendant') }}
     </h1>
 
     <div class="form-group">
@@ -15,16 +15,16 @@
         {{ t('Amount payable by the defendant is calculated on the amount you’re claiming and any other costs minus any amount paid by the defendant.') }}
       </p>
       <table class="table-form">
-        <caption class="visuallyhidden">{{ t("Amount payable by the defendant") }}</caption>
+        <caption class="visuallyhidden">{{ t('Amount payable by the defendant') }}</caption>
         <thead>
         <tr>
           <th scope="col"></th>
-          <th class="numeric last" scope="col">{{ t("Amount") }}</th>
+          <th class="numeric last" scope="col">{{ t('Amount') }}</th>
         </tr>
         </thead>
         <tbody>
         <tr>
-          <th scope="row">{{ t("Claim amount") }}</th>
+          <th scope="row">{{ t('Claim amount') }}</th>
           <td class="numeric last">
             <span class="font-small">{{ claim.claimData.amount.totalAmount() | numeral }}</span>
           </td>
@@ -34,17 +34,17 @@
           <th scope="row">
             <details role="group">
               <summary role="button" aria-controls="details-content-0" aria-expanded="false">
-                {{ t("Interest to date of judgment") }}
+                {{ t('Interest to date of judgment') }}
               </summary>
               <div class="panel text-small" id="details-content-0" aria-hidden>
-                {{ t("Interest calculated at %s%% for %s days", {
+                {{ t('Interest calculated at %s%% for %s days', {
                   postProcess: 'sprintf', sprintf: [ interestDetails.rate, interestDetails.numberOfDays ]
                   })
                 }}
                 <br>
                 <span class="font-xsmall">
                 ({{
-                  t("%s to %s", {
+                  t('%s to %s', {
                     postProcess: 'sprintf', sprintf: [
                       interestDetails.interestDate | date,
                       interestDetails.defaultJudgmentDate | date
@@ -61,7 +61,7 @@
         </tr>
         {% endif %}
         <tr>
-          <th scope="row">{{ t("Claim fee") }}</th>
+          <th scope="row">{{ t('Claim fee') }}</th>
           <td class="numeric last">
             <span class="font-small">{{ claim.claimData.paidFeeAmount | numeral }}</span>
           </td>
@@ -69,11 +69,11 @@
 
         {% if alreadyPaid %}
         <tr>
-          <th scope="col" class="bold-small">{{ t("Sub total") }}</th>
+          <th scope="col" class="bold-small">{{ t('Sub total') }}</th>
           <td class="numeric last bold-small"><span id="sub-total">{{ claim.totalAmount | numeral }}</span></td>
         </tr>
         <tr>
-          <th scope="row">{{ t("Minus amount already paid") }}</th>
+          <th scope="row">{{ t('Minus amount already paid') }}</th>
           <td class="numeric last">
             <span class="font-small">{{ alreadyPaid | numeral }}</span>
           </td>
@@ -81,7 +81,7 @@
         {% endif %}
 
         <tr>
-          <th scope="col" class="bold-medium">{{ t("Total") }}</th>
+          <th scope="col" class="bold-medium">{{ t('Total') }}</th>
           <td class="numeric last bold-medium"><span id="total">{{ (claim.totalAmount - alreadyPaid) | numeral }}</span></td>
         </tr>
         </tbody>
@@ -89,7 +89,7 @@
     </div>
 
     <div class="form-group">
-      <a class="button" href="{{nextPageUrl}}">{{ t("Continue") }}</a>
+      <a class="button" href="{{nextPageUrl}}">{{ t('Continue') }}</a>
     </div>
   </div>
 </div>

--- a/src/main/features/ccj/views/pay-by-set-date.njk
+++ b/src/main/features/ccj/views/pay-by-set-date.njk
@@ -13,13 +13,13 @@
 
         <h1 class="heading-large">
           <span class="heading-secondary">{{ t('County Court Judgment') }}</span>
-          {{ t("Order them to pay full amount by a set date") }}
+          {{ t('Order them to pay full amount by a set date') }}
         </h1>
 
         <fieldset class="form-group {% if error %} form-group-error {% endif %}">
           <legend>
               <span class="form-label-bold">
-                {{ t("When you want them to pay the amount") }}
+                {{ t('When you want them to pay the amount') }}
               </span>
           </legend>
         </fieldset>

--- a/src/main/features/ccj/views/payment-options.njk
+++ b/src/main/features/ccj/views/payment-options.njk
@@ -8,9 +8,9 @@
   <div class="column-two-thirds">
 
     <h1 class="heading-large">
-      <span class="heading-secondary">{{ t("County Court Judgment") }} </span>
+      <span class="heading-secondary">{{ t('County Court Judgment') }} </span>
 
-      {{ t("Payment options") }}
+      {{ t('Payment options') }}
     </h1>
 
     <form method="post" class="analytics-submit-event-trigger" data-event-action="CCJ: Select payment option" data-event-label-from="option" novalidate>

--- a/src/main/features/ccj/views/repayment-plan.njk
+++ b/src/main/features/ccj/views/repayment-plan.njk
@@ -7,8 +7,8 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large">
-        <span class="heading-secondary">{{ t("County Court Judgment") }}</span>
-        {{ t("Order them to pay by instalments") }}
+        <span class="heading-secondary">{{ t('County Court Judgment') }}</span>
+        {{ t('Order them to pay by instalments') }}
       </h1>
       <p>{{ t('Total amount payable by the defendant is %s',
         { postProcess: 'sprintf', sprintf: [ remainingAmount | numeral ]}) }}

--- a/src/main/features/claim/views/amount.njk
+++ b/src/main/features/claim/views/amount.njk
@@ -23,7 +23,7 @@
               <div id="claim-amount-heading-1" class="claim-amount-column-1 mobile-hide">
                 <span class="form-label-bold">{{ t('What you’re claiming for') }}</span>
                 <span class="form-hint">
-                  {{ t('Briefly explain why you’re claiming for this - for example, "unpaid debt" or "house deposit not returned"') }}
+                  {{ t('Briefly explain why you’re claiming for this - for example, “unpaid debt” or “house deposit not returned”') }}
                 </span>
               </div>
               <div id="claim-amount-heading-2" class="claim-amount-column-2 mobile-hide">
@@ -86,4 +86,3 @@
     </div>
   </div>
 {% endblock %}
-

--- a/src/main/features/claim/views/check-and-send.njk
+++ b/src/main/features/claim/views/check-and-send.njk
@@ -5,14 +5,14 @@
 {% from "statement-of-truth.njk" import statementOfTruth %}
 {% from "party/details.njk" import partyDetailsSummaryFragment %}
 
-{% set title = t("Money claim") %}
-{% set heading = t("Check your answers before submitting your claim") %}
+{% set title = t('Money claim') %}
+{% set heading = t('Check your answers before submitting your claim') %}
 
 {% block content %}
   <form novalidate method="post">
     {{ csrfProtection(csrf) }}
 
-    {{ tableStart("yourDetails", "Your details") }}
+    {{ tableStart('yourDetails', 'Your details') }}
     {{
         partyDetailsSummaryFragment(
           partyDetails = draftClaim.claimant.partyDetails,
@@ -23,10 +23,10 @@
           }
         )
     }}
-    {{ row("Phone:", draftClaim.claimant.mobilePhone.number, paths.claimantMobilePage.uri) }}
+    {{ row('Phone:', draftClaim.claimant.mobilePhone.number, paths.claimantMobilePage.uri) }}
     {{ tableEnd() }}
 
-    {{ tableStart("theirDetails", "Their details") }}
+    {{ tableStart('theirDetails', 'Their details') }}
       {{
           partyDetailsSummaryFragment(
             partyDetails = draftClaim.defendant.partyDetails,
@@ -38,33 +38,33 @@
         )
     }}
 
-    {{ row("Email:", draftClaim.defendant.email.address, paths.defendantEmailPage.uri) }}
+    {{ row('Email:', draftClaim.defendant.email.address, paths.defendantEmailPage.uri) }}
     {{ tableEnd() }}
 
-    {{ tableStart("claimAmount", "Claim amount") }}
-    {{ row("Claim amount:", claimAmountTotal.claimAmount | numeral, paths.amountPage.uri )}}
+    {{ tableStart('claimAmount', 'Claim amount') }}
+    {{ row('Claim amount:', claimAmountTotal.claimAmount | numeral, paths.amountPage.uri )}}
 
     {% if (interestClaimed === true) %}
       {% if (draftClaim.interest.rate) %}
-        {{ row("Interest rate:", draftClaim.interest.rate | numeral("0,0.00") + "\% \(" + draftClaim.interest.type + "\)" , paths.interestPage.uri) }}
+        {{ row('Interest rate:', draftClaim.interest.rate | numeral('0,0.00') + '\% \(' + draftClaim.interest.type + '\)' , paths.interestPage.uri) }}
       {% endif %}
       {% if payAtSubmission === false %}
-        {{ row("Date interest is claimed from:", draftClaim.interestDate.date.asString() | date, paths.interestDatePage.uri) }}
+        {{ row('Date interest is claimed from:', draftClaim.interestDate.date.asString() | date, paths.interestDatePage.uri) }}
       {% else %}
-        {{ row("Date interest is claimed from:", t( 'Date you submit the claim' ), paths.interestDatePage.uri) }}
+        {{ row('Date interest is claimed from:', t( 'Date you submit the claim' ), paths.interestDatePage.uri) }}
       {% endif %}
       {% if (claimAmountTotal.interestAmount) %}
-        {{ row("Interest:", claimAmountTotal.interestAmount | numeral, paths.interestPage.uri) }}
+        {{ row('Interest:', claimAmountTotal.interestAmount | numeral, paths.interestPage.uri) }}
       {% endif %}
     {% else %}
-      {{ row("Interest rate:", t('I don’t want to claim interest'), paths.interestPage.uri )}}
+      {{ row('Interest rate:', t('I don’t want to claim interest'), paths.interestPage.uri )}}
     {% endif %}
 
-    {{ row("Claim fee:", claimAmountTotal.feeAmount | numeral) }}
+    {{ row('Claim fee:', claimAmountTotal.feeAmount | numeral) }}
     {{ row('Total amount you’re claiming:',  claimAmountTotal.totalAmount | numeral) }}
     {{ tableEnd() }}
 
-    {{ tableStart("claimDetails", "Claim details") }}
+    {{ tableStart('claimDetails', 'Claim details') }}
     {{ row('Why you’re owed the money:', draftClaim.reason.reason, paths.reasonPage.uri ) }}
     {{ tableEnd() }}
     <div class="column-two-thirds">

--- a/src/main/features/claim/views/claimant-mobile.njk
+++ b/src/main/features/claim/views/claimant-mobile.njk
@@ -8,7 +8,7 @@
   <div class="grid-row">
       <div class="column-two-thirds">
 
-        <p>{{ t("We might need to contact you about your claim. We’ll only call on weekdays between 9:30am and 5pm.") }}</p>
+        <p>{{ t('We might need to contact you about your claim. We’ll only call on weekdays between 9:30am and 5pm.') }}</p>
         <form method="post">
           {{ csrfProtection(csrf) }}
 

--- a/src/main/features/claim/views/claimant-party-type-selection.njk
+++ b/src/main/features/claim/views/claimant-party-type-selection.njk
@@ -1,11 +1,11 @@
 {% extends "layout.njk" %}
 {% from "form.njk" import nameInput, csrfProtection, errorSummary, radioGroup, saveAndContinueButton %}
 
-{% set title = t("Money claim") %}
+{% set title = t('Money claim') %}
 
 {% block content %}
   <div class="grid-row">
-    <h1 class="heading-large">{{ t("About you and this claim") }}</h1>
+    <h1 class="heading-large">{{ t('About you and this claim') }}</h1>
     <p>{{ t('I’m claiming as:') }}</p>
     <form method="POST" novalidate>
       {{ csrfProtection(csrf) }}

--- a/src/main/features/claim/views/completing-claim.njk
+++ b/src/main/features/claim/views/completing-claim.njk
@@ -14,7 +14,7 @@
 
         <p class="bold-medium">{{ t('You should') }}:</p>
 
-        <p>{{ t("Include all the main points of your claim now. You may have to pay an extra fee if you want to make changes later such as") }}:</p>
+        <p>{{ t('Include all the main points of your claim now. You may have to pay an extra fee if you want to make changes later such as') }}:</p>
 
         <ul class="list list-bullet form-group">
           <li>{{ t('naming someone else as owing you the money - for example, saying a company director owes you money instead of the contractor who carried out the work') }}</li>

--- a/src/main/features/claim/views/confirmation.njk
+++ b/src/main/features/claim/views/confirmation.njk
@@ -27,7 +27,7 @@
         }
         ) | safe }}
       </p>
-      <p>{{ t("We’ll send you an update by email if they do respond, and we’ll explain what to do if they don’t.") }}</p>
+      <p>{{ t('We’ll send you an update by email if they do respond, and we’ll explain what to do if they don’t.') }}</p>
 
       <p>{{ t('You can <a href="%s">view your claim</a> at any time.',
         {
@@ -56,9 +56,9 @@
       <p>
         {{ t('You might have to go to a court hearing if:') }}
       <ul class="list-bullet">
-        <li>{{ t("the defendant says they don’t owe you any money") }}</li>
-        <li>{{ t("they disagree with the amount you’ve claimed") }}</li>
-        <li>{{ t("you don’t agree with how they’ve offered to repay you") }}</li>
+        <li>{{ t('the defendant says they don’t owe you any money') }}</li>
+        <li>{{ t('they disagree with the amount you’ve claimed') }}</li>
+        <li>{{ t('you don’t agree with how they’ve offered to repay you') }}</li>
       </ul>
       </p>
       <p>{{ t('The court may send you a questionnaire asking for more information on the case.') }}</p>

--- a/src/main/features/claim/views/defendant-party-type-selection.njk
+++ b/src/main/features/claim/views/defendant-party-type-selection.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 {% from "form.njk" import nameInput, csrfProtection, errorSummary, radioGroup, saveAndContinueButton %}
 
-{% set title = t("Money claim") %}
+{% set title = t('Money claim') %}
 
 {% block content %}
   <div class="grid-row">

--- a/src/main/features/claim/views/interest.njk
+++ b/src/main/features/claim/views/interest.njk
@@ -9,7 +9,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
 
-      <p>{{ t("You can also claim interest on the money you’re owed. The court will decide if you’re entitled to it.") }} </p>
+      <p>{{ t('You can also claim interest on the money you’re owed. The court will decide if you’re entitled to it.') }} </p>
 
       <form novalidate method="post">
         {{ csrfProtection(csrf) }}

--- a/src/main/features/claim/views/reason.njk
+++ b/src/main/features/claim/views/reason.njk
@@ -8,7 +8,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
 
-      <p>{{ t("Briefly explain why you are owed the money.") }}</p>
+      <p>{{ t('Briefly explain why you are owed the money.') }}</p>
       <div class="panel panel-border-wide">
         <p>{{ t('Your claim will be sent to the defendant %1$s - a judge will not consider your explanation unless the defendant %1$s rejects your claim.',
         {

--- a/src/main/features/claim/views/resolving-this-dispute.njk
+++ b/src/main/features/claim/views/resolving-this-dispute.njk
@@ -9,15 +9,15 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <p>{{ t("You should try to solve the dispute directly with the party before making a claim by:") }}</p>
+    <p>{{ t('You should try to solve the dispute directly with the party before making a claim by:') }}</p>
 
     <ul class="list-bullet form-group">
-      <li>{{ t("Speaking to them (send an email or letter if you want a record)") }}.</li>
-      <li>{{ t("Telling them what you believe they owe you and why") }}.</li>
+      <li>{{ t('Speaking to them (send an email or letter if you want a record)') }}.</li>
+      <li>{{ t('Telling them what you believe they owe you and why') }}.</li>
       <li>{{ t('Explaining that if you can’t reach an agreement (such as a timetable for paying the money) you’ll make a legal money claim') }}.</li>
-      <li>{{ t("Telling them that they might have to pay the full amount as well as") }}
+      <li>{{ t('Telling them that they might have to pay the full amount as well as') }}
         <a href="http://hmctsformfinder.justice.gov.uk/HMCTS/GetLeaflet.do?court_leaflets_id=264">
-          {{ t("fees and other costs") }}</a>
+          {{ t('fees and other costs') }}</a>
         {{ t('if they ‘defend the claim’, and that they could get a <a target="_blank" href="%s"> County Court Judgment (CCJ) </a> registered against them',
           {
             postProcess: 'sprintf',
@@ -28,7 +28,7 @@
     </ul>
 
     <p class="panel panel-border-wide form-group">
-      {{ t("It might count against you in court if you don’t try to sort out the dispute with the person directly, before you make an official claim") }}.
+      {{ t('It might count against you in court if you don’t try to sort out the dispute with the person directly, before you make an official claim') }}.
     </p>
 
     <form novalidate method="post">

--- a/src/main/features/claim/views/start.njk
+++ b/src/main/features/claim/views/start.njk
@@ -5,8 +5,6 @@
 {% from "form.njk" import submitButton %}
 {% from "support.njk" import supportWidget %}
 
-
-
 {% block content %}
 
   <div class="grid-row">
@@ -18,8 +16,8 @@
       <p class="panel panel-border-wide">{{ t('A money claim might not be your only or best option. Find out about') }}
         <a href="/other-options">{{ t('other ways to get your money') }}</a>.</p>
 
-      <p>{{ t("You might have to go to a hearing in front of a judge if the person says they don’t owe you. It can take
-                up to 7 months to get a hearing date.") }}</p>
+      <p>{{ t('You might have to go to a hearing in front of a judge if the person says they don’t owe you. It can take
+                up to 7 months to get a hearing date.') }}</p>
 
       <p>{{ t('Find out more about') }} <a
           href="https://www.gov.uk/make-court-claim-for-money">{{ t('making a money claim') }}</a>,

--- a/src/main/features/claim/views/start.njk
+++ b/src/main/features/claim/views/start.njk
@@ -13,42 +13,42 @@
     <div class="column-two-thirds">
       <h1 class="heading-large">{{ t('Make a money claim') }}</h1>
 
-      <p>{{ t("You can make a money claim if someone owes you money and won’t agree to pay you back.") }}</p>
+      <p>{{ t('You can make a money claim if someone owes you money and won’t agree to pay you back.') }}</p>
 
-      <p class="panel panel-border-wide">{{ t("A money claim might not be your only or best option. Find out about") }}
-        <a href="/other-options">{{ t("other ways to get your money") }}</a>.</p>
+      <p class="panel panel-border-wide">{{ t('A money claim might not be your only or best option. Find out about') }}
+        <a href="/other-options">{{ t('other ways to get your money') }}</a>.</p>
 
       <p>{{ t("You might have to go to a hearing in front of a judge if the person says they don’t owe you. It can take
                 up to 7 months to get a hearing date.") }}</p>
 
-      <p>{{ t("Find out more about") }} <a
-          href="https://www.gov.uk/make-court-claim-for-money">{{ t("making a money claim") }}</a>,
-        {{ t("such as the") }} <a
-          href="https://www.gov.uk/make-court-claim-for-money/court-fees">{{ t(" fees you’ll pay") }}</a>.</p>
+      <p>{{ t('Find out more about') }} <a
+          href="https://www.gov.uk/make-court-claim-for-money">{{ t('making a money claim') }}</a>,
+        {{ t('such as the') }} <a
+          href="https://www.gov.uk/make-court-claim-for-money/court-fees">{{ t(' fees you’ll pay') }}</a>.</p>
 
       <h2 class="heading-medium">{{ t('What you’ll need') }}</h2>
 
       <ul class="list list-bullet">
-        <li>{{ t("Current address and any other contact details of the person or company you’re claiming against.") }}</li>
-        <li>{{ t("A credit or debit card to pay the") }} <a
-            href="https://www.gov.uk/make-court-claim-for-money/court-fees">{{ t("claim fee") }}</a>.
+        <li>{{ t('Current address and any other contact details of the person or company you’re claiming against.') }}</li>
+        <li>{{ t('A credit or debit card to pay the') }} <a
+            href="https://www.gov.uk/make-court-claim-for-money/court-fees">{{ t('claim fee') }}</a>.
         </li>
-        <li>{{ t("Around 30 minutes to make your claim.") }}</li>
+        <li>{{ t('Around 30 minutes to make your claim.') }}</li>
       </ul>
 
-      <p class="panel panel-border-wide">{{ t("You can save your claim and return to it at any time.") }}</p>
+      <p class="panel panel-border-wide">{{ t('You can save your claim and return to it at any time.') }}</p>
 
       <div class="clearfix">
-        <a class="button button-start" href="{{ startLink }}" role="button">{{ t("Start now") }}</a>
+        <a class="button button-start" href="{{ startLink }}" role="button">{{ t('Start now') }}</a>
       </div>
 
       <br>
 
-      <h2 class="heading-medium">{{ t("Other ways to claim") }}</h2>
+      <h2 class="heading-medium">{{ t('Other ways to claim') }}</h2>
 
-      <p>{{ t("You can print and fill in a") }} <a
-          href="http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=338">{{ t("paper claim
-                form.") }}</a> {{ t("Send it and a cheque for your claim fee to the the address on the form.") }}</p>
+      <p>{{ t('You can print and fill in a') }} <a
+          href="http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=338">{{ t('paper claim
+                form.') }}</a> {{ t('Send it and a cheque for your claim fee to the the address on the form.') }}</p>
 
       {{ supportWidget('Help to use this service') }}
 
@@ -60,23 +60,23 @@
           'http://www.advicenow.org.uk/'
           ] }) | safe }}
       </p>
-      <p>{{ t("You don’t have to use a lawyer to make a money claim but some people choose to, for example, if there’s"
-        + " a lot of money involved.") }}
+      <p>{{ t('You don’t have to use a lawyer to make a money claim but some people choose to, for example, if there’s'
+        + ' a lot of money involved.') }}
       </p>
 
     </div>
 
     <div class="column-third">
       <aside class="govuk-related-items" role="complementary">
-        <h2 class="heading-medium" id="subsection-title">{{ t("Support") }}</h2>
+        <h2 class="heading-medium" id="subsection-title">{{ t('Support') }}</h2>
         <nav role="navigation" aria-labelledby="subsection-title">
           <ul class="font-xsmall">
-            <li><a href="https://www.gov.uk/make-court-claim-for-money">{{ t("Make a court claim for money") }}</a></li>
-            <li><a href="https://www.gov.uk/make-court-claim-for-money/court-fees">{{ t("Money claim fees") }}</a></li>
-            <li><a href="/other-options">{{ t("Other options") }}</a></li>
+            <li><a href="https://www.gov.uk/make-court-claim-for-money">{{ t('Make a court claim for money') }}</a></li>
+            <li><a href="https://www.gov.uk/make-court-claim-for-money/court-fees">{{ t('Money claim fees') }}</a></li>
+            <li><a href="/other-options">{{ t('Other options') }}</a></li>
             <li><a class="external" rel="external"
                    href="https://courttribunalfinder.service.gov.uk/courts/county-court-business-centre-ccbc"
-                   target="_blank">{{ t("Contact us") }}</a></li>
+                   target="_blank">{{ t('Contact us') }}</a></li>
           </ul>
         </nav>
       </aside>

--- a/src/main/features/first-contact/views/claim-reference.njk
+++ b/src/main/features/first-contact/views/claim-reference.njk
@@ -19,18 +19,18 @@
       </form>
 
       <details>
-        <summary><span class="summary">{{ t("What happens once I’ve viewed the claim?") }}</span></summary>
+        <summary><span class="summary">{{ t('What happens once I’ve viewed the claim?') }}</span></summary>
         <div class="panel panel-border-narrow">
-          <p><span class="bold">{{ t('If you accept the claim is fair') }}</span> {{ t("you can respond to say that you agree to pay the money. If you can’t afford to pay it all at once you can make a suggestion, such as a repayment plan, for them to consider.") }}
+          <p><span class="bold">{{ t('If you accept the claim is fair') }}</span> {{ t('you can respond to say that you agree to pay the money. If you can’t afford to pay it all at once you can make a suggestion, such as a repayment plan, for them to consider.') }}
           </p>
           <p><span
-              class="bold">{{ t("If you don’t accept you owe the amount of money claimed") }}</span> {{ t("you’ll be asked to submit your defence and might have to go to a hearing. You’ll also have the option to ") }}
+              class="bold">{{ t('If you don’t accept you owe the amount of money claimed') }}</span> {{ t('you’ll be asked to submit your defence and might have to go to a hearing. You’ll also have the option to ') }}
             <span
-              class="bold"> {{ t("make a 'without prejudice' suggestion") }} </span> {{ t("to try to settle the claim. This means the other side can’t mention that you made a suggestion to them if they reject it and you end up at a hearing.") }}
+              class="bold"> {{ t('make a ‘without prejudice’ suggestion') }} </span> {{ t('to try to settle the claim. This means the other side can’t mention that you made a suggestion to them if they reject it and you end up at a hearing.') }}
           </p>
 
           <p><span
-              class="bold">{{ t('If you believe the claimant owes you money ') }} </span> {{ t("you can make a claim against them (‘counterclaim’). You might have to pay a ") }}
+              class="bold">{{ t('If you believe the claimant owes you money ') }} </span> {{ t('you can make a claim against them (‘counterclaim’). You might have to pay a ') }}
             <a class="external" rel="external" href="https://www.gov.uk/make-court-claim-for-money/court-fees"
                target="_blank">{{ t('claim fee') }} </a>.</p>
         </div>
@@ -41,7 +41,7 @@
     <div class="column-third">
 
       <aside class="govuk-related-items" role="complementary">
-        <h2 class="heading-medium" id="subsection-title">{{ t("Support") }}</h2>
+        <h2 class="heading-medium" id="subsection-title">{{ t('Support') }}</h2>
         <nav role="navigation" aria-labelledby="subsection-title">
           <ul class="font-xsmall">
             <li><a

--- a/src/main/features/first-contact/views/claim-summary.njk
+++ b/src/main/features/first-contact/views/claim-summary.njk
@@ -3,7 +3,7 @@
 {% from "form.njk" import csrfProtection, submitButton %}
 
 {% set title = t('Money claim') %}
-{% set heading = t("View the claim") %}
+{% set heading = t('View the claim') %}
 
 {% set claimantFullName = claim.claimData.claimant.name %}
 {% set responseDeadline = claim.responseDeadline.format('LL') %}

--- a/src/main/features/first-contact/views/start.njk
+++ b/src/main/features/first-contact/views/start.njk
@@ -72,14 +72,14 @@
     </div>
     <div class="column-third">
       <aside class="govuk-related-items" role="complementary">
-        <h2 class="heading-medium" id="subsection-title">{{ t("Support") }}</h2>
+        <h2 class="heading-medium" id="subsection-title">{{ t('Support') }}</h2>
         <nav role="navigation" aria-labelledby="subsection-title">
           <ul class="font-xsmall">
-            <li><a href="https://www.gov.uk/make-court-claim-for-money/court-fees">{{ t("Money claim fees") }}</a></li>
-            <li><a href="/other-options">{{ t("Other options") }}</a></li>
+            <li><a href="https://www.gov.uk/make-court-claim-for-money/court-fees">{{ t('Money claim fees') }}</a></li>
+            <li><a href="/other-options">{{ t('Other options') }}</a></li>
             <li><a class="external" rel="external"
                    href="https://courttribunalfinder.service.gov.uk/courts/county-court-business-centre-ccbc"
-                   target="_blank">{{ t("Contact us") }}</a></li>
+                   target="_blank">{{ t('Contact us') }}</a></li>
           </ul>
         </nav>
       </aside>

--- a/src/main/features/offer/views/offer-confirmation.njk
+++ b/src/main/features/offer/views/offer-confirmation.njk
@@ -15,7 +15,7 @@
         </div>
         <h2 class="heading-medium">{{ t('What happens next') }}</h2>
         <p>
-        {{ t("%s can accept, reject or make a counter offer. We’ll let you know when they respond.",
+        {{ t('%s can accept, reject or make a counter offer. We’ll let you know when they respond.',
         {
           postProcess: 'sprintf',
           sprintf: [ claim.claimData.claimant.name ]

--- a/src/main/features/offer/views/settle-out-of-court.njk
+++ b/src/main/features/offer/views/settle-out-of-court.njk
@@ -2,13 +2,13 @@
 {% from "form.njk" import csrfProtection, submitButton %}
 {% from "support.njk" import supportWidget %}
 {% set title = t('Money claim') %}
-{% set heading = t("Make an offer to settle out of court") %}
+{% set heading = t('Make an offer to settle out of court') %}
 {% block content %}
   <div class="grid-row">
     <div class="column-two-thirds">
         <p>{{ t('You can avoid going to a hearing if you settle out of court.') }}</p>
         <p>
-        {{ t("If %s accepts your offer you’ll both sign a legal agreement. This agreement will replace the claim.",
+        {{ t('If %s accepts your offer you’ll both sign a legal agreement. This agreement will replace the claim.',
         {
           postProcess: 'sprintf',
           sprintf: [claim.claimData.claimant.name]
@@ -16,7 +16,7 @@
         ) }}
       </p>
       <p>
-        {{ t("You can ask the court to make a Judgment if %s breaks the agreement.",
+        {{ t('You can ask the court to make a Judgment if %s breaks the agreement.',
         {
           postProcess: 'sprintf',
           sprintf: [claim.claimData.claimant.name]
@@ -24,7 +24,7 @@
         ) }}
       </p>
       <p>
-        {{ t("Out of court offers can’t be mentioned in court if you don’t reach an agreement.") }}
+        {{ t('Out of court offers can’t be mentioned in court if you don’t reach an agreement.') }}
       </p>
       
       {{ t('<a href="%s" class="button">Continue</a>',

--- a/src/main/features/offer/views/your-offer.njk
+++ b/src/main/features/offer/views/your-offer.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 {% from "form.njk" import csrfProtection, submitButton, errorSummary, textArea %}
 {% from "date.njk" import dateInput %}
-{% set heading = t("Make an offer") %}
+{% set heading = t('Make an offer') %}
 {% set title = t('Money claim') %}
 
 {% block content %}
@@ -14,7 +14,7 @@
           <h4 class="heading-small"> {{ t('Your offer') }}</h4>
         </div>
 
-        <span class="form-hint">{{ t("For example a payment, fix a problem or return goods.") }}</span>
+        <span class="form-hint">{{ t('For example a payment, fix a problem or return goods.') }}</span>
         {{ textArea(id='offerText', label= '', name='offerText', form = form, rows = 10) }}
         
         <div class="description-block">
@@ -26,7 +26,7 @@
 
         <div class="panel panel-border-wide">
           <p>
-            {{ t("%s can accept, reject or make a counter offer.",
+            {{ t('%s can accept, reject or make a counter offer.',
             {
               postProcess: 'sprintf',
               sprintf: [claim.claimData.claimant.name]

--- a/src/main/features/response/views/check-and-send.njk
+++ b/src/main/features/response/views/check-and-send.njk
@@ -73,7 +73,7 @@
       {% if draft.rejectPartOfClaim.option === RejectPartOfClaimOption.PAID_WHAT_BELIEVED_WAS_OWED %}
         {{ row('How much have you paid the claimant?', draft.howMuchIsPaid.amount | numeral, paths.defendantHowMuchPaid.evaluateUri({ externalId: claim.externalId })) }}
         {{ row('When did you pay this amount?', draft.howMuchIsPaid.date.toMoment() | date, paths.defendantHowMuchPaid.evaluateUri({ externalId: claim.externalId })) }}
-        {{ row("Explain why you don't owe the full amount", draft.howMuchIsPaid.text, paths.defendantHowMuchPaid.evaluateUri({ externalId: claim.externalId })) }}
+        {{ row('Explain why you don’t owe the full amount', draft.howMuchIsPaid.text, paths.defendantHowMuchPaid.evaluateUri({ externalId: claim.externalId })) }}
       {% endif %}
 
       {% set atLeastOneRow = false %}

--- a/src/main/features/response/views/confirmation.njk
+++ b/src/main/features/response/views/confirmation.njk
@@ -1,24 +1,24 @@
 {% extends "layout.njk" %}
 
-{% set title = t("Money claim") %}
+{% set title = t('Money claim') %}
 {% from "support.njk" import supportWidget %}
 
 {% block content %}
   <div class="grid-row">
     <div class="column-two-thirds">
       <div class="govuk-box-highlight">
-        <h1 class="bold-large">{{ t("Defence submitted") }}</h1>
+        <h1 class="bold-large">{{ t('Defence submitted') }}</h1>
 
         <p>
           <strong class="bold">{{ submittedOn | date }}</strong>
         </p>
         <p class="issue-receipt-download ">
-          <a href="{{ paths.receiptReceiver.evaluateUri({ externalId: claim.externalId }) }}">{{ t("Download defence as pdf") }}</a>
+          <a href="{{ paths.receiptReceiver.evaluateUri({ externalId: claim.externalId }) }}">{{ t('Download defence as pdf') }}</a>
         </p>
       </div>
 
       <p>
-        {{ t("Your defence will be shared with %s and the court.",
+        {{ t('Your defence will be shared with %s and the court.',
         {
           postProcess: 'sprintf',
           sprintf: [claim.claimData.claimant.name]
@@ -28,9 +28,9 @@
       <p>{{ t('We’ve also sent a copy to:') }} <strong>{{ defendantEmail }}</strong>.</p>
 
       <div>
-        <h2 class="heading-medium">{{ t("What happens next") }}</h2>
+        <h2 class="heading-medium">{{ t('What happens next') }}</h2>
         <p>
-          {{ t("The case will be reviewed by a judge and might go to a hearing. We’ll contact you if a hearing date is scheduled and explain what you need to do to prepare.") }}
+          {{ t('The case will be reviewed by a judge and might go to a hearing. We’ll contact you if a hearing date is scheduled and explain what you need to do to prepare.') }}
         </p>
 
         <p>{{ t('You can <a href="%s">view the status of this claim</a> at any time.',
@@ -40,7 +40,7 @@
           }) | safe }}</p>
 
 
-        <h2 class="heading-medium">{{ t("What you can do to settle the claim") }}</h2>
+        <h2 class="heading-medium">{{ t('What you can do to settle the claim') }}</h2>
         <p>
           {{ t('Unless you’ve been asked not to, you can still contact %s directly to make a <a href="%s">settlement out of court</a>. If you can reach an agreement you won’t have to go to a hearing.',
           {

--- a/src/main/features/response/views/counter-claim.njk
+++ b/src/main/features/response/views/counter-claim.njk
@@ -2,9 +2,9 @@
 {% from "form.njk" import radioGroup, saveAndContinueButton, errorSummary %}
 {% from "support.njk" import supportWidget %}
 
-{% set title = t("Money claim") %}
+{% set title = t('Money claim') %}
 
-{% set heading = t("Next steps") %}
+{% set heading = t('Next steps') %}
 
 {% block content %}
   <div class="grid-row">

--- a/src/main/features/response/views/free-mediation.njk
+++ b/src/main/features/response/views/free-mediation.njk
@@ -1,27 +1,27 @@
 {% extends "layout.njk" %}
 {% from "form.njk" import csrfProtection, radioOption, saveAndContinueButton, errorSummary %}
 
-{% set title = t("Money claim") %}
+{% set title = t('Money claim') %}
 
-{% set heading = t("Free mediation") %}
+{% set heading = t('Free mediation') %}
 
 {% block content %}
   <div class="grid-row">
     <div class="column-two-thirds">
 
       <p class="lede">
-        {{ t("You might feel you need to go to a hearing now. However, many people resolve their dispute before a hearing by taking part in telephone mediation.") }}</p>
+        {{ t('You might feel you need to go to a hearing now. However, many people resolve their dispute before a hearing by taking part in telephone mediation.') }}</p>
 
-      <p>{{ t("A mediator will:") }}</p>
+      <p>{{ t('A mediator will:') }}</p>
 
       <ul class="list list-bullet">
-        <li>{{ t("listen to each side separately - you won’t talk to directly to the other side") }}</li>
-        <li>{{ t("ask you to consider what the other side says, but won’t make you compromise") }}</li>
-        <li>{{ t("help you reach an agreement, if possible") }}</li>
+        <li>{{ t('listen to each side separately - you won’t talk to directly to the other side') }}</li>
+        <li>{{ t('ask you to consider what the other side says, but won’t make you compromise') }}</li>
+        <li>{{ t('help you reach an agreement, if possible') }}</li>
       </ul>
 
       <h2 class="heading-medium">
-        {{ t("Will you try mediation?") }}
+        {{ t('Will you try mediation?') }}
       </h2>
 
       <form method="post"
@@ -33,13 +33,13 @@
         <div class="form-group">
           <fieldset>
 
-            <legend id="option[label]" class="visually-hidden">{{ t("Will you try mediation?") }}</legend>
+            <legend id="option[label]" class="visually-hidden">{{ t('Will you try mediation?') }}</legend>
 
-            <p>{{ t("Over 68% of people who use our Mediation Service settle on the day.*") }}</p>
+            <p>{{ t('Over 68% of people who use our Mediation Service settle on the day.*') }}</p>
 
             {{
               radioOption(
-                label = t("Yes, I want help to resolve this dispute"),
+                label = t('Yes, I want help to resolve this dispute'),
                 name = 'option',
                 form = form,
                 value = 'yes'
@@ -86,7 +86,7 @@
           {{ saveAndContinueButton() }}
         </div>
       </form>
-      <p>{{ t("* Source: Money Claim Mediation Service statistics, April 2015 to March 2016.") }}</p>
+      <p>{{ t('* Source: Money Claim Mediation Service statistics, April 2015 to March 2016.') }}</p>
     </div>
   </div>
 {% endblock %}

--- a/src/main/features/response/views/full-admission.njk
+++ b/src/main/features/response/views/full-admission.njk
@@ -2,9 +2,9 @@
 {% from "form.njk" import radioGroup, saveAndContinueButton, errorSummary %}
 {% from "support.njk" import supportWidget %}
 
-{% set title = t("Money claim") %}
+{% set title = t('Money claim') %}
 
-{% set heading = t("Next steps") %}
+{% set heading = t('Next steps') %}
 
 {% block content %}
   <div class="grid-row">

--- a/src/main/features/response/views/more-time-confirmation.njk
+++ b/src/main/features/response/views/more-time-confirmation.njk
@@ -1,16 +1,16 @@
 {% extends "layout.njk" %}
 {% from "form.njk" import csrfProtection, submitButton %}
 
-{% set title = t("Money claim") %}
+{% set title = t('Money claim') %}
 
-{% set heading = t("You have an extra 14 days to respond") %}
+{% set heading = t('You have an extra 14 days to respond') %}
 
 {% block content %}
   <div class="grid-row">
     <div class="column-two-thirds">
 
       <p>
-        {{ t("Your claim response deadline is now %s.", { postProcess: 'sprintf', sprintf: [newDeadline | date] }) }}
+        {{ t('Your claim response deadline is now %s.', { postProcess: 'sprintf', sprintf: [newDeadline | date] }) }}
       </p>
 
       <p>

--- a/src/main/features/response/views/more-time-request.njk
+++ b/src/main/features/response/views/more-time-request.njk
@@ -2,16 +2,16 @@
 {% from "form.njk" import csrfProtection, radioGroup, saveAndContinueButton, errorSummary %}
 {% from "table.njk" import tableStart, tableEnd, row, rowWithMultipleValue %}
 
-{% set title = t("Money claim") %}
+{% set title = t('Money claim') %}
 
-{% set heading = t("Do you want more time to respond?") %}
+{% set heading = t('Do you want more time to respond?') %}
 
 {% block content %}
   <div class="grid-row">
     <div class="column-two-thirds">
 
       <p class="lede">
-        {{ t("You can request an extra 14 days to prepare your case.") }}
+        {{ t('You can request an extra 14 days to prepare your case.') }}
       </p>
       <form method="post" class="analytics-submit-event-trigger"
             data-event-action="Response: More time request"

--- a/src/main/features/response/views/partial-admission.njk
+++ b/src/main/features/response/views/partial-admission.njk
@@ -2,9 +2,9 @@
 {% from "form.njk" import radioGroup, saveAndContinueButton, errorSummary %}
 {% from "support.njk" import supportWidget %}
 
-{% set title = t("Money claim") %}
+{% set title = t('Money claim') %}
 
-{% set heading = t("Next steps") %}
+{% set heading = t('Next steps') %}
 
 {% block content %}
   <div class="grid-row">

--- a/src/main/features/response/views/your-defence.njk
+++ b/src/main/features/response/views/your-defence.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 {% from "form.njk" import csrfProtection, saveAndContinueButton, errorSummary, textArea %}
 
-{% set heading = t("Your defence") %}
+{% set heading = t('Your defence') %}
 {% set title = t('Money claim') %}
 
 {% set claimantFullName = claim.claimData.claimant.name %}
@@ -18,11 +18,11 @@
       <form novalidate method="post">
         {{ csrfProtection(csrf) }}
 
-        {{ textArea(label = t("Briefly explain why you disagree with the claim. If you disagree with only some of the claim, say what you believe is wrong and what you believe is correct."), name = 'text', form = form, rows = 10) }}
+        {{ textArea(label = t('Briefly explain why you disagree with the claim. If you disagree with only some of the claim, say what you believe is wrong and what you believe is correct.'), name = 'text', form = form, rows = 10) }}
 
         <div class="panel panel-border-wide">
           <p>
-            {{ t("Your response will be sent to the claimant %s. A judge will not consider see your explanation unless the claim is defended.",
+            {{ t('Your response will be sent to the claimant %s. A judge will not consider see your explanation unless the claim is defended.',
             {
               postProcess: 'sprintf',
               sprintf: [claimantFullName]

--- a/src/main/features/response/views/your-mobile.njk
+++ b/src/main/features/response/views/your-mobile.njk
@@ -8,7 +8,7 @@
   <div class="grid-row">
       <div class="column-two-thirds">
 
-        <p>{{ t("We might need to contact you about your defence. We’ll only call on weekdays between 9:30am and 5pm.") }}</p>
+        <p>{{ t('We might need to contact you about your defence. We’ll only call on weekdays between 9:30am and 5pm.') }}</p>
         <form method="post">
           {{ csrfProtection(csrf) }}
 

--- a/src/main/views/other-options.njk
+++ b/src/main/views/other-options.njk
@@ -11,7 +11,7 @@
       <h2 class="heading-medium">{{ t('Talk to the person who owes you') }}</h2>
 
       <p>
-        {{ t("Before you make a claim it’s a good idea to try to sort out the situation with the person who owes first.") }}
+        {{ t('Before you make a claim it’s a good idea to try to sort out the situation with the person who owes first.') }}
       </p>
 
       <ul class="list list-bullet">
@@ -23,7 +23,7 @@
         </li>
         <li>{{ t('Tell them what you believe they owe you and why.') }}</li>
         <li>
-          {{ t("Explain that if you can’t reach an agreement (such as a timetable for paying the money) you’ll make an official money claim.") }}
+          {{ t('Explain that if you can’t reach an agreement (such as a timetable for paying the money) you’ll make an official money claim.') }}
         </li>
         <li>
           {{ t('Tell them that they might have to pay the full amount as well as <a target="_blank" href="%s">fees and other costs</a>'
@@ -65,9 +65,9 @@
           'http://civilmediation.justice.gov.uk/'
           ] }) | safe }}
       <p>
-        {{ t("Mediation is when an impartial person helps both sides work out an agreement. You can often do this over"
-        + " the phone. And if you don’t want to speak to the person you’re claiming against a mediator can speak to you"
-        + " separately.") }}
+        {{ t('Mediation is when an impartial person helps both sides work out an agreement. You can often do this over'
+        + ' the phone. And if you don’t want to speak to the person you’re claiming against a mediator can speak to you'
+        + ' separately.') }}
 
       </p>
 


### PR DESCRIPTION
### JIRA link ###
none


### Change description ###
Refactored .njk templates to change all (that I could find) double quotes around translated strings to single ones, and replace straight apostrophes with curly ones.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
