### PR TITLE
Fix date tests

### DIFF
--- a/src/test/features/response/draft/payBySetDate.ts
+++ b/src/test/features/response/draft/payBySetDate.ts
@@ -68,8 +68,8 @@ describe('PayBySetDate', () => {
       expect(payBySetDate.requiresExplanation()).to.be.false
     })
 
-    it('should require explanation if payment date month away', () => {
-      payBySetDate.paymentDate.date = localDateFrom(MomentFactory.currentDate().add(1, 'month'))
+    it('should require explanation if payment date more than 28 days away', () => {
+      payBySetDate.paymentDate.date = localDateFrom(MomentFactory.currentDate().add(29, 'days'))
       expect(payBySetDate.requiresExplanation()).to.be.true
     })
   })

--- a/src/test/features/response/tasks/whenWillYouPayTask.ts
+++ b/src/test/features/response/tasks/whenWillYouPayTask.ts
@@ -76,7 +76,7 @@ function validResponseDraftWith (paymentType: DefendantPaymentType): ResponseDra
 }
 
 function dateMoreThan28DaysFromNow () {
-  return localDateFrom(MomentFactory.currentDate().add(1, 'months'))
+  return localDateFrom(MomentFactory.currentDate().add(29, 'days'))
 }
 
 describe('WhenWillYouPayTask', () => {


### PR DESCRIPTION
February has 28 days, 1 month is currently equalling 28 days whereas the
check is for greater than 28 days, so do 29 days -.-