### PR TITLE
ROC-3435: Make claim converter test compare JSON objects instead of JSON literals

### DIFF
--- a/src/test/app/claims/claimModelConverter.ts
+++ b/src/test/app/claims/claimModelConverter.ts
@@ -34,6 +34,10 @@ function prepareClaimData (claimantParty: object, defendantParty: object): Claim
   })
 }
 
+function convertObjectLiteralToJSON (value: object): object {
+  return JSON.parse(JSON.stringify(value))
+}
+
 describe('ClaimModelConverter', () => {
   [
     [[individualDetails, individual], [soleTraderDetails, soleTrader]],
@@ -47,7 +51,8 @@ describe('ClaimModelConverter', () => {
       const claimDraft = prepareClaimDraft(claimantPartyDetails, defendantPartyDetails)
       const claimData = prepareClaimData(claimantParty, defendantParty)
 
-      expect(ClaimModelConverter.convert(claimDraft)).to.deep.equal(claimData)
+      expect(convertObjectLiteralToJSON(ClaimModelConverter.convert(claimDraft)))
+        .to.deep.equal(convertObjectLiteralToJSON(claimData))
     })
   })
 })


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-3435

### Change description

This PR changes claim converter test to assert JSON in the format that is being sent to the API instead of comparing JSON literals with Moment instances that are terrible to call `equals` against.

### Work checklist

- [x] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [x] Yes
- [ ] No