### PR TITLE
Banish Serializable interface

### DIFF
--- a/src/main/app/claims/models/address.ts
+++ b/src/main/app/claims/models/address.ts
@@ -1,6 +1,4 @@
-import { Serializable } from 'models/serializable'
-
-export class Address implements Serializable<Address> {
+export class Address {
 
   line1: string
   line2?: string

--- a/src/main/app/claims/models/claim.ts
+++ b/src/main/app/claims/models/claim.ts
@@ -1,5 +1,3 @@
-import { Serializable } from 'models/serializable'
-
 import { Moment } from 'moment'
 import { ClaimData } from 'app/claims/models/claimData'
 import { MomentFactory } from 'common/momentFactory'
@@ -14,7 +12,7 @@ import { Offer } from 'claims/models/offer'
 import { Interest, InterestType } from 'claim/form/models/interest'
 import { InterestDate } from 'claims/models/interestDate'
 
-export class Claim implements Serializable<Claim> {
+export class Claim {
   id: number
   claimantId: string
   externalId: string

--- a/src/main/app/claims/models/claimData.ts
+++ b/src/main/app/claims/models/claimData.ts
@@ -1,4 +1,3 @@
-import { Serializable } from 'app/models/serializable'
 import { ClaimAmountBreakdown } from 'features/claim/form/models/claimAmountBreakdown'
 import { InterestDate } from 'app/claims/models/interestDate'
 import { Interest } from 'features/claim/form/models/interest'
@@ -16,7 +15,7 @@ import { Organisation as DefendantAsOrganisation } from 'claims/models/details/t
 import { Payment } from 'app/pay/payment'
 import { StatementOfTruth } from 'claims/models/statementOfTruth'
 
-export class ClaimData implements Serializable<ClaimData> {
+export class ClaimData {
   externalId: string
   claimants: Party[]
   defendants: TheirDetails[]

--- a/src/main/app/claims/models/countyCourtJudgment.ts
+++ b/src/main/app/claims/models/countyCourtJudgment.ts
@@ -1,10 +1,9 @@
 import { RepaymentPlan } from 'claims/models/replaymentPlan'
 import { MomentFactory } from 'common/momentFactory'
-import { Serializable } from 'models/serializable'
 import { Moment } from 'moment'
 import { StatementOfTruth } from 'claims/models/statementOfTruth'
 
-export class CountyCourtJudgment implements Serializable<CountyCourtJudgment> {
+export class CountyCourtJudgment {
 
   constructor (public defendantDateOfBirth?: Moment,
                public paymentOption?: string,

--- a/src/main/app/claims/models/defendantResponse.ts
+++ b/src/main/app/claims/models/defendantResponse.ts
@@ -1,4 +1,3 @@
-import { Serializable } from 'app/models/serializable'
 import { PartyType } from 'app/common/partyType'
 import { Individual } from 'app/claims/models/details/theirs/individual'
 import { Company } from 'app/claims/models/details/theirs/company'
@@ -8,7 +7,7 @@ import { TheirDetails } from 'app/claims/models/details/theirs/theirDetails'
 import { StatementOfTruth } from 'claims/models/statementOfTruth'
 import { ResponseType } from 'response/form/models/responseType'
 
-export class DefendantResponse implements Serializable<DefendantResponse> {
+export class DefendantResponse {
   type: ResponseType
   defence: string
   freeMediation: string

--- a/src/main/app/claims/models/details/theirs/theirDetails.ts
+++ b/src/main/app/claims/models/details/theirs/theirDetails.ts
@@ -1,8 +1,7 @@
-import { Serializable } from 'models/serializable'
 import { Address } from 'claims/models/address'
 import { PartyType } from 'app/common/partyType'
 
-export class TheirDetails implements Serializable<TheirDetails> {
+export class TheirDetails {
   type: string
   name: string
   address: Address

--- a/src/main/app/claims/models/details/yours/party.ts
+++ b/src/main/app/claims/models/details/yours/party.ts
@@ -1,8 +1,7 @@
-import { Serializable } from 'models/serializable'
 import { Address } from 'claims/models/address'
 import { PartyType } from 'app/common/partyType'
 
-export class Party implements Serializable<Party> {
+export class Party {
   type: string
   name: string
   address: Address

--- a/src/main/app/claims/models/interestDate.ts
+++ b/src/main/app/claims/models/interestDate.ts
@@ -1,8 +1,7 @@
-import { Serializable } from 'models/serializable'
 import { Moment } from 'moment'
 import { MomentFactory } from 'common/momentFactory'
 
-export class InterestDate implements Serializable<InterestDate> {
+export class InterestDate {
 
   constructor (public type?: string, public date?: Moment, public reason?: string) {}
 

--- a/src/main/app/claims/models/offer.ts
+++ b/src/main/app/claims/models/offer.ts
@@ -1,9 +1,8 @@
 
-import { Serializable } from 'models/serializable'
 import { Moment } from 'moment'
 import { MomentFactory } from 'common/momentFactory'
 
-export class Offer implements Serializable<Offer> {
+export class Offer {
   content: string
   completionDate: Moment
 

--- a/src/main/app/claims/models/partyStatement.ts
+++ b/src/main/app/claims/models/partyStatement.ts
@@ -1,8 +1,7 @@
 
-import { Serializable } from 'models/serializable'
 import { Offer } from 'claims/models/offer'
 
-export class PartyStatement implements Serializable<PartyStatement> {
+export class PartyStatement {
   type: string
   madeBy: string
   offer?: Offer

--- a/src/main/app/claims/models/replaymentPlan.ts
+++ b/src/main/app/claims/models/replaymentPlan.ts
@@ -1,9 +1,8 @@
 import { Moment } from 'moment'
 import { PaymentSchedule } from 'ccj/form/models/paymentSchedule'
 import { MomentFactory } from 'common/momentFactory'
-import { Serializable } from 'models/serializable'
 
-export class RepaymentPlan implements Serializable<RepaymentPlan> {
+export class RepaymentPlan {
 
   constructor (public firstPayment?: number,
                public instalmentAmount?: number,

--- a/src/main/app/claims/models/settlement.ts
+++ b/src/main/app/claims/models/settlement.ts
@@ -1,10 +1,9 @@
-import { Serializable } from 'app/models/serializable'
 import { PartyStatement } from 'claims/models/partyStatement'
 import { Offer } from 'claims/models/offer'
 import { StatementType } from 'offer/form/models/statementType'
 import { MadeBy } from 'offer/form/models/madeBy'
 
-export class Settlement implements Serializable<Settlement> {
+export class Settlement {
   partyStatements: PartyStatement[]
 
   deserialize (input: any): Settlement {

--- a/src/main/app/claims/models/statementOfTruth.ts
+++ b/src/main/app/claims/models/statementOfTruth.ts
@@ -1,6 +1,4 @@
-import { Serializable } from 'models/serializable'
-
-export class StatementOfTruth implements Serializable<StatementOfTruth> {
+export class StatementOfTruth {
   signerName: string
   signerRole: string
 

--- a/src/main/app/drafts/models/draftClaim.ts
+++ b/src/main/app/drafts/models/draftClaim.ts
@@ -1,4 +1,3 @@
-import { Serializable } from 'models/serializable'
 import { Claimant } from 'drafts/models/claimant'
 import { ClaimAmountBreakdown } from 'claim/form/models/claimAmountBreakdown'
 import { Interest } from 'claim/form/models/interest'
@@ -10,7 +9,7 @@ import { DraftDocument } from '@hmcts/cmc-draft-store-middleware'
 import { QualifiedStatementOfTruth } from 'app/forms/models/qualifiedStatementOfTruth'
 import { Eligibility } from 'claim/form/models/eligibility/eligibility'
 
-export class DraftClaim extends DraftDocument implements Serializable<DraftClaim> {
+export class DraftClaim extends DraftDocument {
 
   externalId = uuid()
   claimant: Claimant = new Claimant()

--- a/src/main/app/forms/models/address.ts
+++ b/src/main/app/forms/models/address.ts
@@ -2,7 +2,6 @@ import { IsDefined, MaxLength } from 'class-validator'
 
 import { IsNotBlank } from 'forms/validation/validators/isBlank'
 
-import { Serializable } from 'models/serializable'
 import { CompletableTask } from 'app/models/task'
 import { Address as ClaimAddress } from 'claims/models/address'
 
@@ -24,7 +23,7 @@ export class ValidationConstants {
   static readonly POSTCODE_MAX_LENGTH: number = 8
 }
 
-export class Address implements Serializable<Address>, CompletableTask {
+export class Address implements CompletableTask {
 
   @IsDefined({ message: ValidationErrors.FIRST_LINE_REQUIRED, groups: ['claimant', 'defendant', 'response'] })
   @IsNotBlank({ message: ValidationErrors.FIRST_LINE_REQUIRED, groups: ['claimant', 'defendant', 'response'] })

--- a/src/main/app/forms/models/claimReference.ts
+++ b/src/main/app/forms/models/claimReference.ts
@@ -1,5 +1,4 @@
 import { IsDefined, Matches } from 'class-validator'
-import { Serializable } from 'models/serializable'
 import { IsNotBlank } from 'app/forms/validation/validators/isBlank'
 
 export class ValidationErrors {
@@ -7,7 +6,7 @@ export class ValidationErrors {
   static readonly CLAIM_REFERENCE_INVALID: string = 'You need to enter valid claim number'
 }
 
-export class ClaimReference implements Serializable<ClaimReference> {
+export class ClaimReference {
 
   @IsDefined({ message: ValidationErrors.CLAIM_REFERENCE_REQUIRED })
   @IsNotBlank({ message: ValidationErrors.CLAIM_REFERENCE_REQUIRED })

--- a/src/main/app/forms/models/dateOfBirth.ts
+++ b/src/main/app/forms/models/dateOfBirth.ts
@@ -9,7 +9,6 @@ import { MinimumAgeValidator } from 'forms/validation/validators/minimumAgeValid
 import { MomentFactory } from 'common/momentFactory'
 import { MomentFormatter } from 'utils/momentFormatter'
 
-import { Serializable } from 'models/serializable'
 import { LocalDate } from 'forms/models/localDate'
 import { CompletableTask } from 'app/models/task'
 import { IsValidYearFormat } from 'app/forms/validation/validators/isValidYearFormat'
@@ -21,7 +20,7 @@ export class ValidationErrors {
   static readonly DATE_UNDER_18: string = 'Please enter a date of birth before %s'
 }
 
-export class DateOfBirth implements Serializable<DateOfBirth>, CompletableTask {
+export class DateOfBirth implements CompletableTask {
   @IsDefined({ message: 'Select an option' })
   known: boolean
 

--- a/src/main/app/forms/models/email.ts
+++ b/src/main/app/forms/models/email.ts
@@ -1,13 +1,12 @@
 import { IsEmail } from 'forms/validation/validators/isEmail'
 import { CompletableTask } from 'app/models/task'
-import { Serializable } from 'models/serializable'
 import { Validator } from 'class-validator'
 
 export class ValidationErrors {
   static readonly ADDRESS_NOT_VALID: string = 'Enter valid email address'
 }
 
-export class Email implements Serializable<Email>, CompletableTask {
+export class Email implements CompletableTask {
 
   @IsEmail({ message: ValidationErrors.ADDRESS_NOT_VALID })
   address?: string

--- a/src/main/app/forms/models/localDate.ts
+++ b/src/main/app/forms/models/localDate.ts
@@ -2,7 +2,6 @@ import { Max, Min } from 'class-validator'
 import * as _ from 'lodash'
 import * as moment from 'moment'
 
-import { Serializable } from 'models/serializable'
 import { DATE_FORMAT } from 'app/utils/momentFormatter'
 
 export class ValidationErrors {
@@ -11,7 +10,7 @@ export class ValidationErrors {
   static readonly DAY_NOT_VALID: string = 'Enter a valid day'
 }
 
-export class LocalDate implements Serializable<LocalDate> {
+export class LocalDate {
 
   @Min(1, { message: ValidationErrors.YEAR_NOT_VALID })
   @Max(9999, { message: ValidationErrors.YEAR_NOT_VALID })

--- a/src/main/app/forms/models/mobilePhone.ts
+++ b/src/main/app/forms/models/mobilePhone.ts
@@ -1,6 +1,5 @@
 import { IsDefined } from 'class-validator'
 
-import { Serializable } from 'models/serializable'
 import { IsMobilePhone } from 'forms/validation/validators/mobilePhone'
 import { CompletableTask } from 'app/models/task'
 
@@ -9,7 +8,7 @@ export class ValidationErrors {
   static readonly NUMBER_NOT_VALID: string = 'Enter valid UK mobile number'
 }
 
-export class MobilePhone implements Serializable<MobilePhone>, CompletableTask {
+export class MobilePhone implements CompletableTask {
 
   @IsDefined({ message: ValidationErrors.NUMBER_REQUIRED })
   @IsMobilePhone({ message: ValidationErrors.NUMBER_NOT_VALID })

--- a/src/main/app/forms/models/multiRowForm.ts
+++ b/src/main/app/forms/models/multiRowForm.ts
@@ -1,11 +1,10 @@
-import { Serializable } from 'models/serializable'
 import { MultiRowFormItem } from 'forms/models/multiRowFormItem'
 import { ValidateNested } from 'class-validator'
 
 export const MAX_NUMBER_OF_ROWS: number = 20
 export const INIT_ROW_COUNT: number = 1
 
-export abstract class MultiRowForm<T extends MultiRowFormItem> implements Serializable<MultiRowForm<T>> {
+export abstract class MultiRowForm<T extends MultiRowFormItem> {
 
   @ValidateNested({ each: true })
   rows: T[]

--- a/src/main/app/forms/models/name.ts
+++ b/src/main/app/forms/models/name.ts
@@ -1,5 +1,4 @@
 import { IsDefined, MaxLength } from 'class-validator'
-import { Serializable } from 'models/serializable'
 import { IsNotBlank } from 'forms/validation/validators/isBlank'
 import { CompletableTask } from 'app/models/task'
 
@@ -8,7 +7,7 @@ export class ValidationErrors {
   static readonly NAME_TOO_LONG: string = 'Name must be no longer than $constraint1 characters'
 }
 
-export class Name implements Serializable<Name>, CompletableTask {
+export class Name implements CompletableTask {
 
   @IsDefined({ message: ValidationErrors.NAME_REQUIRED })
   @IsNotBlank({ message: ValidationErrors.NAME_REQUIRED })

--- a/src/main/app/forms/models/partyDetails.ts
+++ b/src/main/app/forms/models/partyDetails.ts
@@ -1,6 +1,5 @@
 import { IsDefined, MaxLength, ValidateIf, ValidateNested, Validator } from 'class-validator'
 import { IsNotBlank } from 'forms/validation/validators/isBlank'
-import { Serializable } from 'models/serializable'
 import { Address } from 'forms/models/address'
 import { CorrespondenceAddress } from 'forms/models/correspondenceAddress'
 import { PartyType } from 'app/common/partyType'
@@ -12,7 +11,7 @@ export class ValidationErrors {
   static readonly NAME_TOO_LONG: string = 'Name must be no longer than $constraint1 characters'
 }
 
-export class PartyDetails implements Serializable<PartyDetails> {
+export class PartyDetails {
   type?: string
 
   @IsDefined({ message: ValidationErrors.NAME_REQUIRED, groups: ['claimant', 'defendant'] })

--- a/src/main/app/forms/models/payBySetDate.ts
+++ b/src/main/app/forms/models/payBySetDate.ts
@@ -3,7 +3,6 @@ import { IsDefined, ValidateNested } from 'class-validator'
 import { IsValidLocalDate } from 'forms/validation/validators/isValidLocalDate'
 import { IsTodayOrInFuture } from 'forms/validation/validators/isTodayOrInFuture'
 
-import { Serializable } from 'models/serializable'
 import { LocalDate } from 'forms/models/localDate'
 import { IsValidYearFormat } from 'app/forms/validation/validators/isValidYearFormat'
 
@@ -14,7 +13,7 @@ export class ValidationErrors {
   static readonly DATE_INVALID_YEAR: string = 'Enter a 4 digit year'
 }
 
-export class PayBySetDate implements Serializable <PayBySetDate> {
+export class PayBySetDate {
 
   @ValidateNested()
   @IsDefined({ message: ValidationErrors.DATE_REQUIRED })

--- a/src/main/app/models/serializable.ts
+++ b/src/main/app/models/serializable.ts
@@ -1,5 +1,0 @@
-interface Serializable<T> {
-  deserialize (obj: any): T
-}
-
-export { Serializable }

--- a/src/main/app/pay/payment.ts
+++ b/src/main/app/pay/payment.ts
@@ -1,6 +1,4 @@
-import { Serializable } from 'app/models/serializable'
-
-export class PaymentState implements Serializable<PaymentState> {
+export class PaymentState {
   status: string
   finished: boolean
 
@@ -13,7 +11,7 @@ export class PaymentState implements Serializable<PaymentState> {
   }
 }
 
-export class Payment implements Serializable<Payment> {
+export class Payment {
   id: string
   amount: number
   reference: string

--- a/src/main/features/ccj/form/models/ccjPaymentOption.ts
+++ b/src/main/features/ccj/form/models/ccjPaymentOption.ts
@@ -1,5 +1,4 @@
 import { IsDefined, IsIn } from 'class-validator'
-import { Serializable } from 'models/serializable'
 
 export class ValidationErrors {
   static readonly OPTION_REQUIRED: string = 'Choose option'
@@ -33,7 +32,7 @@ export class PaymentType {
   }
 }
 
-export class CCJPaymentOption implements Serializable <CCJPaymentOption> {
+export class CCJPaymentOption {
 
   @IsDefined({ message: ValidationErrors.OPTION_REQUIRED })
   @IsIn(PaymentType.all(), { message: ValidationErrors.OPTION_REQUIRED })

--- a/src/main/features/ccj/form/models/paidAmount.ts
+++ b/src/main/features/ccj/form/models/paidAmount.ts
@@ -1,5 +1,4 @@
 import { IsDefined, IsIn, IsPositive, ValidateIf } from 'class-validator'
-import { Serializable } from 'models/serializable'
 import { PaidAmountOption } from 'ccj/form/models/yesNoOption'
 import { Fractions } from 'forms/validation/validators/fractions'
 import { IsLessThan } from 'forms/validation/validators/isLessThan'
@@ -12,7 +11,7 @@ export class ValidationErrors {
   static readonly PAID_AMOUNT_GREATER_THAN_TOTAL_AMOUNT: string = 'Paid amount cannot be greater than or equal to total amount'
 }
 
-export class PaidAmount implements Serializable <PaidAmount> {
+export class PaidAmount {
 
   @IsDefined({ message: ValidationErrors.OPTION_REQUIRED })
   @IsIn(PaidAmountOption.all(), { message: ValidationErrors.OPTION_REQUIRED })

--- a/src/main/features/claim/form/models/claimAmountBreakdown.ts
+++ b/src/main/features/claim/form/models/claimAmountBreakdown.ts
@@ -1,6 +1,5 @@
 import { ValidateNested } from 'class-validator'
 
-import { Serializable } from 'app/models/serializable'
 import { ClaimAmountRow } from 'features/claim/form/models/claimAmountRow'
 import { MinTotal } from 'app/forms/validation/validators/minTotal'
 
@@ -11,7 +10,7 @@ export class ValidationErrors {
   static readonly AMOUNT_REQUIRED: string = 'Enter an amount of money'
 }
 
-export class ClaimAmountBreakdown implements Serializable<ClaimAmountBreakdown> {
+export class ClaimAmountBreakdown {
   readonly type: string = 'breakdown'
 
   @ValidateNested({ each: true })

--- a/src/main/features/claim/form/models/eligibility/eligibility.ts
+++ b/src/main/features/claim/form/models/eligibility/eligibility.ts
@@ -1,11 +1,10 @@
-import { Serializable } from 'models/serializable'
 import { YesNoOption } from 'models/yesNoOption'
 import { IsIn } from 'class-validator'
 import { ValidationErrors } from 'forms/validation/validationErrors'
 import { ValidationGroups } from 'claim/helpers/eligibility/validationGroups'
 import { ClaimValue } from 'claim/form/models/eligibility/claimValue'
 
-export class Eligibility implements Serializable<Eligibility> {
+export class Eligibility {
 
   @IsIn(YesNoOption.all(), { message: ValidationErrors.YES_NO_REQUIRED, groups: [ValidationGroups.CLAIMANT_ADDRESS] })
   claimantAddress?: YesNoOption

--- a/src/main/features/claim/form/models/interest.ts
+++ b/src/main/features/claim/form/models/interest.ts
@@ -1,6 +1,5 @@
 import { IsDefined, IsIn, IsPositive, MaxLength, ValidateIf } from 'class-validator'
 
-import { Serializable } from 'app/models/serializable'
 import { IsNotBlank } from 'app/forms/validation/validators/isBlank'
 import { CompletableTask } from 'app/models/task'
 
@@ -28,7 +27,7 @@ export class ValidationErrors {
   static readonly REASON_TOO_LONG: string = 'Enter reason no longer than $constraint1 characters'
 }
 
-export class Interest implements Serializable <Interest>, CompletableTask {
+export class Interest implements CompletableTask {
 
   static readonly STANDARD_RATE = 8
 

--- a/src/main/features/claim/form/models/interestDate.ts
+++ b/src/main/features/claim/form/models/interestDate.ts
@@ -4,7 +4,6 @@ import { IsNotBlank } from 'app/forms/validation/validators/isBlank'
 import { IsNotInFuture } from 'app/forms/validation/validators/notInFuture'
 import { IsValidLocalDate } from 'app/forms/validation/validators/isValidLocalDate'
 
-import { Serializable } from 'app/models/serializable'
 import { LocalDate } from 'app/forms/models/localDate'
 import { CompletableTask } from 'app/models/task'
 import { InterestDateType } from 'app/common/interestDateType'
@@ -22,7 +21,7 @@ export class ValidationErrors {
   static readonly REASON_TOO_LONG: string = 'Enter reason no longer than $constraint1 characters'
 }
 
-export class InterestDate implements Serializable<InterestDate>, CompletableTask {
+export class InterestDate implements CompletableTask {
 
   @IsDefined({ message: ValidationErrors.TYPE_REQUIRED })
   @IsIn(InterestDateType.all(), { message: ValidationErrors.TYPE_REQUIRED })

--- a/src/main/features/claim/form/models/reason.ts
+++ b/src/main/features/claim/form/models/reason.ts
@@ -1,5 +1,4 @@
 import { MaxLength, IsDefined } from 'class-validator'
-import { Serializable } from 'app/models/serializable'
 import { IsNotBlank } from 'app/forms/validation/validators/isBlank'
 import { CompletableTask } from 'app/models/task'
 import { ValidationConstraints } from 'forms/validation/validationConstraints'
@@ -9,7 +8,7 @@ export class ValidationErrors {
   static readonly REASON_REQUIRED: string = 'You need to explain why you’re owed the money'
 }
 
-export class Reason implements Serializable<Reason>, CompletableTask {
+export class Reason implements CompletableTask {
   @IsDefined({ message: ValidationErrors.REASON_REQUIRED })
   @IsNotBlank({ message: ValidationErrors.REASON_REQUIRED })
   @MaxLength(ValidationConstraints.FREE_TEXT_MAX_LENGTH, { message: DefaultValidationErrors.FREE_TEXT_TOO_LONG })

--- a/src/main/features/offer/form/models/defendantResponse.ts
+++ b/src/main/features/offer/form/models/defendantResponse.ts
@@ -1,11 +1,10 @@
 import { IsDefined, IsIn } from 'class-validator'
-import { Serializable } from 'models/serializable'
 import { StatementType } from './statementType'
 export class ValidationErrors {
   static readonly OPTION_REQUIRED: string = 'Choose option: yes or no or make an offer'
 }
 
-export class DefendantResponse implements Serializable<DefendantResponse> {
+export class DefendantResponse {
   @IsDefined({ message: ValidationErrors.OPTION_REQUIRED })
   @IsIn(StatementType.all(), { message: ValidationErrors.OPTION_REQUIRED })
   option?: StatementType

--- a/src/main/features/offer/form/models/offer.ts
+++ b/src/main/features/offer/form/models/offer.ts
@@ -1,5 +1,4 @@
 import { MaxLength, IsDefined, ValidateNested } from 'class-validator'
-import { Serializable } from 'models/serializable'
 import { IsNotBlank } from 'app/forms/validation/validators/isBlank'
 import { IsFutureDate } from 'forms/validation/validators/dateFutureConstraint'
 import { LocalDate } from 'forms/models/localDate'
@@ -14,7 +13,7 @@ export class ValidationErrors {
   static readonly OFFER_TEXT_TOO_LONG: string = 'You’ve entered too many characters'
 }
 
-export class Offer implements Serializable<Offer> {
+export class Offer {
   @IsDefined({ message: ValidationErrors.OFFER_REQUIRED })
   @IsNotBlank({ message: ValidationErrors.OFFER_REQUIRED })
   @MaxLength(ValidationConstraints.FREE_TEXT_MAX_LENGTH, { message: ValidationErrors.OFFER_TEXT_TOO_LONG })

--- a/src/main/features/response/draft/payBySetDate.ts
+++ b/src/main/features/response/draft/payBySetDate.ts
@@ -1,9 +1,8 @@
-import { Serializable } from 'models/serializable'
 import { PayBySetDate as PaymentDate } from 'forms/models/payBySetDate'
 import { Explanation } from 'response/form/models/pay-by-set-date/explanation'
 import { PaymentDateChecker } from 'response/helpers/paymentDateChecker'
 
-export class PayBySetDate implements Serializable<PayBySetDate> {
+export class PayBySetDate {
   paymentDate: PaymentDate
   explanation?: Explanation
 

--- a/src/main/features/response/draft/responseData.ts
+++ b/src/main/features/response/draft/responseData.ts
@@ -1,4 +1,3 @@
-import { Serializable } from 'models/serializable'
 import { PartyType } from 'app/common/partyType'
 import { Party } from 'app/claims/models/details/yours/party'
 import { Individual } from 'app/claims/models/details/yours/individual'
@@ -7,7 +6,7 @@ import { Organisation } from 'app/claims/models/details/yours/organisation'
 import { SoleTrader } from 'app/claims/models/details/yours/soleTrader'
 import { StatementOfTruth } from 'claims/models/statementOfTruth'
 
-export class ResponseData implements Serializable<ResponseData> {
+export class ResponseData {
 
   response?: string
   defence?: string

--- a/src/main/features/response/draft/responseDraft.ts
+++ b/src/main/features/response/draft/responseDraft.ts
@@ -1,5 +1,4 @@
 import { Response } from 'response/form/models/response'
-import { Serializable } from 'models/serializable'
 import { FreeMediation } from 'response/form/models/freeMediation'
 import { RejectPartOfClaim, RejectPartOfClaimOption } from 'response/form/models/rejectPartOfClaim'
 import { RejectAllOfClaim, RejectAllOfClaimOption } from 'response/form/models/rejectAllOfClaim'
@@ -23,7 +22,7 @@ import { ImpactOfDispute } from 'response/form/models/impactOfDispute'
 import { PayBySetDate } from 'response/draft/payBySetDate'
 import { StatementOfMeans } from 'response/draft/statementOfMeans'
 
-export class ResponseDraft extends DraftDocument implements Serializable<ResponseDraft> {
+export class ResponseDraft extends DraftDocument {
 
   response?: Response
   defence?: Defence

--- a/src/main/features/response/draft/statementOfMeans.ts
+++ b/src/main/features/response/draft/statementOfMeans.ts
@@ -1,4 +1,3 @@
-import { Serializable } from 'models/serializable'
 import { Residence } from 'response/form/models/statement-of-means/residence'
 import { Employment } from 'response/form/models/statement-of-means/employment'
 import { Employers } from 'response/form/models/statement-of-means/employers'
@@ -11,7 +10,7 @@ import { ResponseDraft } from 'response/draft/responseDraft'
 import { ResponseType } from 'response/form/models/responseType'
 import { RejectPartOfClaimOption } from 'response/form/models/rejectPartOfClaim'
 
-export class StatementOfMeans implements Serializable<StatementOfMeans> {
+export class StatementOfMeans {
   residence?: Residence
   dependants?: Dependants
   maintenance?: Maintenance

--- a/src/main/features/response/form/models/defence.ts
+++ b/src/main/features/response/form/models/defence.ts
@@ -1,5 +1,4 @@
 import { MaxLength, IsDefined } from 'class-validator'
-import { Serializable } from 'models/serializable'
 import { IsNotBlank } from 'app/forms/validation/validators/isBlank'
 import { ValidationConstraints } from 'forms/validation/validationConstraints'
 import { ValidationErrors as DefaultValidationErrors } from 'forms/validation/validationErrors'
@@ -8,7 +7,7 @@ export class ValidationErrors {
   static readonly DEFENCE_REQUIRED: string = "You need to explain why you don't owe the money"
 }
 
-export class Defence implements Serializable<Defence> {
+export class Defence {
   @IsDefined({ message: ValidationErrors.DEFENCE_REQUIRED })
   @IsNotBlank({ message: ValidationErrors.DEFENCE_REQUIRED })
   @MaxLength(ValidationConstraints.FREE_TEXT_MAX_LENGTH, { message: DefaultValidationErrors.FREE_TEXT_TOO_LONG })

--- a/src/main/features/response/form/models/defendantPaymentOption.ts
+++ b/src/main/features/response/form/models/defendantPaymentOption.ts
@@ -1,5 +1,4 @@
 import { IsDefined, IsIn } from 'class-validator'
-import { Serializable } from 'models/serializable'
 import { ResponseType } from 'response/form/models/responseType'
 
 export class DefendantPaymentTypeLabels {
@@ -55,7 +54,7 @@ export class ValidationErrors {
   static readonly WHEN_WILL_YOU_PAY_OPTION_REQUIRED: string = 'Please select when you will pay'
 }
 
-export class DefendantPaymentOption implements Serializable <DefendantPaymentOption> {
+export class DefendantPaymentOption {
 
   @IsDefined({ message: ValidationErrors.WHEN_WILL_YOU_PAY_OPTION_REQUIRED })
   @IsIn(DefendantPaymentType.all(), { message: ValidationErrors.WHEN_WILL_YOU_PAY_OPTION_REQUIRED })

--- a/src/main/features/response/form/models/evidence.ts
+++ b/src/main/features/response/form/models/evidence.ts
@@ -1,12 +1,11 @@
 import { ValidateNested } from 'class-validator'
 
-import { Serializable } from 'models/serializable'
 import { EvidenceRow } from 'response/form/models/evidenceRow'
 
 export const INIT_ROW_COUNT: number = 4
 export const MAX_NUMBER_OF_ROWS: number = 20
 
-export class Evidence implements Serializable<Evidence> {
+export class Evidence {
   readonly type: string = 'breakdown'
 
   @ValidateNested({ each: true })

--- a/src/main/features/response/form/models/howMuchOwed.ts
+++ b/src/main/features/response/form/models/howMuchOwed.ts
@@ -1,11 +1,10 @@
-import { Serializable } from 'models/serializable'
 import { IsDefined, IsPositive, MaxLength } from 'class-validator'
 import { IsNotBlank } from 'app/forms/validation/validators/isBlank'
 import { ValidationErrors } from 'forms/validation/validationErrors'
 import { Fractions } from 'forms/validation/validators/fractions'
 import { ValidationConstraints } from 'forms/validation/validationConstraints'
 
-export class HowMuchOwed implements Serializable<HowMuchOwed> {
+export class HowMuchOwed {
 
   @IsDefined({ message: ValidationErrors.AMOUNT_REQUIRED })
   @IsPositive({ message: ValidationErrors.VALID_OWED_AMOUNT_REQUIRED })

--- a/src/main/features/response/form/models/howMuchPaid.ts
+++ b/src/main/features/response/form/models/howMuchPaid.ts
@@ -1,4 +1,3 @@
-import { Serializable } from 'models/serializable'
 import { IsDefined, IsPositive, MaxLength, Min } from 'class-validator'
 import { IsPastDate } from 'forms/validation/validators/datePastConstraint'
 import { LocalDate } from 'forms/models/localDate'
@@ -23,7 +22,7 @@ export class ValidationErrors {
   static readonly AMOUNT_INVALID_DECIMALS: string = 'Enter valid amount, maximum two decimal places'
 }
 
-export class HowMuchPaid implements Serializable<HowMuchPaid> {
+export class HowMuchPaid {
 
   @IsDefined({ message: ValidationErrors.AMOUNT_REQUIRED })
   @IsPositive({ message: ValidationErrors.VALID_AMOUNT_REQUIRED })

--- a/src/main/features/response/form/models/impactOfDispute.ts
+++ b/src/main/features/response/form/models/impactOfDispute.ts
@@ -1,9 +1,8 @@
-import { Serializable } from 'models/serializable'
 import { ValidationConstraints } from 'forms/validation/validationConstraints'
 import { ValidationErrors } from 'forms/validation/validationErrors'
 import { MaxLength } from 'forms/validation/validators/maxLengthValidator'
 
-export class ImpactOfDispute implements Serializable<ImpactOfDispute> {
+export class ImpactOfDispute {
 
   @MaxLength(ValidationConstraints.FREE_TEXT_MAX_LENGTH, { message: ValidationErrors.FREE_TEXT_TOO_LONG })
   text?: string

--- a/src/main/features/response/form/models/pay-by-set-date/explanation.ts
+++ b/src/main/features/response/form/models/pay-by-set-date/explanation.ts
@@ -2,13 +2,12 @@ import { IsDefined, MaxLength } from 'class-validator'
 import { IsNotBlank } from 'forms/validation/validators/isBlank'
 import { ValidationConstraints } from 'forms/validation/validationConstraints'
 import { ValidationErrors as DefaultValidationErrors } from 'forms/validation/validationErrors'
-import { Serializable } from 'models/serializable'
 
 export class ValidationErrors {
   static readonly EXPLAIN_WHY_YOU_CANT_PAY_NOW = 'Enter an explanation of why you can’t pay now'
 }
 
-export class Explanation implements Serializable<Explanation> {
+export class Explanation {
   @IsDefined({ message: ValidationErrors.EXPLAIN_WHY_YOU_CANT_PAY_NOW })
   @IsNotBlank({ message: ValidationErrors.EXPLAIN_WHY_YOU_CANT_PAY_NOW })
   @MaxLength(ValidationConstraints.FREE_TEXT_MAX_LENGTH, { message: DefaultValidationErrors.FREE_TEXT_TOO_LONG })

--- a/src/main/features/response/form/models/statement-of-means/dependants.ts
+++ b/src/main/features/response/form/models/statement-of-means/dependants.ts
@@ -1,6 +1,5 @@
 import { IsDefined, ValidateIf, ValidateNested } from 'class-validator'
 
-import { Serializable } from 'models/serializable'
 import * as toBoolean from 'to-boolean'
 import { ValidationErrors as GlobalValidationErrors } from 'forms/validation/validationErrors'
 import { NumberOfChildren } from 'response/form/models/statement-of-means/numberOfChildren'
@@ -10,7 +9,7 @@ export class ValidationErrors {
   static readonly ENTER_AT_LEAST_ONE: string = 'Enter a number for at least one field'
 }
 
-export class Dependants implements Serializable<Dependants> {
+export class Dependants {
 
   @IsDefined({ message: GlobalValidationErrors.YES_NO_REQUIRED })
   hasAnyChildren: boolean

--- a/src/main/features/response/form/models/statement-of-means/education.ts
+++ b/src/main/features/response/form/models/statement-of-means/education.ts
@@ -1,6 +1,5 @@
 import { IsDefined, IsInt, Min } from 'class-validator'
 
-import { Serializable } from 'models/serializable'
 import { toNumberOrUndefined } from 'common/utils/numericUtils'
 import { ValidationErrors as GlobalValidationErrors } from 'forms/validation/validationErrors'
 import { IsLessThanOrEqualTo } from 'forms/validation/validators/isLessThanOrEqualTo'
@@ -9,7 +8,7 @@ export class ValidationErrors {
   static readonly INVALID_NUMBER_OF_CHILDREN: string = 'Number can’t be higher than on previous page'
 }
 
-export class Education implements Serializable<Education> {
+export class Education {
 
   @IsDefined({ message: GlobalValidationErrors.NUMBER_REQUIRED })
   @IsInt({ message: GlobalValidationErrors.INTEGER_REQUIRED })

--- a/src/main/features/response/form/models/statement-of-means/employment.ts
+++ b/src/main/features/response/form/models/statement-of-means/employment.ts
@@ -1,6 +1,5 @@
 import { IsDefined, ValidateIf } from 'class-validator'
 
-import { Serializable } from 'models/serializable'
 import * as toBoolean from 'to-boolean'
 import { IsBooleanTrue } from 'forms/validation/validators/isBooleanTrue'
 import { ValidationErrors as GlobalValidationErrors } from 'forms/validation/validationErrors'
@@ -9,7 +8,7 @@ export class ValidationErrors {
   static readonly SELECT_AT_LEAST_ONE_OPTION: string = 'You must select at least one option'
 }
 
-export class Employment implements Serializable<Employment> {
+export class Employment {
   @IsDefined({ message: GlobalValidationErrors.YES_NO_REQUIRED })
   isCurrentlyEmployed: boolean
 

--- a/src/main/features/response/form/models/statement-of-means/maintenance.ts
+++ b/src/main/features/response/form/models/statement-of-means/maintenance.ts
@@ -1,11 +1,10 @@
 import { IsDefined, IsInt, IsPositive, ValidateIf } from 'class-validator'
 
-import { Serializable } from 'models/serializable'
 import { toNumberOrUndefined } from 'common/utils/numericUtils'
 import * as toBoolean from 'to-boolean'
 import { ValidationErrors as GlobalValidationErrors } from 'forms/validation/validationErrors'
 
-export class Maintenance implements Serializable<Maintenance> {
+export class Maintenance {
 
   @IsDefined({ message: GlobalValidationErrors.YES_NO_REQUIRED })
   option: boolean

--- a/src/main/features/response/form/models/statement-of-means/residence.ts
+++ b/src/main/features/response/form/models/statement-of-means/residence.ts
@@ -1,5 +1,4 @@
 import { ResidenceType } from 'response/form/models/statement-of-means/residenceType'
-import { Serializable } from 'models/serializable'
 import { IsDefined, IsIn, MaxLength, ValidateIf } from 'class-validator'
 import { ValidationErrors as DefaultValidationErrors } from 'forms/validation/validationErrors'
 import { ValidationConstraints } from 'forms/validation/validationConstraints'
@@ -9,7 +8,7 @@ export class ValidationErrors {
   static readonly DESCRIBE_YOUR_HOUSING: string = 'Describe your housing'
 }
 
-export class Residence implements Serializable<Residence> {
+export class Residence {
   @IsDefined({ message: DefaultValidationErrors.SELECT_AN_OPTION })
   @IsIn(ResidenceType.all(), { message: DefaultValidationErrors.SELECT_AN_OPTION })
   type?: ResidenceType

--- a/src/main/features/response/form/models/statement-of-means/selfEmployed.ts
+++ b/src/main/features/response/form/models/statement-of-means/selfEmployed.ts
@@ -1,5 +1,4 @@
 import { IsDefined, Max, Min, ValidateIf } from 'class-validator'
-import { Serializable } from 'models/serializable'
 import { IsNotBlank } from 'forms/validation/validators/isBlank'
 import { MaxLength } from 'forms/validation/validators/maxLengthValidator'
 import { Fractions } from 'forms/validation/validators/fractions'
@@ -19,7 +18,7 @@ export class ValidationConstraints {
   static readonly AMOUNT_YOU_OWE_MIN_VALUE: number = 1
 }
 
-export class SelfEmployed implements Serializable<SelfEmployed> {
+export class SelfEmployed {
 
   @IsDefined({ message: ValidationErrors.JOB_TITLE_REQUIRED })
   @IsNotBlank({ message: ValidationErrors.JOB_TITLE_REQUIRED })

--- a/src/main/features/response/form/models/timeline.ts
+++ b/src/main/features/response/form/models/timeline.ts
@@ -1,12 +1,11 @@
 import { ValidateNested } from 'class-validator'
 
-import { Serializable } from 'models/serializable'
 import { TimelineRow } from 'response/form/models/timelineRow'
 
 export const INIT_ROW_COUNT: number = 4
 export const MAX_NUMBER_OF_EVENTS: number = 20
 
-export class Timeline implements Serializable<Timeline> {
+export class Timeline {
   readonly type: string = 'breakdown'
 
   @ValidateNested({ each: true })


### PR DESCRIPTION
### JIRA link
N/A


### Change description
Banish `Serializable` interface from codebase.
It's not consumed anywhere and serves no real purpose - the implementing type needs to be known in every place anyway. Also, its name is a lie.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
