### PR TITLE
Try fix broken cnp deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "i18next-sprintf-postprocessor": "^0.2.2",
     "jquery": "3.3.1",
     "js-base64": "^2.3.2",
+    "lodash": "^4.17.5",
     "mime": "^2.0.3",
     "moment": "^2.18.1",
     "nodelist-foreach-polyfill": "^1.2.0",


### PR DESCRIPTION
```

D:\home\site\wwwroot\node_modules\applicationinsights\out\AutoCollection\CorrelationContextManager.js:193
            orig.apply(this, arguments);
                 ^
Error: Cannot find module 'lodash'
    at new AppInsightsAsyncCorrelatedErrorWrapper (D:\home\site\wwwroot\node_modules\applicationinsights\out\AutoCollection\CorrelationContextManager.js:193:18)
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._resolveFilename (D:\home\site\wwwroot\node_modules\tsconfig-paths\lib\register.js:31:40)
    at Function.Module._load (module.js:474:25)
    at Module.require (module.js:596:17)
    at Module.patchedRequire [as require] (D:\home\site\wwwroot\node_modules\diagnostic-channel\dist\src\patchRequire.js:14:46)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (D:\home\site\wwwroot\src\main\features\eligibility\store.ts:4:1)
    at Module._compile (module.js:652:30)
    at Module.m._compile (D:\home\site\wwwroot\node_modules\ts-node\src\index.ts:392:23)
    at Module._extensions..js (module.js:663:10)
    at Object.require.extensions.(anonymous function)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at Module.patchedRequire [as require] (D:\home\site\wwwroot\node_modules\diagnostic-channel\dist\src\patchRequire.js:14:46)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (D:\home\site\wwwroot\src\main\features\claim\guards\claimEligibilityGuard.ts:9:1)
    at Module._compile (module.js:652:30)

```