### PR TITLE
ROC-2908: Remove TS to JS compilation and start service using ts-node

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,7 +9,6 @@
 
 !gulpfile.js
 !tsconfig.json
-!tsconfig.prod.json
 
 !src/main/**
 !config/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: yarn
 script:
   - yarn --version
   - yarn check --integrity
-  - yarn copy-assets
+  - yarn setup
   - yarn lint
   - yarn test
   - yarn test:routes

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY package.json yarn.lock /usr/src/app/
 RUN yarn install
 
 COPY config /usr/src/app/config
-COPY tsconfig.json tsconfig.prod.json gulpfile.js /usr/src/app/
+COPY tsconfig.json gulpfile.js /usr/src/app/
 COPY src/main /usr/src/app/src/main
 
 RUN yarn setup

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ timestamps {
           stage('Setup') {
             sh '''
               yarn install
-              yarn copy-assets
+              yarn setup
             '''
           }
 
@@ -108,7 +108,6 @@ timestamps {
             'TESTS_TAG'               : '@citizen'
           ])
         }
-
 
         onMaster {
           stage('Package application (RPM)') {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,7 +76,6 @@ gulp.task('develop', () => {
   setTimeout(() => {
     livereload.listen()
     nodemon({
-      exec: 'yarn start-dev',
       ext: 'ts js po',
       stdout: true
     }).on('readable', () => {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,8 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "compile": "tsc --project tsconfig.prod.json",
-    "copy-assets": "gulp sass copy-files",
-    "setup": "yarn compile && yarn copy-assets",
-    "start": "node src/main/server.js",
-    "start-dev": "TS_NODE_FAST=true ./node_modules/.bin/ts-node src/main/server.ts",
+    "setup": "gulp sass copy-files",
+    "start": "TS_NODE_FAST=true ./node_modules/.bin/ts-node src/main/server.ts",
     "lint": "tslint --project tsconfig.json && sass-lint -v -q",
     "test": "TS_NODE_FAST=true NODE_ENV=mocha LOG_LEVEL=OFF mocha --opts mocha.opts $(find src/test \\( -name '*.ts' \\) ! -path '*a11y*' ! -path '*/routes/*') --reporter-options reportFilename=unit,inlineAssets=true,reportTitle=citizen-frontend-unit",
     "test:routes": "TS_NODE_FAST=true NODE_ENV=mocha LOG_LEVEL=OFF mocha --opts mocha.opts $(find src/test \\( -name '*.ts' \\) -path '*/routes/*') --timeout 4000 --reporter-options reportFilename=routes,inlineAssets=true,reportTitle=citizen-frontend-routes",

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": [
-    "src/test"
-  ]
-}


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-2908

### Change description

This PR removes TS to JS compilation and brings back ts-node for running services.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No