### PR TITLE
ROC-3482: For no daily interest selected, details of daily interest should not be listed

### DIFF
--- a/src/main/features/ccj/views/paid-amount-summary.njk
+++ b/src/main/features/ccj/views/paid-amount-summary.njk
@@ -32,7 +32,7 @@
         {% if interestDetails %}
         <tr>
           <th scope="row">
-            {{ interestSnippet(label = 'Interest to date', interestDetails.rate, interestDetails.numberOfDays,
+            {{ interestSnippet(label = 'Interest', interestDetails.rate, interestDetails.numberOfDays,
               interestDetails.interestFromDate, defaultJudgmentDate, interestDetails.specificDailyAmount) }}
           </th>
           <td class="numeric last">

--- a/src/main/views/macro/amountBreakdown.njk
+++ b/src/main/views/macro/amountBreakdown.njk
@@ -24,7 +24,7 @@
           {% if claim.claimData.interest.type !== InterestType.NO_INTEREST %}
             <tr>
               <td scope="row">
-                {{ interestSnippet(label = 'Interest to date', interestData.rate, interestData.numberOfDays,
+                {{ interestSnippet(label = 'Interest', interestData.rate, interestData.numberOfDays,
                   interestData.interestFromDate, interestData.interestToDate, interestData.specificDailyAmount) }}
               </td>
               <td class="numeric last">

--- a/src/main/views/macro/interestSnippet.njk
+++ b/src/main/views/macro/interestSnippet.njk
@@ -1,23 +1,29 @@
 {% macro interestSnippet(label = 'Interest', rate, numberOfDays, interestDate, interestToDate, specificDailyAmount) %}
-  <details role="group">
+  {% if rate or specificDailyAmount > 0 %}
+    <details role="group">
     <summary role="button" aria-controls="details-content-0" aria-expanded="false">
       {{ t(label) }}
     </summary>
-    <div class="panel text-small" id="details-content-0" aria-hidden>
-      <div>
-        {% if rate %}
-        {{ t('Interest calculated at %s%% for %s days', {
-          postProcess: 'sprintf', sprintf: [ rate, numberOfDays ] })
-        }}
-        {% else %}
+    {% if rate %}
+      <div class="panel text-small" id="details-content-0" aria-hidden>
+        <div>
+          {{ t('Interest calculated at %s%% for %s days', {
+            postProcess: 'sprintf', sprintf: [ rate, numberOfDays ] }) }}
+          ({{ t('%s to %s', { postProcess: 'sprintf', sprintf: [ interestDate | date, interestToDate | date ]}) }})
+        </div>
+      </div>
+    {% elseif specificDailyAmount > 0 %}
+      <div class="panel text-small" id="details-content-0" aria-hidden>
+        <div>
           {{ t('Interest calculated with daily interest amount of %s for %s days', {
-            postProcess: 'sprintf', sprintf: [ specificDailyAmount | numeral, numberOfDays ] })
-          }}
-        {% endif %}
+            postProcess: 'sprintf', sprintf: [ specificDailyAmount | numeral, numberOfDays ] }) }}
+          ({{ t('%s to %s', { postProcess: 'sprintf', sprintf: [ interestDate | date, interestToDate | date ]}) }})
+        </div>
       </div>
-      <div class="font-xsmall">
-        ({{ t('%s to %s', { postProcess: 'sprintf', sprintf: [ interestDate | date, interestToDate | date ]}) }})
-      </div>
-    </div>
+    {% endif %}
+  {% else %}
+    {{ t(label) }}
+  {% endif %}
   </details>
+
 {% endmacro %}

--- a/src/main/views/macro/interestSnippet.njk
+++ b/src/main/views/macro/interestSnippet.njk
@@ -7,17 +7,17 @@
     {% if rate %}
       <div class="panel text-small" id="details-content-0" aria-hidden>
         <div>
-          {{ t('Interest calculated at %s%% for %s days', {
-            postProcess: 'sprintf', sprintf: [ rate, numberOfDays ] }) }}
-          ({{ t('%s to %s', { postProcess: 'sprintf', sprintf: [ interestDate | date, interestToDate | date ]}) }})
+          {{ t('Interest calculated at {{ rate }}% for {{ numberOfDays }} days', { rate: rate, numberOfDays: numberOfDays}) }}
+          {{ t('({{ interestDate }} to {{ interestToDate }})', { interestDate: interestDate | date, interestToDate: interestToDate | date }) }}
+          )
         </div>
       </div>
     {% elseif specificDailyAmount > 0 %}
       <div class="panel text-small" id="details-content-0" aria-hidden>
         <div>
-          {{ t('Interest calculated with daily interest amount of %s for %s days', {
-            postProcess: 'sprintf', sprintf: [ specificDailyAmount | numeral, numberOfDays ] }) }}
-          ({{ t('%s to %s', { postProcess: 'sprintf', sprintf: [ interestDate | date, interestToDate | date ]}) }})
+          {{ t('Interest calculated with daily interest amount of {{ specificDailyAmount }} for {{ numberOfDays}} days', {
+            specificDailyAmount: specificDailyAmount | numeral, numberOfDays: numberOfDays }) }}
+          {{ t('({{ interestDate }} to {{ interestToDate }})', { interestDate: interestDate | date, interestToDate: interestToDate | date }) }}
         </div>
       </div>
     {% endif %}

--- a/src/main/views/macro/interestSnippet.njk
+++ b/src/main/views/macro/interestSnippet.njk
@@ -1,29 +1,20 @@
 {% macro interestSnippet(label = 'Interest', rate, numberOfDays, interestDate, interestToDate, specificDailyAmount) %}
   {% if rate or specificDailyAmount > 0 %}
     <details role="group">
-    <summary role="button" aria-controls="details-content-0" aria-expanded="false">
-      {{ t(label) }}
-    </summary>
-    {% if rate %}
+      <summary role="button" aria-controls="details-content-0" aria-expanded="false">
+        {{ t(label) }}
+      </summary>
       <div class="panel text-small" id="details-content-0" aria-hidden>
-        <div>
+        {% if rate %}
           {{ t('Interest calculated at {{ rate }}% for {{ numberOfDays }} days', { rate: rate, numberOfDays: numberOfDays}) }}
-          {{ t('({{ interestDate }} to {{ interestToDate }})', { interestDate: interestDate | date, interestToDate: interestToDate | date }) }}
-          )
-        </div>
-      </div>
-    {% elseif specificDailyAmount > 0 %}
-      <div class="panel text-small" id="details-content-0" aria-hidden>
-        <div>
+        {% elseif specificDailyAmount > 0 %}
           {{ t('Interest calculated with daily interest amount of {{ specificDailyAmount }} for {{ numberOfDays}} days', {
             specificDailyAmount: specificDailyAmount | numeral, numberOfDays: numberOfDays }) }}
-          {{ t('({{ interestDate }} to {{ interestToDate }})', { interestDate: interestDate | date, interestToDate: interestToDate | date }) }}
-        </div>
+        {% endif %}
+        {{ t('({{ interestDate }} to {{ interestToDate }})', { interestDate: interestDate | date, interestToDate: interestToDate | date }) }}
       </div>
-    {% endif %}
+    </details>
   {% else %}
     {{ t(label) }}
   {% endif %}
-  </details>
-
 {% endmacro %}


### PR DESCRIPTION
### JIRA link
[ROC-3482](https://tools.hmcts.net/jira/browse/ROC-3482)

### Change description
When claimant has selected no daily interest, we are still displaying the daily interest details with £0 for N days etc. This should not be displayed in this case. Also updated the label from `Interest to date` to `Interest` as advised.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
