### PR TITLE
ROC-3224 Remove express access logger

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import * as favicon from 'serve-favicon'
 import * as cookieParser from 'cookie-parser'
 import * as bodyParser from 'body-parser'
-import { RequestTracing, Express, Logger } from '@hmcts/nodejs-logging'
+import { RequestTracing, Logger } from '@hmcts/nodejs-logging'
 import { ForbiddenError, NotFoundError } from './errors'
 import { ErrorLogger } from 'logging/errorLogger'
 import { RouterFinder } from 'common/router/routerFinder'
@@ -51,10 +51,6 @@ app.use(bodyParser.urlencoded({
   extended: true
 }))
 app.use(cookieParser())
-
-if (!developmentMode) {
-  app.use(Express.accessLogger())
-}
 
 app.use(express.static(path.join(__dirname, 'public')))
 


### PR DESCRIPTION
Application insights provides the same and doubling up makes insights
really hard to use