### PR TITLE
Use heading for task-list rather than bold span

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepush": "yarn test && yarn test:routes"
   },
   "dependencies": {
-    "@hmcts/cmc-common-frontend": "^1.37.0",
+    "@hmcts/cmc-common-frontend": "^1.38.0",
     "@hmcts/cmc-draft-store-middleware": "^2.0.0",
     "@hmcts/draft-store-client": "^1.1.1",
     "@hmcts/info-provider": "^1.0.0",

--- a/src/main/public/stylesheets/components/_task-list.scss
+++ b/src/main/public/stylesheets/components/_task-list.scss
@@ -29,9 +29,9 @@
 }
 
 .task-list-heading {
-  @extend .heading-medium;
-  margin-top: 0;
+  @extend .heading-medium; // sass-lint:disable-line placeholder-in-extend heading-medium is simple, so its ok to extend
   margin-bottom: 0;
+  margin-top: 0;
 }
 
 .task-name {

--- a/src/main/public/stylesheets/components/_task-list.scss
+++ b/src/main/public/stylesheets/components/_task-list.scss
@@ -28,6 +28,12 @@
   }
 }
 
+.task-list-heading {
+  @extend .heading-medium;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
 .task-name {
   @include media (mobile) {
     margin-left: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@hmcts/cmc-common-frontend@^1.37.0":
-  version "1.37.0"
-  resolved "https://registry.yarnpkg.com/@hmcts/cmc-common-frontend/-/cmc-common-frontend-1.37.0.tgz#298f87355c5a3614fa399dbb6aef032b3baaf145"
+"@hmcts/cmc-common-frontend@^1.38.0":
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/@hmcts/cmc-common-frontend/-/cmc-common-frontend-1.38.0.tgz#69716b573c3eacbeed83fa112be3aded71aa8dfe"
 
 "@hmcts/cmc-draft-store-middleware@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
Screen readers aren't reading out the sections when headers are being
read out which means the context isn't is good as it could be.