### PR TITLE
Fix: Use correct interest dates range in interest breakdown

### DIFF
--- a/src/main/features/first-contact/routes/claim-summary.ts
+++ b/src/main/features/first-contact/routes/claim-summary.ts
@@ -8,7 +8,6 @@ import { JwtExtractor } from 'idam/jwtExtractor'
 import { ClaimantRequestedCCJGuard } from 'first-contact/guards/claimantRequestedCCJGuard'
 import { OAuthHelper } from 'idam/oAuthHelper'
 import { getInterestDetails } from 'common/interestUtils'
-import { MomentFactory } from '../../../common/momentFactory'
 
 const sessionCookie = config.get<string>('session.cookieName')
 
@@ -25,8 +24,7 @@ export default express.Router()
       const claim: Claim = res.locals.claim
       const interestData = await getInterestDetails(claim)
       res.render(Paths.claimSummaryPage.associatedView, {
-        interestData: interestData,
-        toDate: MomentFactory.currentDate()
+        interestData: interestData
       })
     })
   .post(Paths.claimSummaryPage.uri, (req: express.Request, res: express.Response): void => {

--- a/src/main/features/first-contact/views/claim-summary.njk
+++ b/src/main/features/first-contact/views/claim-summary.njk
@@ -15,7 +15,7 @@
       <p><span class="bold-small">{{ t('Claim number:') }}</span> {{ referenceNumber }}</p>
       <p><span class="bold-small">{{ t('Claim amount:') }}</span> {{ claim.totalAmountTillToday | numeral }}</p>
 
-      {{ amountBreakdownTable('View amount breakdown', claim, interestData, toDate) }}
+      {{ amountBreakdownTable('View amount breakdown', claim, interestData) }}
 
       <p class="bold form-group-related">{{ t('Reason for claim:') }}</p>
       <p>{{ claim.claimData.reason }}</p>

--- a/src/main/features/response/routes/claim-details.ts
+++ b/src/main/features/response/routes/claim-details.ts
@@ -2,7 +2,6 @@ import * as express from 'express'
 import { Paths } from 'response/paths'
 import { Claim } from 'claims/models/claim'
 import { getInterestDetails } from 'common/interestUtils'
-import { MomentFactory } from 'common/momentFactory'
 
 /* tslint:disable:no-default-export */
 export default express.Router()
@@ -11,8 +10,7 @@ export default express.Router()
       const claim: Claim = res.locals.claim
       const interestData = await getInterestDetails(claim)
       res.render(Paths.claimDetailsPage.associatedView, {
-        interestData: interestData,
-        today: MomentFactory.currentDate()
+        interestData: interestData
       })
     } catch (err) {
       next(err)

--- a/src/main/features/response/views/claim-details.njk
+++ b/src/main/features/response/views/claim-details.njk
@@ -14,7 +14,7 @@
       <p><span class="bold-small">{{ t('Claim reference') }}:</span> {{ claim.claimNumber }}</p>
       <p><span class="bold-small">{{ t('Claim amount') }}:</span> {{ claim.totalAmountTillToday | numeral }}</p>
 
-      {{ amountBreakdownTable('View amount breakdown', claim, interestData, today) }}
+      {{ amountBreakdownTable('View amount breakdown', claim, interestData) }}
       <p><span class="bold-small">{{ t('Reason for claim') }}:</span></p>
       <p>{{ claim.claimData.reason }}</p>
 

--- a/src/main/views/macro/amountBreakdown.njk
+++ b/src/main/views/macro/amountBreakdown.njk
@@ -1,6 +1,6 @@
 {% from "interestSnippet.njk" import interestSnippet %}
 
-{% macro amountBreakdownTable(label, claim, interestData, toDate) %}
+{% macro amountBreakdownTable(label, claim, interestData) %}
   <details>
     <summary>{{ t(label) }}</summary>
       <div class="panel panel-border-narrow">
@@ -24,7 +24,7 @@
           {% if claim.claimData.interest.rate %}
             <tr>
               <td scope="row">
-                {{ interestSnippet(interestData.rate, interestData.numberOfDays, interestData.interestFromDate, toDate) }}
+                {{ interestSnippet(interestData.rate, interestData.numberOfDays, interestData.interestFromDate, interestData.interestToDate) }}
               </td>
               <td class="numeric last">
                 {{ interestData.interest | numeral }}


### PR DESCRIPTION
### JIRA link

None

### Change description

This PR uses dates range from `InterestData` when amount break down is displayed. This is to correctly handle the scenario when issue date is next day due to the fact claim was issued after 4pm.

Screenshot:

<img width="635" alt="screen shot 2018-02-28 at 23 16 04" src="https://user-images.githubusercontent.com/1724691/36818848-ddd08bf4-1cde-11e8-8bee-b189e7cc86a2.png">


### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No