### PR TITLE
ROC-1105: Use latest nodejs-logging 

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@hmcts/draft-store-client": "^1.1.1",
     "@hmcts/info-provider": "^1.0.0",
     "@hmcts/nodejs-healthcheck": "^1.4.5",
-    "@hmcts/nodejs-logging": "^2.0.0",
+    "@hmcts/nodejs-logging": "^2.2.0",
     "@types/config": "^0.0.33",
     "@types/cookies": "^0.7.1",
     "@types/csurf": "^1.9.33",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,9 +40,9 @@
     js-yaml "^3.8.4"
     superagent "^3.5.1"
 
-"@hmcts/nodejs-logging@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hmcts/nodejs-logging/-/nodejs-logging-2.0.0.tgz#3010b18780e5ddc42e0308f57b6e46f6ee098cf7"
+"@hmcts/nodejs-logging@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@hmcts/nodejs-logging/-/nodejs-logging-2.2.0.tgz#53370e39e7585c7a95073e913d6a128dd8b96bcf"
   dependencies:
     continuation-local-storage "^3.2.1"
     lodash.merge "^4.6.0"


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-1105

### Change description

Use latest version of nodejs-logging to add tracing headers on all logging calls.

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
