### PR TITLE
ROC-2772: fixed js for evidence page

### DIFF
--- a/src/main/public/js/evidence-select-handler.js
+++ b/src/main/public/js/evidence-select-handler.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
-  $('.timeline-row .form-control-select').on('change', function () {
+  $('.multiline-row .form-control-select').on('change', function () {
 
     var $content = $(this).next()
 


### PR DESCRIPTION
Fixed broken JS script. `timeline` class was replaced with `multiline` as it's more generic name.