### PR TITLE
Ignore hook error from nsp check

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -2,6 +2,7 @@
   "exceptions": [
     "https://nodesecurity.io/advisories/532",
     "https://nodesecurity.io/advisories/533",
-    "https://nodesecurity.io/advisories/534"
+    "https://nodesecurity.io/advisories/534",
+    "https://nodesecurity.io/advisories/566"
   ]
 }


### PR DESCRIPTION
Build is failing on CNP environment on NSP check stage.To suppress error  Ignore hoek from nsp check.
### Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No
