### PR TITLE
ROC-2772: fix issue with number of rows displayed on other court orders

### DIFF
--- a/src/main/app/forms/utils/multiRowFormUtils.ts
+++ b/src/main/app/forms/utils/multiRowFormUtils.ts
@@ -1,0 +1,8 @@
+import { MultiRowForm } from 'forms/models/multiRowForm'
+import { MultiRowFormItem } from 'forms/models/multiRowFormItem'
+
+export function makeSureThereIsAtLeastOneRow (model: MultiRowForm<MultiRowFormItem>): void {
+  if (model && model.getPopulatedRowsOnly().length === 0) {
+    model.appendRow()
+  }
+}

--- a/src/main/features/response/routes/statement-of-means/court-orders.ts
+++ b/src/main/features/response/routes/statement-of-means/court-orders.ts
@@ -12,10 +12,12 @@ import { CourtOrders } from 'response/form/models/statement-of-means/courtOrders
 import { Draft } from '@hmcts/draft-store-client'
 import { ResponseDraft } from 'response/draft/responseDraft'
 import { Claim } from 'claims/models/claim'
+import { makeSureThereIsAtLeastOneRow } from 'forms/utils/multiRowFormUtils'
 
 const page: RoutablePath = StatementOfMeansPaths.courtOrdersPage
 
 function renderView (form: Form<CourtOrders>, res: express.Response): void {
+  makeSureThereIsAtLeastOneRow(form.model)
   res.render(page.associatedView, { form: form })
 }
 

--- a/src/main/features/response/routes/statement-of-means/debts.ts
+++ b/src/main/features/response/routes/statement-of-means/debts.ts
@@ -12,17 +12,12 @@ import { Debts } from 'response/form/models/statement-of-means/debts'
 import { ResponseDraft } from 'response/draft/responseDraft'
 import { Claim } from 'claims/models/claim'
 import { Draft } from '@hmcts/draft-store-client'
+import { makeSureThereIsAtLeastOneRow } from 'forms/utils/multiRowFormUtils'
 
 const page: RoutablePath = StatementOfMeansPaths.debtsPage
 
-function makeSureThereIsAtLeastOneRow (form: Form<Debts>) {
-  if (form.model.getPopulatedRowsOnly().length === 0) {
-    form.model.appendRow()
-  }
-}
-
 function renderView (form: Form<Debts>, res: express.Response): void {
-  makeSureThereIsAtLeastOneRow(form)
+  makeSureThereIsAtLeastOneRow(form.model)
   res.render(page.associatedView, { form: form })
 }
 

--- a/src/main/features/response/views/statement-of-means/check-and-send.njk
+++ b/src/main/features/response/views/statement-of-means/check-and-send.njk
@@ -142,7 +142,7 @@
 {{ row('Food and Housekeeping', expenses.foodAndHousekeeping | numeral, '', false) }}
 {{ row('TV and Broadband', expenses.tvAndBroadband | numeral, '', false) }}
 {{ row('Mobile phone', expenses.mobilePhone | numeral, '', false) }}
-{{ row('Maintenance payments', expenses.maintenance | numeral, '', otherIncome.length === 0) }}
+{{ row('Maintenance payments', expenses.maintenance | numeral, '', otherExpenses.length === 0) }}
 
 {% set indexOfLastRow = otherExpenses.length - 1 %}
 {% for expenseRow in otherExpenses %}

--- a/src/test/app/forms/utils/multiRowFormUtils.ts
+++ b/src/test/app/forms/utils/multiRowFormUtils.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai'
+import { Debts } from 'response/form/models/statement-of-means/debts'
+import { DebtRow } from 'response/form/models/statement-of-means/debtRow'
+import { makeSureThereIsAtLeastOneRow } from 'forms/utils/multiRowFormUtils'
+import { Form } from 'forms/form'
+import { MultiRowForm } from 'forms/models/multiRowForm'
+import { MultiRowFormItem } from 'forms/models/multiRowFormItem'
+
+describe('makeSureThereIsAtLeastOneRow', () => {
+
+  describe('does nothing when', () => {
+
+    it('there is more than 0 rows', () => {
+      const model = new Debts(true, [new DebtRow('my card', 100, 10)])
+
+      expect(model.rows.length).to.be.eq(1)
+
+      makeSureThereIsAtLeastOneRow(model)
+
+      expect(model.rows.length).to.be.eq(1)
+    })
+
+    it('model is undefined', () => {
+      const form = Form.empty()
+
+      makeSureThereIsAtLeastOneRow(form.model as MultiRowForm<MultiRowFormItem>)
+    })
+  })
+
+  it('adds one row when there is an empty list', () => {
+    const model = new Debts(true, undefined)
+    model.removeExcessRows()
+
+    expect(model.rows.length).to.be.eq(0)
+
+    makeSureThereIsAtLeastOneRow(model)
+
+    expect(model.rows.length).to.be.eq(1)
+  })
+})


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-2772


### Change description
Fix number of rows displayed by default (other court orders)
Fix bottom border on check and send page


### Work checklist

- [x] Unit tests added where applicable
- [x] Route tests added for new pages
- [x] New pages included in a11y tests
- [x] Task list and task completeness checks updated
- [x] Check and send page updated
- [x] Routes, page content and page flows of new features are toggled 
- [x] UI changes look good on mobile
- [x] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
