### PR TITLE
ROC-3113: Fix expandable section so that it handles content with break lines

### DIFF
--- a/src/main/features/response/views/macro/expandableSection.njk
+++ b/src/main/features/response/views/macro/expandableSection.njk
@@ -1,11 +1,13 @@
 {% macro expandableSection(label, content, limit = 400, id) %}
+  {% set longContent = content.length > limit %}
+
   <div class="show-more-block">
     <div class="bold-small">{{ t(label) }}</div>
-    {% if content.length > limit %}
+    {% if longContent %}
       <input id="{{ id }}" type="checkbox">
     {% endif %}
-    <p class="form-group-compound">{{ content }}</p>
-    {% if content.length > limit %}
+    <p class="content {% if longContent %}expandable{% endif %}">{{ content }}</p>
+    {% if longContent %}
       <label class="link more" for="{{ id }}">{{ t('Show more') }}</label>
       <label class="link less" for="{{ id }}">{{ t('Show less') }}</label>
     {% endif %}

--- a/src/main/public/stylesheets/components/_expandable-content.scss
+++ b/src/main/public/stylesheets/components/_expandable-content.scss
@@ -2,11 +2,15 @@
   background-color: $expandable-background;
   padding: 20px 20px 10px;
 
-  p {
-    height: 125px;
-    overflow: hidden;
+  .content {
+    margin-bottom: 10px;
     white-space: pre-line;
     word-wrap: break-word;
+
+    &.expandable {
+      height: 125px;
+      overflow: hidden;
+    }
   }
 
   .more {
@@ -20,7 +24,7 @@
   input {
     display: none;
 
-    &:checked + p {
+    &:checked + .expandable {
       height: auto;
     }
 


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-3113

### Change description

Problem was reported when text had break lines. In that case rendered text had greater height then fixed 125px set for content container.

The solution is to make content container adjust to the content hight if limit of characters (default 400) is not exceeded. In opposite scenario where limit is exceeded fixed height is applied and more / less links are rendered.

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No