### PR TITLE
Content changes based on Civil Procedure rules feedback

### DIFF
--- a/src/main/features/claim/views/interest-rate.njk
+++ b/src/main/features/claim/views/interest-rate.njk
@@ -60,7 +60,7 @@
           </summary>
 
           <div class="panel panel-border-narrow">
-            <p>{{ t('You can claim 8% interest on money owed to you. If you know that a different rate applies you can use that. For example if you have a contract with a specific rate.') }}</p>
+            <p>{{ t('You can claim 8% interest on money owed to you. This is the statutory rate. If you know that a different rate applies you can use that. For example if you have a contract with a specific rate.') }}</p>
             <p>{{ t('The court will decide if you’re entitled to some or all of the interest claimed.') }}</p>
           </div>
         </details>

--- a/src/main/features/claim/views/interest.njk
+++ b/src/main/features/claim/views/interest.njk
@@ -15,7 +15,7 @@
           {{ t(' Help with interest rates') }}
         </summary>
         <div class="panel panel-border-narrow">
-          <p>{{ t('You can claim 8% interest on money owed to you. If you know that a different rate applies you can use that. For example if you have a contract with a specific rate.') }}</p>
+          <p>{{ t('You can claim 8% interest on money owed to you. This is the statutory rate. If you know that a different rate applies you can use that. For example if you have a contract with a specific rate.') }}</p>
           <p>{{ t('The court will decide if you’re entitled to some or all of the interest claimed.') }}</p>
         </div>
       </details>

--- a/src/main/features/eligibility/views/claimant-address.njk
+++ b/src/main/features/eligibility/views/claimant-address.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 {% from "form.njk" import csrfProtection, radioGroup, errorSummary, saveAndContinueButton %}
 
-{% set heading = 'Do you have an address in the UK?' %}
+{% set heading = 'Do you have a postal address in the UK?' %}
 {% set additionalInformation = t('The UK is made up of England, Scotland, Wales and Northern Ireland.') %}
 
 {% block content %}

--- a/src/main/features/eligibility/views/defendant-address.njk
+++ b/src/main/features/eligibility/views/defendant-address.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 {% from "form.njk" import csrfProtection, errorSummary, radioGroup, saveAndContinueButton %}
 
-{% set heading = 'Does the person or organisation you’re claiming against have an address in England or Wales?' %}
+{% set heading = 'Does the person or organisation you’re claiming against have a postal address in England or Wales?' %}
 
 {% block content %}
 

--- a/src/test/features/eligibility/routes/claimant-address.ts
+++ b/src/test/features/eligibility/routes/claimant-address.ts
@@ -13,7 +13,7 @@ import { YesNoOption } from 'models/yesNoOption'
 
 const pagePath: string = Paths.claimantAddressPage.uri
 const pageRedirect: string = Paths.defendantAddressPage.uri
-const expectedTextOnPage: string = 'Do you have an address in the UK?'
+const expectedTextOnPage: string = 'Do you have a postal address in the UK?'
 const notEligibleReason: string = NotEligibleReason.CLAIMANT_ADDRESS
 
 describe('Claim eligibility: claimant address page', () => {

--- a/src/test/features/eligibility/routes/defendant-address.ts
+++ b/src/test/features/eligibility/routes/defendant-address.ts
@@ -14,7 +14,7 @@ import { YesNoOption } from 'models/yesNoOption'
 
 const pagePath: string = Paths.defendantAddressPage.uri
 const pageRedirect: string = Paths.over18Page.uri
-const expectedTextOnPage: string = 'Does the person or organisation you’re claiming against have an address in England or Wales?'
+const expectedTextOnPage: string = 'Does the person or organisation you’re claiming against have a postal address in England or Wales?'
 const notEligibleReason: string = NotEligibleReason.DEFENDANT_ADDRESS
 
 describe('Claim eligibility: defendant address page', () => {


### PR DESCRIPTION
1. I've changed the two eligibility questions which mention an address so they say "postal address" instead - this is apparently important.
2. I've added "this is the statutory rate" to the help text when we talk about 8% interest - on two different pages. This is apparently important and insisted on despite the lack of a user need.

### JIRA link



### Change description



### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
