### PR TITLE
Stop restarting node process on template change

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,7 +76,7 @@ gulp.task('develop', () => {
   setTimeout(() => {
     livereload.listen()
     nodemon({
-      ext: 'ts js njk po',
+      ext: 'ts js po',
       stdout: true
     }).on('readable', () => {
       this.stdout.on('data', function (chunk) {

--- a/src/main/modules/nunjucks/index.ts
+++ b/src/main/modules/nunjucks/index.ts
@@ -46,6 +46,7 @@ export default class Nunjucks {
     ], {
       autoescape: true,
       throwOnUndefined: true,
+      watch: this.developmentMode,
       express: app
     })
 


### PR DESCRIPTION
### JIRA link ###

None

### Change description ###

Nunjucks engine has a watch feature which reloads template file without a need to restart whole node process. That should speed up development process by reducing wait time when only template changes are being made.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```