### PR TITLE
Update to new idam version

### DIFF
--- a/src/integration-test/tests/citizen/defence/pages/defendant-register.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-register.ts
@@ -3,7 +3,7 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const links = {
-  iAlreadyHaveAnAccount: 'Already have an account? Click here to login instead.'
+  iAlreadyHaveAnAccount: 'Sign in to your account.'
 }
 
 export class DefendantRegisterPage {


### PR DESCRIPTION
They changed the text on the register page which broke the pin and post login in our integration tests:
container update: https://github.com/hmcts/cmc-integration-tests/pull/167

I ran the test against AAT after updating the test and:
```
  OK  | 1 passed   // 51s
```