### PR TITLE
ROC-3027: Use external id as identifier rather than database id

### DIFF
--- a/src/main/app/claims/ccjClient.ts
+++ b/src/main/app/claims/ccjClient.ts
@@ -8,10 +8,10 @@ import { DraftCCJ } from 'ccj/draft/draftCCJ'
 import { Draft } from '@hmcts/draft-store-client'
 
 export class CCJClient {
-  static save (claimId: number, draft: Draft<DraftCCJ>, user: User): Promise<Claim> {
+  static save (externalId: string, draft: Draft<DraftCCJ>, user: User): Promise<Claim> {
     const countyCourtJudgment: CountyCourtJudgment = CCJModelConverter.convert(draft.document)
 
-    return request.post(`${claimStoreApiUrl}/${claimId}/county-court-judgment`, {
+    return request.post(`${claimStoreApiUrl}/${externalId}/county-court-judgment`, {
       body: countyCourtJudgment,
       headers: {
         Authorization: `Bearer ${user.bearerToken}`

--- a/src/main/features/ccj/routes/check-and-send.ts
+++ b/src/main/features/ccj/routes/check-and-send.ts
@@ -93,7 +93,7 @@ export default express.Router()
           await new DraftService().save(draft, user.bearerToken)
         }
 
-        await CCJClient.save(claim.id, draft, user)
+        await CCJClient.save(claim.externalId, draft, user)
         await new DraftService().delete(draft.id, user.bearerToken)
         res.redirect(Paths.confirmationPage.evaluateUri({ externalId: req.params.externalId }))
       }

--- a/src/test/features/ccj/routes/check-and-send.ts
+++ b/src/test/features/ccj/routes/check-and-send.ts
@@ -112,7 +112,7 @@ describe('CCJ: check and send page', () => {
         it('should redirect to confirmation page when signature is basic', async () => {
           claimStoreServiceMock.resolveRetrieveClaimByExternalId()
           draftStoreServiceMock.resolveFind('ccj')
-          claimStoreServiceMock.resolveSaveCcjForUser()
+          claimStoreServiceMock.resolveSaveCcjForExternalId()
           draftStoreServiceMock.resolveDelete()
 
           await request(app)
@@ -125,7 +125,7 @@ describe('CCJ: check and send page', () => {
           claimStoreServiceMock.resolveRetrieveClaimByExternalId()
           draftStoreServiceMock.resolveFind('ccj')
           draftStoreServiceMock.resolveSave()
-          claimStoreServiceMock.resolveSaveCcjForUser()
+          claimStoreServiceMock.resolveSaveCcjForExternalId()
           draftStoreServiceMock.resolveDelete()
 
           await request(app)
@@ -138,7 +138,7 @@ describe('CCJ: check and send page', () => {
         it('should return 500 when cannot save CCJ', async () => {
           claimStoreServiceMock.resolveRetrieveClaimByExternalId()
           draftStoreServiceMock.resolveFind('ccj')
-          claimStoreServiceMock.rejectSaveCcjForUser()
+          claimStoreServiceMock.rejectSaveCcjForExternalId()
 
           await request(app)
             .post(pagePath)

--- a/src/test/http-mocks/claim-store.ts
+++ b/src/test/http-mocks/claim-store.ts
@@ -239,9 +239,10 @@ export function rejectSaveClaimForUser (reason: string = 'HTTP error') {
     .reply(HttpStatus.INTERNAL_SERVER_ERROR, reason)
 }
 
-export function resolveSaveCcjForUser () {
+export function resolveSaveCcjForExternalId () {
   mock(`${serviceBaseURL}/claims`)
-    .post(new RegExp('/[0-9]+/county-court-judgment'))
+    .post(new RegExp('/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}' +
+      '/county-court-judgment'))
     .reply(HttpStatus.OK, { ...sampleClaimObj })
 }
 
@@ -269,9 +270,10 @@ export function resolveRejectOffer (by: string = 'claimant') {
     .reply(HttpStatus.CREATED)
 }
 
-export function rejectSaveCcjForUser (reason: string = 'HTTP error') {
+export function rejectSaveCcjForExternalId (reason: string = 'HTTP error') {
   mock(`${serviceBaseURL}/claims`)
-    .post(new RegExp('/[0-9]+/county-court-judgment'))
+    .post(new RegExp('/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}' +
+      '/county-court-judgment'))
     .reply(HttpStatus.INTERNAL_SERVER_ERROR, reason)
 }
 


### PR DESCRIPTION
### JIRA link
[ROC-3017](https://tools.hmcts.net/jira/browse/ROC-3027)

### Change description
This PR accommodates the changes in `cmc-claim-store`, which uses the external id to save CCJ rather than claim database id.
Relevant pull request at `cmc-claim-store` repo is: https://github.com/hmcts/cmc-claim-store/pull/161 
