### PR TITLE
ROC-3135: Provide startsWith polyfill and return 400 error on validation failure

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,6 +45,10 @@ gulp.task('copy-files', () => {
     .pipe(rename('classlist-polyfill.js'))
     .pipe(gulp.dest(`${assetsDirectory}/js/lib/`))
 
+  gulp.src('./node_modules/string.prototype.startswith/startswith.js')
+    .pipe(rename('startswith-polyfill.js'))
+    .pipe(gulp.dest(`${assetsDirectory}/js/lib/`))
+
   gulp.src([
     './node_modules/HTML_CodeSniffer/HTMLCS.js'
   ])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,13 +30,33 @@ gulp.task('sass', () => {
 })
 
 gulp.task('copy-files', () => {
+  copyGovUkTemplate()
+  copyClientPolyfills()
+  copyA11ySniffer()
+})
+
+function copyGovUkTemplate () {
   gulp.src([
     './node_modules/jquery/dist/jquery.min.js',
     './node_modules/govuk_frontend_toolkit/javascripts/**/*.js',
     './node_modules/govuk_template_jinja/assets/javascripts/**/*.js'
   ])
-  .pipe(gulp.dest(`${assetsDirectory}/js/lib/`))
+    .pipe(gulp.dest(`${assetsDirectory}/js/lib/`))
 
+  gulp.src([
+    './node_modules/govuk_frontend_toolkit/images/**/*',
+    './node_modules/govuk_template_jinja/assets/images/*.*'
+  ])
+    .pipe(gulp.dest(`${assetsDirectory}/img/lib/`))
+
+  gulp.src([
+    './node_modules/govuk_template_jinja/assets/stylesheets/**/*'
+  ])
+    .pipe(replace('images/', '/stylesheets/lib/images/', { skipBinary: true }))
+    .pipe(gulp.dest(`${assetsDirectory}/stylesheets/lib/`))
+}
+
+function copyClientPolyfills () {
   gulp.src('./node_modules/nodelist-foreach-polyfill/index.js')
     .pipe(rename('nodelist-foreach-polyfill.js'))
     .pipe(gulp.dest(`${assetsDirectory}/js/lib/`))
@@ -48,39 +68,29 @@ gulp.task('copy-files', () => {
   gulp.src('./node_modules/string.prototype.startswith/startswith.js')
     .pipe(rename('startswith-polyfill.js'))
     .pipe(gulp.dest(`${assetsDirectory}/js/lib/`))
+}
 
+function copyA11ySniffer () {
   gulp.src([
     './node_modules/HTML_CodeSniffer/HTMLCS.js'
   ])
-  .pipe(gulp.dest(`${assetsDirectory}/js/lib/htmlcs`))
+    .pipe(gulp.dest(`${assetsDirectory}/js/lib/htmlcs`))
 
   gulp.src([
     './node_modules/HTML_CodeSniffer/Standards/**'
   ])
-  .pipe(gulp.dest(`${assetsDirectory}/js/lib/htmlcs/Standards`))
+    .pipe(gulp.dest(`${assetsDirectory}/js/lib/htmlcs/Standards`))
 
   gulp.src([
     './node_modules/HTML_CodeSniffer/Auditor/HTMLCSAuditor.js'
   ])
-  .pipe(gulp.dest(`${assetsDirectory}/js/lib/htmlcs/Auditor`))
+    .pipe(gulp.dest(`${assetsDirectory}/js/lib/htmlcs/Auditor`))
 
   gulp.src([
     './node_modules/HTML_CodeSniffer/Auditor/**/*.{css,gif,png}'
   ])
-  .pipe(gulp.dest(`${assetsDirectory}/stylesheets/lib/`))
-
-  gulp.src([
-    './node_modules/govuk_frontend_toolkit/images/**/*',
-    './node_modules/govuk_template_jinja/assets/images/*.*'
-  ])
-  .pipe(gulp.dest(`${assetsDirectory}/img/lib/`))
-
-  gulp.src([
-    './node_modules/govuk_template_jinja/assets/stylesheets/**/*'
-  ])
-  .pipe(replace('images/', '/stylesheets/lib/images/', { skipBinary: true }))
-  .pipe(gulp.dest(`${assetsDirectory}/stylesheets/lib/`))
-})
+    .pipe(gulp.dest(`${assetsDirectory}/stylesheets/lib/`))
+}
 
 gulp.task('watch', () => {
   gulp.watch(stylesheetsDirectory + '/**/*.scss', [ 'sass' ])

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "request-promise-native": "^1.0.3",
     "require-directory": "^2.1.1",
     "serve-favicon": "^2.3.0",
+    "string.prototype.startswith": "^0.2.0",
     "to-boolean": "^1.0.0",
     "ts-node": "^3.3.0",
     "tsconfig-paths": "^3.1.1",

--- a/src/main/routes/postcode-lookup.ts
+++ b/src/main/routes/postcode-lookup.ts
@@ -12,6 +12,14 @@ const logger = Logger.getLogger('postcode-lookup')
 /* tslint:disable:no-default-export */
 export default express.Router()
   .get(AppPaths.postcodeLookupProxy.uri, (req, res) => {
+    if (!req.query.postcode || !req.query.postcode.trim()) {
+      return res.status(400).json({
+        error: {
+          status: 400,
+          message: 'Postcode not provided'
+        }
+      })
+    }
     postcodeClient.lookupPostcode(req.query.postcode)
       .then((postcodeInfoResponse: PostcodeInfoResponse) => res.json(postcodeInfoResponse))
       .catch(err => {

--- a/src/main/views/postcode-lookup-client-scripts.njk
+++ b/src/main/views/postcode-lookup-client-scripts.njk
@@ -1,3 +1,4 @@
 <script src="{{ asset_paths['js_vendor'] }}/nodelist-foreach-polyfill.js"></script>
 <script src="{{ asset_paths['js_vendor'] }}/classlist-polyfill.js"></script>
+<script src="{{ asset_paths['js_vendor'] }}/startswith-polyfill.js"></script>
 <script src="{{ asset_paths['js'] }}/postcode-lookup.js"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6011,6 +6011,10 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string.prototype.startswith@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz#da68982e353a4e9ac4a43b450a2045d1c445ae7b"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-3135

### Change description

- provided a polyfill for missing `startsWith` `String` function on IE
- changed the postcode lookup endpoint to return 400 status when client does not send a postcode

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
