### PR TITLE
Fix hang on login failure

### DIFF
--- a/src/main/routes/receiver.ts
+++ b/src/main/routes/receiver.ts
@@ -150,12 +150,13 @@ export default express.Router()
           cookies.set(stateCookieName, req.query.state, { sameSite: 'lax' })
           return res.redirect(FirstContactPaths.claimSummaryPage.uri)
         } else {
-          Promise.all((user as User).getLetterHolderIdList().map(
+          Promise.all(user.getLetterHolderIdList().map(
             (letterHolderId) => linkDefendantWithClaimByLetterHolderId(letterHolderId, user)
             )
           )
             .then(async () => res.redirect(await retrieveRedirectForLandingPage(res.locals.user)))
             .catch(async () => res.redirect(await retrieveRedirectForLandingPage(res.locals.user)))
+            .catch(next)
         }
       } else {
         res.redirect(OAuthHelper.forLogin(req, res))


### PR DESCRIPTION
Unlikely to happen to a real user but the claim store was giving errors
for me on login and the page hung.
This was because the `then` and `catch` blocks were both making calls to
the claim store, I've added another catch block which just uses our
error handler