### PR TITLE
Always redirect to SSL

### DIFF
--- a/src/main/app/utils/callbackBuilder.ts
+++ b/src/main/app/utils/callbackBuilder.ts
@@ -8,7 +8,7 @@ export function buildURL (req: express.Request, path: string): string {
   if (req === undefined) {
     throw new Error('Request is undefined')
   }
-  const protocol = (req.secure) ? 'https://' : 'http://'
+  const protocol = 'https://'
   const host = req.headers.host
 
   const baseURL: string = `${protocol}${host}`

--- a/src/test/app/utils/callbackBuilder.ts
+++ b/src/test/app/utils/callbackBuilder.ts
@@ -18,7 +18,7 @@ describe('CallbackBuilder', () => {
 
     it('for non SSL request ', () => {
       const path = 'my/service/path'
-      const expected = `http://localhost/${path}`
+      const expected = `https://localhost/${path}`
       req.secure = false
       req.headers = { host: 'localhost' }
 

--- a/src/test/features/first-contact/routes/claim-reference.ts
+++ b/src/test/features/first-contact/routes/claim-reference.ts
@@ -29,7 +29,7 @@ describe('Defendant first contact: claim reference page', () => {
     })
 
     it('should redirect to pin validation page when form is valid and everything is fine', async () => {
-      const redirectPattern = new RegExp(`${config.get('idam.authentication-web.url')}/login/pin\\?.+redirect_uri=http://127.0.0.1:[0-9]{1,5}/receiver`)
+      const redirectPattern = new RegExp(`${config.get('idam.authentication-web.url')}/login/pin\\?.+redirect_uri=https://127.0.0.1:[0-9]{1,5}/receiver`)
       claimStoreServiceMock.resolveIsClaimLinked(false)
 
       await request(app)

--- a/src/test/features/first-contact/routes/claim-summary.ts
+++ b/src/test/features/first-contact/routes/claim-summary.ts
@@ -60,7 +60,7 @@ describe('Defendant first contact: claim summary page', () => {
     checkAuthorizationGuards(app, 'post', Paths.claimSummaryPage.uri)
 
     it('should redirect to registration page when everything is fine', async () => {
-      const registrationPagePattern = new RegExp(`${config.get('idam.authentication-web.url')}/login/uplift\\?response_type=code&state=1&client_id=cmc_citizen&redirect_uri=http://127.0.0.1:[0-9]{5}/receiver&jwt=ABC`)
+      const registrationPagePattern = new RegExp(`${config.get('idam.authentication-web.url')}/login/uplift\\?response_type=code&state=1&client_id=cmc_citizen&redirect_uri=https://127.0.0.1:[0-9]{5}/receiver&jwt=ABC`)
 
       idamServiceMock.resolveRetrieveUserFor('1', 'citizen', 'letter-holder')
 

--- a/src/test/routes/authorization-check.ts
+++ b/src/test/routes/authorization-check.ts
@@ -8,7 +8,7 @@ import './expectations'
 import * as idamServiceMock from '../http-mocks/idam'
 
 const cookieName: string = config.get<string>('session.cookieName')
-export const defaultAccessDeniedPagePattern = new RegExp(`${config.get('idam.authentication-web.url')}/login\\?response_type=code&state=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}&client_id=cmc_citizen&redirect_uri=http://127.0.0.1:[0-9]{1,5}/receiver`)
+export const defaultAccessDeniedPagePattern = new RegExp(`${config.get('idam.authentication-web.url')}/login\\?response_type=code&state=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}&client_id=cmc_citizen&redirect_uri=https://127.0.0.1:[0-9]{1,5}/receiver`)
 
 export function checkAuthorizationGuards (app: any,
                                           method: string,


### PR DESCRIPTION
The setting that was used in CNP to force redirect http to https appears
to get overridden by deployments, we will look to get this fixed
properly but this change should stop users from not being able to
complete their journeys