### PR TITLE
ROC-2864: Align sonar scan task to CNP requirements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ SmokeTests smokeTests = new SmokeTests(this)
 IntegrationTests integrationTests = new IntegrationTests(env, this)
 
 InfluxDbPublisher influxDbPublisher = new InfluxDbPublisher(
-  this, 
+  this,
   currentBuild,
   'cmc'
 )
@@ -99,7 +99,7 @@ timestamps {
             }
           }
           stage('Sonar') {
-            sh "yarn sonar-scanner -- -Dsonar.host.url=$SONARQUBE_URL"
+            sh "yarn sonar-scan -- -Dsonar.host.url=$SONARQUBE_URL"
           }
 
         }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:coverage": "NODE_ENV=mocha LOG_LEVEL=OFF nyc mocha --opts mocha.opts $(find src/test \\( -name '*.ts' -or -name '*.js' \\) ! -path '*a11y*')",
     "test:codacy-upload": "cat ./coverage-report/lcov.info | codacy-coverage",
     "test:codecov-upload": "nyc report --reporter=json && codecov -f coverage-report/*.json",
-    "sonar-scanner": "sonar-scanner -Dsonar.projectName='CMC :: Citizen Frontend' -Dsonar.sources=src/main -Dsonar.tests=src/test -Dsonar.exclusions=src/main/public/** -Dsonar.typescript.lcov.reportPaths=coverage-report/lcov.info",
+    "sonar-scan": "sonar-scanner -Dsonar.projectName='CMC :: Citizen Frontend' -Dsonar.sources=src/main -Dsonar.tests=src/test -Dsonar.exclusions=src/main/public/** -Dsonar.typescript.lcov.reportPaths=coverage-report/lcov.info",
     "precommit": "yarn lint",
     "prepush": "yarn test && yarn test:routes"
   },


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-2864

### Change description

CNP pipeline expects a `sonar-scan` yarn task to be available, we named ours `sonar-scanner`.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
