### PR TITLE
ROC-2908: Include type checking in linting step

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "setup": "gulp sass copy-files",
     "start": "TS_NODE_FAST=true ./node_modules/.bin/ts-node src/main/server.ts",
-    "lint": "tslint --project tsconfig.json && sass-lint -v -q",
+    "lint": "tsc --noEmit && tslint --project tsconfig.json && sass-lint -v -q",
     "test": "TS_NODE_FAST=true NODE_ENV=mocha LOG_LEVEL=OFF mocha --opts mocha.opts $(find src/test \\( -name '*.ts' \\) ! -path '*a11y*' ! -path '*/routes/*') --reporter-options reportFilename=unit,inlineAssets=true,reportTitle=citizen-frontend-unit",
     "test:routes": "TS_NODE_FAST=true NODE_ENV=mocha LOG_LEVEL=OFF mocha --opts mocha.opts $(find src/test \\( -name '*.ts' \\) -path '*/routes/*') --timeout 4000 --reporter-options reportFilename=routes,inlineAssets=true,reportTitle=citizen-frontend-routes",
     "test:a11y": "TS_NODE_FAST=true NODE_ENV=mocha LOG_LEVEL=ERROR mocha --exit --opts mocha.opts src/test/a11y/a11y.ts --timeout 60000 --reporter-options reportFilename=a11y,inlineAssets=true,reportTitle=citizen-frontend-a11y",

--- a/src/test/app/logging/requestTracingHandler.ts
+++ b/src/test/app/logging/requestTracingHandler.ts
@@ -45,7 +45,7 @@ describe('RequestTracingHandler', () => {
     Object.keys(requestPromise).forEach((httpMethod) => {
       requestPromise[httpMethod].reset()
     })
-    handler = new RequestTracingHandler(requestPromise, MockedRequestTracing)
+    handler = new RequestTracingHandler(requestPromise as any, MockedRequestTracing)
     proxy = new Proxy(requestPromise, handler)
   })
 


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-2908

### Change description

This PR brings back type checking. Type checking is done before listing starts. That brings the behaviour removed by us when `tslint` deprecated `--type-check` CLI flag.

Type checking when `yarn lint` is executed will give us type safety before committing code and on Jenkins. In remaining cases IDE will highlight compilation errors in opened files we actively work on.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No