### PR TITLE
ROC-3501: Upgrade requestretry version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@hmcts/nodejs-healthcheck": "^1.4.5",
     "@hmcts/nodejs-logging": "^2.2.0",
     "@hmcts/postcodeinfo-client": "^1.1.0",
-    "@hmcts/requestretry": "^1.1.0",
+    "@hmcts/requestretry": "^1.1.2",
     "@types/config": "^0.0.34",
     "@types/cookies": "^0.7.1",
     "@types/csurf": "^1.9.33",

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,9 +62,9 @@
     request "^2.83.0"
     request-promise-native "^1.0.5"
 
-"@hmcts/requestretry@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@hmcts/requestretry/-/requestretry-1.1.0.tgz#5d9a1734571e435ed025ee21ec432beee5f0c41e"
+"@hmcts/requestretry@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@hmcts/requestretry/-/requestretry-1.1.2.tgz#e0bca727abce98702a48b17a83984febd8ae3198"
   dependencies:
     extend "^3.0.0"
     lodash "^4.15.0"


### PR DESCRIPTION
### JIRA link
[ROC-3501](https://tools.hmcts.net/jira/browse/ROC-3501)

### Change description
This PR upgrades `requestretry` version to `1.1.2`, which fixes the issue raised in [ROC-3501](https://tools.hmcts.net/jira/browse/ROC-3501)

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
