### PR TITLE
ROC-3215 Update eligibility cookie ttl to 2 days

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -60,7 +60,7 @@
   },
   "eligibility": {
     "cookie": {
-      "timeToLiveInMinutes": 10
+      "timeToLiveInMinutes": 2880
     }
   },
   "support": {

--- a/src/main/views/cookies.njk
+++ b/src/main/views/cookies.njk
@@ -149,7 +149,7 @@
           <td>
             {{ t('Stores answers to eligibility questions') }}
           </td>
-          <td class="text-area">{{ t('Ten minutes') }}</td>
+          <td class="text-area">{{ t('48 hours') }}</td>
         </tr>
         </tbody>
       </table>


### PR DESCRIPTION
2 days is the length of time idam activation emails are valid for, Martin requested this config value to be updated