### PR TITLE
Bug Fix: Allow Yes and Organisation option for defendantAge, to create a valid claim

### DIFF
--- a/src/main/features/eligibility/model/eligibility.ts
+++ b/src/main/features/eligibility/model/eligibility.ts
@@ -120,7 +120,7 @@ export class Eligibility {
       this.claimantAddress === YesNoOption.YES &&
       this.defendantAddress === YesNoOption.YES &&
       this.eighteenOrOver === YesNoOption.YES &&
-      (this.defendantAge === (DefendantAgeOption.YES) || this.defendantAge === (DefendantAgeOption.COMPANY_OR_ORGANISATION)) &&
+      (this.defendantAge === DefendantAgeOption.YES || this.defendantAge === DefendantAgeOption.COMPANY_OR_ORGANISATION) &&
       this.claimType === ClaimType.PERSONAL_CLAIM &&
       this.singleDefendant === YesNoOption.NO &&
       this.governmentDepartment === YesNoOption.NO &&

--- a/src/main/features/eligibility/model/eligibility.ts
+++ b/src/main/features/eligibility/model/eligibility.ts
@@ -120,7 +120,7 @@ export class Eligibility {
       this.claimantAddress === YesNoOption.YES &&
       this.defendantAddress === YesNoOption.YES &&
       this.eighteenOrOver === YesNoOption.YES &&
-      this.defendantAge === (DefendantAgeOption.YES || DefendantAgeOption.COMPANY_OR_ORGANISATION) &&
+      (this.defendantAge === (DefendantAgeOption.YES) || this.defendantAge === (DefendantAgeOption.COMPANY_OR_ORGANISATION)) &&
       this.claimType === ClaimType.PERSONAL_CLAIM &&
       this.singleDefendant === YesNoOption.NO &&
       this.governmentDepartment === YesNoOption.NO &&

--- a/src/test/features/eligibility/model/eligibility.ts
+++ b/src/test/features/eligibility/model/eligibility.ts
@@ -53,4 +53,45 @@ describe('Eligibility', () => {
     })
   })
 
+  describe('eligible', () => {
+
+    it('should be valid if all eligibility answers are eligible', () => {
+
+      const eligibility = new Eligibility(
+        ClaimValue.UNDER_10000,
+        YesNoOption.NO,
+        YesNoOption.YES,
+        YesNoOption.YES,
+        YesNoOption.YES,
+        DefendantAgeOption.COMPANY_OR_ORGANISATION,
+        ClaimType.PERSONAL_CLAIM,
+        YesNoOption.NO,
+        YesNoOption.NO,
+        YesNoOption.NO
+      )
+
+      expect(eligibility.eligible).to.equal(true)
+
+    })
+
+    it('should be invalid if any eligibility answer is not eligible', () => {
+
+      const eligibility = new Eligibility(
+        ClaimValue.UNDER_10000,
+        YesNoOption.NO,
+        YesNoOption.YES,
+        YesNoOption.YES,
+        YesNoOption.YES,
+        DefendantAgeOption.NO,
+        ClaimType.PERSONAL_CLAIM,
+        YesNoOption.NO,
+        YesNoOption.NO,
+        YesNoOption.NO
+      )
+
+      expect(eligibility.eligible).to.equal(false)
+
+    })
+  })
+
 })


### PR DESCRIPTION
### Change description
Improved logic for defendantAge question to allow Organisation to be selected and classified as eligible to prevent a looping back to the start of eligibility questions, on submission.
