### PR TITLE
Fix 3 tests failures on CNP Jenkins

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "setup": "gulp sass copy-files",
     "start": "node server.js",
     "lint": "tsc --noEmit && tslint --project tsconfig.json && sass-lint -v -q",
-    "test": "TS_NODE_FAST=true NODE_ENV=mocha LOG_LEVEL=OFF mocha --opts mocha.opts $(find src/test \\( -name '*.ts' \\) ! -path '*a11y*' ! -path '*/routes/*') --reporter-options reportFilename=unit,inlineAssets=true,reportTitle=citizen-frontend-unit",
+    "test": "TS_NODE_FAST=true NODE_ENV=mocha LOG_LEVEL=DEBUG mocha --opts mocha.opts $(find src/test \\( -name '*.ts' \\) ! -path '*a11y*' ! -path '*/routes/*') --reporter-options reportFilename=unit,inlineAssets=true,reportTitle=citizen-frontend-unit",
     "test:routes": "TS_NODE_FAST=true NODE_ENV=mocha LOG_LEVEL=OFF mocha --opts mocha.opts $(find src/test \\( -name '*.ts' \\) -path '*/routes/*') --timeout 4000 --reporter-options reportFilename=routes,inlineAssets=true,reportTitle=citizen-frontend-routes",
     "test:a11y": "TS_NODE_FAST=true NODE_ENV=mocha LOG_LEVEL=ERROR mocha --exit --opts mocha.opts src/test/a11y/a11y.ts --timeout 60000 --reporter-options reportFilename=a11y,inlineAssets=true,reportTitle=citizen-frontend-a11y",
     "test:functional": "./bin/run-functional-tests.sh",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "setup": "gulp sass copy-files",
     "start": "node server.js",
     "lint": "tsc --noEmit && tslint --project tsconfig.json && sass-lint -v -q",
-    "test": "TS_NODE_FAST=true NODE_ENV=mocha LOG_LEVEL=DEBUG mocha --opts mocha.opts $(find src/test \\( -name '*.ts' \\) ! -path '*a11y*' ! -path '*/routes/*') --reporter-options reportFilename=unit,inlineAssets=true,reportTitle=citizen-frontend-unit",
+    "test": "TS_NODE_FAST=true NODE_ENV=mocha LOG_LEVEL=OFF mocha --opts mocha.opts $(find src/test \\( -name '*.ts' \\) ! -path '*a11y*' ! -path '*/routes/*') --reporter-options reportFilename=unit,inlineAssets=true,reportTitle=citizen-frontend-unit",
     "test:routes": "TS_NODE_FAST=true NODE_ENV=mocha LOG_LEVEL=OFF mocha --opts mocha.opts $(find src/test \\( -name '*.ts' \\) -path '*/routes/*') --timeout 4000 --reporter-options reportFilename=routes,inlineAssets=true,reportTitle=citizen-frontend-routes",
     "test:a11y": "TS_NODE_FAST=true NODE_ENV=mocha LOG_LEVEL=ERROR mocha --exit --opts mocha.opts src/test/a11y/a11y.ts --timeout 60000 --reporter-options reportFilename=a11y,inlineAssets=true,reportTitle=citizen-frontend-a11y",
     "test:functional": "./bin/run-functional-tests.sh",

--- a/src/test/app/common/calculateInterest.ts
+++ b/src/test/app/common/calculateInterest.ts
@@ -1,31 +1,28 @@
 import { expect } from 'chai'
-import * as moment from 'moment'
+import { MomentFactory } from 'common/momentFactory'
 
 import { calculateInterest } from 'app/common/calculateInterest'
-import { InterestRateOption } from 'claim/form/models/interestRateOption'
 import { mockCalculateInterestRate } from '../../http-mocks/claim-store'
 
 describe('calculateInterest', () => {
 
-  describe('should call api for any data gets what API returns', async () => {
+  beforeEach(() => {
+    mockCalculateInterestRate(0.08)
+  })
 
-    beforeEach(() => {
-      mockCalculateInterestRate(0)
-    })
+  it(`should return 0 without calling an API when interest period is 0 days`, async () => {
+    const interestFromDate = MomentFactory.currentDateTime()
+    const interestToDate = MomentFactory.currentDateTime()
+    const amount = await calculateInterest(100, 8, interestFromDate, interestToDate)
 
-    // when rate is 0, InterestRateOption = STANDARD gets 0:
-    // when rate is 1, InterestRateOption = STANDARD gets 0:
-    Object.keys(InterestRateOption).forEach(async (type) => {
-      [0, 1, 1000].forEach(async (rate) => {
-        it(`when rate is ${rate}, InterestRateOption = ${type} gets 0`, async () => {
+    expect(amount).to.equal(0)
+  })
 
-          const interestFromDate = moment().subtract(5, 'years')
+  it(`should return interest value calculated by API when interest period is greater then 0 days`, async () => {
+    const interestFromDate = MomentFactory.currentDateTime().subtract(1, 'year')
+    const interestToDate = MomentFactory.currentDateTime()
+    const amount = await calculateInterest(100, 8, interestFromDate, interestToDate)
 
-          const expected: number = await calculateInterest(0, rate, interestFromDate)
-
-          expect(expected).to.equal(0)
-        })
-      })
-    })
+    expect(amount).to.equal(0.08)
   })
 })

--- a/src/test/app/common/calculateInterest.ts
+++ b/src/test/app/common/calculateInterest.ts
@@ -4,11 +4,10 @@ import { MomentFactory } from 'common/momentFactory'
 import { calculateInterest } from 'app/common/calculateInterest'
 import { mockCalculateInterestRate } from '../../http-mocks/claim-store'
 
-describe('calculateInterest', () => {
+import { attachDefaultHooks } from '../../../test/hooks'
 
-  beforeEach(() => {
-    mockCalculateInterestRate(0.08)
-  })
+describe('calculateInterest', () => {
+  attachDefaultHooks()
 
   it(`should return 0 without calling an API when interest period is 0 days`, async () => {
     const interestFromDate = MomentFactory.currentDateTime()
@@ -19,6 +18,8 @@ describe('calculateInterest', () => {
   })
 
   it(`should return interest value calculated by API when interest period is greater then 0 days`, async () => {
+    mockCalculateInterestRate(0.08)
+
     const interestFromDate = MomentFactory.currentDateTime().subtract(1, 'year')
     const interestToDate = MomentFactory.currentDateTime()
     const amount = await calculateInterest(100, 8, interestFromDate, interestToDate)

--- a/src/test/app/common/calculateInterest.ts
+++ b/src/test/app/common/calculateInterest.ts
@@ -13,6 +13,8 @@ describe('calculateInterest', () => {
       mockCalculateInterestRate(0)
     })
 
+    // when rate is 0, InterestRateOption = STANDARD gets 0:
+    // when rate is 1, InterestRateOption = STANDARD gets 0:
     Object.keys(InterestRateOption).forEach(async (type) => {
       [0, 1, 1000].forEach(async (rate) => {
         it(`when rate is ${rate}, InterestRateOption = ${type} gets 0`, async () => {

--- a/src/test/common/interestUtils.ts
+++ b/src/test/common/interestUtils.ts
@@ -3,7 +3,6 @@ import { expect } from 'chai'
 import { Claim } from 'claims/models/claim'
 import { getInterestDetails } from 'common/interestUtils'
 import { MomentFactory } from 'common/momentFactory'
-import * as claimStoreServiceMock from '../http-mocks/claim-store'
 import { InterestEndDateOption } from 'claim/form/models/interestEndDate'
 import { Interest } from 'claims/models/interest'
 import { InterestDate } from 'claims/models/interestDate'
@@ -43,8 +42,6 @@ describe('getInterestDetails', () => {
   })
 
   it('should return 0 for number of days when interest date starts from today', async () => {
-    claimStoreServiceMock.mockCalculateInterestRate(5)
-
     const today = MomentFactory.currentDate()
     const claim: Claim = new Claim().deserialize({ ...sampleClaimObj, issuedOn: today })
 
@@ -53,8 +50,6 @@ describe('getInterestDetails', () => {
   })
 
   it('should return 1 for number of days when interest date starts from yesterday', async () => {
-    claimStoreServiceMock.mockCalculateInterestRate(5)
-
     const yesterday = MomentFactory.currentDate().subtract(1, 'days')
     const claim: Claim = new Claim().deserialize({ ...sampleClaimObj, issuedOn: yesterday })
 
@@ -63,8 +58,6 @@ describe('getInterestDetails', () => {
   })
 
   it('should return 0 for number of days when interest date starts from tomorrow (issue date in the future)', async () => {
-    claimStoreServiceMock.mockCalculateInterestRate(5)
-
     const tomorrow = MomentFactory.currentDate().add(1, 'days')
     const claim: Claim = new Claim().deserialize({ ...sampleClaimObj, issuedOn: tomorrow })
 

--- a/src/test/features/claim/guards/claimEligibilityGuard.ts
+++ b/src/test/features/claim/guards/claimEligibilityGuard.ts
@@ -19,9 +19,13 @@ import { DraftClaim } from 'drafts/models/draftClaim'
 import * as idamServiceMock from '../../../http-mocks/idam'
 import * as draftStoreServiceMock from '../../../http-mocks/draft-store'
 
+import { attachDefaultHooks } from '../../../../test/hooks'
+
 chai.use(spies)
 
 describe('Claim eligibility guard', () => {
+  attachDefaultHooks()
+
   let claimDraft: Draft<DraftClaim>
 
   const next = (e?: any): void => {

--- a/src/test/features/response/routes/how-much-owed.ts
+++ b/src/test/features/response/routes/how-much-owed.ts
@@ -21,7 +21,7 @@ const cookieName: string = config.get<string>('session.cookieName')
 const pagePath = ResponsePaths.defendantHowMuchOwed.evaluateUri({ externalId: claimStoreServiceMock.sampleClaimObj.externalId })
 
 describe('Defendant response: how much money do you believe you owe', () => {
-  attachDefaultHooks()
+  attachDefaultHooks(app)
 
   describe('on GET', () => {
     const method = 'get'

--- a/src/test/features/response/routes/how-much-paid.ts
+++ b/src/test/features/response/routes/how-much-paid.ts
@@ -20,7 +20,7 @@ const cookieName: string = config.get<string>('session.cookieName')
 
 const pagePath = ResponsePaths.defendantHowMuchPaid.evaluateUri({ externalId: claimStoreServiceMock.sampleClaimObj.externalId })
 describe('Defendant response: how much have you paid', () => {
-  attachDefaultHooks()
+  attachDefaultHooks(app)
 
   describe('on GET', () => {
     const method = 'get'

--- a/src/test/features/response/routes/when-did-you-pay.ts
+++ b/src/test/features/response/routes/when-did-you-pay.ts
@@ -20,7 +20,7 @@ const cookieName: string = config.get<string>('session.cookieName')
 
 const pagePath = ResponsePaths.whenDidYouPay.evaluateUri({ externalId: claimStoreServiceMock.sampleClaimObj.externalId })
 describe('Defendant response: when did you pay', () => {
-  attachDefaultHooks()
+  attachDefaultHooks(app)
 
   describe('on GET', () => {
     const method = 'get'

--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai'
+import * as mock from 'nock'
+
+import * as idamServiceMock from './http-mocks/idam'
+
+export function attachDefaultHooks () {
+  let retrieveServiceTokenMock: any
+
+  beforeEach(() => {
+    mock.cleanAll()
+
+    retrieveServiceTokenMock = idamServiceMock.resolveRetrieveServiceToken()
+  })
+
+  afterEach(() => {
+    const pendingMocks = (mock.pendingMocks() as any).filter(item => item !== retrieveServiceTokenMock.interceptors[0]._key)
+    expect(pendingMocks, 'At least one mock were declared but not used').to.be.deep.equal([])
+  })
+}

--- a/src/test/http-mocks/claim-store.ts
+++ b/src/test/http-mocks/claim-store.ts
@@ -107,8 +107,9 @@ export const sampleDefendantResponseObj = {
 }
 
 export function mockCalculateInterestRate (expected: number): mock.Scope {
-  return mock(`${serviceBaseURL}/interest/calculate`)
-    .get(new RegExp('.+'))
+  return mock(serviceBaseURL)
+    .get('/interest/calculate')
+    .query(true)
     .reply(HttpStatus.OK, { amount: expected })
 }
 

--- a/src/test/routes/hooks.ts
+++ b/src/test/routes/hooks.ts
@@ -1,26 +1,11 @@
-import { expect } from 'chai'
 import * as express from 'express'
-import * as mock from 'nock'
 
-import * as idamServiceMock from '../http-mocks/idam'
+import { attachDefaultHooks as attachBaseDefaultHooks } from '../hooks'
 
-export function attachDefaultHooks (app?: express.Express) {
-  let retrieveServiceTokenMock: any
+export function attachDefaultHooks (app: express.Express) {
+  attachBaseDefaultHooks()
 
   before(() => {
-    if (app) {
-      app.locals.csrf = 'dummy-token'
-    }
-  })
-
-  beforeEach(() => {
-    mock.cleanAll()
-
-    retrieveServiceTokenMock = idamServiceMock.resolveRetrieveServiceToken()
-  })
-
-  afterEach(() => {
-    const pendingMocks = (mock.pendingMocks() as any).filter(item => item !== retrieveServiceTokenMock.interceptors[0]._key)
-    expect(pendingMocks, 'At least one mock were declared but not used').to.be.deep.equal([])
+    app.locals.csrf = 'dummy-token'
   })
 }


### PR DESCRIPTION
### JIRA link

None

### Change description

There were two causes:

- some unit tests that utilised nock mocks did not verify / clear unused mocks which meant that these mocks remained and were used in other tests. That caused tests from file A impact tests from file B.
- calculate interest nock mock was set in invalid way so in conjunction with previous issue it caused that 'get claim by external ID' used to received response from 'calculate interest' mock

Solution:

- I verified, removed unused mocks and added hooks to detect it in the future
- I fixed mock for calculate interest endpoint
- I rewritten calculate interest tests to make these useful / readable

### Work checklist

- [x] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No