### PR TITLE
Application Insights: obfuscate UUID's in url's which are not static files

### DIFF
--- a/src/main/modules/app-insights/index.ts
+++ b/src/main/modules/app-insights/index.ts
@@ -6,11 +6,11 @@ declare class AppInsightsConfiguration {
   roleName: string
 }
 
-function hideUuidInUrlIfNotStaticFile (url: string): string {
-  let fileRegexp = new RegExp('(\\..{2,5}$)')
-  let uuidRegexp = new RegExp('[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}')
+const fileRegexp = new RegExp('(\\..{2,5}$)')
+const uuidRegexp = new RegExp('[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}')
 
-  if (url.match(fileRegexp) == null) {
+function hideUuidInUrlIfNotStaticFile (url: string): string {
+  if (!fileRegexp.test(url)) {
     return url.replace(uuidRegexp, '{uuid}')
   } else {
     return url

--- a/src/main/modules/app-insights/index.ts
+++ b/src/main/modules/app-insights/index.ts
@@ -13,6 +13,32 @@ export class AppInsights {
     appInsights.setup(appInsightsConfig.instrumentationKey)
       .setAutoCollectConsole(true, true)
     appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] = appInsightsConfig.roleName
+
+    let fileRegexp = new RegExp('(\\..{2,5}$)')
+    let removeUuidRegexp = new RegExp('[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}', 'g')
+
+    appInsights.defaultClient.addTelemetryProcessor(function (envelope, contextObjects) {
+      if (contextObjects) {
+        if (contextObjects.correlationContext) {
+          // if there's operation, rename request having claim UUID to {uuid} mask to aggregate them correctly
+          if (contextObjects.correlationContext.operation) {
+            let operationName = contextObjects.correlationContext.operation.name
+
+            // if operation's name is not static file
+            if (operationName.match(fileRegexp) == null) {
+              let newOperationName = operationName.replace(removeUuidRegexp, '{uuid}')
+              // console.log(contextObjects.correlationContext.operation.name)
+              // console.log(newOperationName)
+
+              contextObjects.correlationContext.operation.name = newOperationName
+            }
+          }
+        }
+      }
+      // always send
+      return true
+    })
+
     appInsights.start()
   }
 }


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-3462


### Change description
Obfuscating UUID's in urls to {uuid} before being sent to App Insights


### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
