### PR TITLE
Bug fix ROC-3739 incorrect eligibility page heading

### DIFF
--- a/src/main/features/eligibility/views/index.njk
+++ b/src/main/features/eligibility/views/index.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 {% from "externalLink.njk" import externalLink %}
 
-{% set heading = 'Find out if you can use this service' %}
+{% set heading = 'Try the new online service' %}
 
 {% block content %}
   <div class="grid-row">
@@ -13,7 +13,6 @@
 
         <a href="{{ EligibilityPaths.claimValuePage.uri }}" class="button">{{ t('Continue') }}</a>
       {% else %}
-        <h1 class="heading-large">{{ t('Try the new online service') }}</h1>
 
         <p>{{ t('We’re building a new service which is currently in beta. This means we’re testing different designs '
           + 'and making changes based on feedback from users.') }}</p>

--- a/src/test/features/eligibility/routes/index.ts
+++ b/src/test/features/eligibility/routes/index.ts
@@ -28,7 +28,7 @@ describe('Claim eligibility: index page', () => {
         await request(app)
           .get(pagePath)
           .set('Cookie', `${cookieName}=ABC;`)
-          .expect(res => expect(res).to.be.successful.withText('Find out if you can use this service'))
+          .expect(res => expect(res).to.be.successful.withText('Try the new online service'))
       })
     })
 


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-3739

### Change description

Remove the incorrect heading 'Find out if you can use this service'

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No