### PR TITLE
ROC-3132 Fix custom event sender in IE

### DIFF
--- a/src/main/public/js/analytics-custom-event-sender.js
+++ b/src/main/public/js/analytics-custom-event-sender.js
@@ -30,13 +30,15 @@ $(function () {
       throw new Error('Label element is required')
     }
 
-    for (var content of labelElement.contents()) {
-      const text = $(content).text().trim()
-      if (text && content.class !== 'form-hint') {
-        return text
-      }
-    }
-    return undefined
+    return labelElement.contents()
+      .filter(function() {
+        if ($(this).hasClass('form-hint')) {
+          return false
+        }
+        return !!this.textContent.trim()
+      })
+      .text()
+      .trim()
   }
 
   function findLabel (form, inputName) {


### PR DESCRIPTION
Because of the `for...of` loop, IE didn't work.
Reworked the code so the loop isn't needed
It assumes the text will always be the first element, have tested on
eligibility
