### PR TITLE
Bug Fix: Added the import for External Link into the claimRejected.njk

### DIFF
--- a/src/main/features/dashboard/views/macro/claimStatus/claimRejected.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/claimRejected.njk
@@ -1,3 +1,5 @@
+{% from "externalLink.njk" import externalLink %}
+
 {% macro claimRejectedAlreadyPaidForClaimantDashboard(claim) %}
   {{ t('{{ defendantName }} believes that they’ve paid the claim in full.',
     { defendantName: claim.claimData.defendant.name }) }}


### PR DESCRIPTION
### Change description

this bug fix addresses the issue where an externalLink macro was added to the claimRejected.njk file without including the necessary import.

- [ ] Yes
- [x] No
