### PR TITLE
Add GA event for response type details

### DIFF
--- a/src/main/features/response/views/response-type.njk
+++ b/src/main/features/response/views/response-type.njk
@@ -7,7 +7,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
 
-      <details class="form-group">
+      <details class="form-group analytics-click-event-trigger" data-event-label="Response: Find out what each response means">
         <summary>{{ t('Find out what each response means') }}</summary>
 
         <div class="panel">


### PR DESCRIPTION
### Change description
Fire an event to Google Analytics when a user clicks on the details section on the response-type page. This will let us track if users are looking at the information before choosing an option.


### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
