### PR TITLE
Run yarn setup in CNP, add an NSP exception

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,5 +1,7 @@
 {
   "exceptions": [
+    // not patched yet
+    https://nodesecurity.io/advisories/532,
     // not patched yet and doesn't affect us
     "https://nodesecurity.io/advisories/533",
     // patched but dependencies haven't upgraded yet, doesn't affect us

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -10,6 +10,10 @@ withPipeline("nodejs", product, component) {
     echo 'citizen-frontend checked out'
   }
 
+  after('build') {
+    sh 'yarn setup'
+  }
+
   onSuccess {
     echo '<<<<<< Success'
   }


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-2864

### Change description

Running `yarn setup` after the build stage as it's not a part of the CNP default pipeline. Also added an NSP exception for https://nodesecurity.io/advisories/532

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
