### PR TITLE
ROC-3940 Use key vault no more hashi vault

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -6,9 +6,9 @@ String product = "cmc"
 String component = "citizen-frontend"
 
 List<LinkedHashMap<String, Object>> secrets = [
-  secret('AatTestUserUsername', 'SMOKE_TEST_CITIZEN_USERNAME'),
-  secret('AatTestUserPassword', 'SMOKE_TEST_USER_PASSWORD'),
-  secret('OAUTH2-CLIENT-SECRET', 'OAUTH2_CLIENT_SECRET')
+  secret('smoke-test-citizen-username', 'SMOKE_TEST_CITIZEN_USERNAME'),
+  secret('smoke-test-user-password', 'SMOKE_TEST_USER_PASSWORD'),
+  secret('citizen-oauth-client-secret', 'OAUTH2_CLIENT_SECRET')
 ]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -10,8 +10,9 @@ properties([
 ])
 
 List<LinkedHashMap<String, Object>> secrets = [
-  secret('AatTestUserUsername', 'SMOKE_TEST_CITIZEN_USERNAME'),
-  secret('AatTestUserPassword', 'SMOKE_TEST_USER_PASSWORD')
+  secret('smoke-test-citizen-username', 'SMOKE_TEST_CITIZEN_USERNAME'),
+  secret('smoke-test-user-password', 'SMOKE_TEST_USER_PASSWORD'),
+  secret('citizen-oauth-client-secret', 'OAUTH2_CLIENT_SECRET')
 ]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -8,43 +8,54 @@ provider "vault" {
   address = "https://vault.reform.hmcts.net:6200"
 }
 
-data "vault_generic_secret" "s2s_secret" {
-  path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/cmc"
-}
-
-data "vault_generic_secret" "draft_store_secret" {
-  path = "secret/${var.vault_section}/cmc/draft-store/encryption-secrets/citizen-frontend"
-}
-
-data "vault_generic_secret" "postcode-lookup-api-key" {
-  path = "secret/${var.vault_section}/cmc/postcode-lookup/api-key"
-}
-
-data "vault_generic_secret" "oauth-client-secret" {
-  path = "secret/${var.vault_section}/ccidam/idam-api/oauth2/client-secrets/cmc-citizen"
-}
-
-data "vault_generic_secret" "staff_email" {
-  path = "secret/${var.vault_section}/cmc/claim-store/staff_email"
-}
-
 locals {
   aseName = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
 
   local_env = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "aat" : "saat" : var.env}"
   local_ase = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "core-compute-aat" : "core-compute-saat" : local.aseName}"
 
-  previewVaultName = "${var.product}-citizen-fe"
-  nonPreviewVaultName = "${var.product}-citizen-fe-${var.env}"
+  previewVaultName = "${var.raw_product}-aat"
+  nonPreviewVaultName = "${var.raw_product}-${var.env}"
   vaultName = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultName : local.nonPreviewVaultName}"
-
-  nonPreviewVaultUri = "${module.citizen-frontend-vault.key_vault_uri}"
-  previewVaultUri = "https://cmc-citizen-fe-aat.vault.azure.net/"
-  vaultUri = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultUri : local.nonPreviewVaultUri}"
 
   s2sUrl = "http://rpe-service-auth-provider-${local.local_env}.service.${local.local_ase}.internal"
   claimStoreUrl = "http://cmc-claim-store-${local.local_env}.service.${local.local_ase}.internal"
   draftStoreUrl = "http://draft-store-service-${local.local_env}.service.${local.local_ase}.internal"
+}
+
+data "azurerm_key_vault" "cmc_key_vault" {
+  name = "${local.vaultName}"
+  resource_group_name = "${local.vaultName}"
+}
+
+data "azurerm_key_vault_secret" "s2s_secret" {
+  name = "cmc-s2s-secret"
+  vault_uri = "${data.azurerm_key_vault.cmc_key_vault.vault_uri}"
+}
+
+data "azurerm_key_vault_secret" "draft_store_primary" {
+  name = "draft-store-primary"
+  vault_uri = "${data.azurerm_key_vault.cmc_key_vault.vault_uri}"
+}
+
+data "azurerm_key_vault_secret" "draft_store_secondary" {
+  name = "draft-store-secondary"
+  vault_uri = "${data.azurerm_key_vault.cmc_key_vault.vault_uri}"
+}
+
+data "azurerm_key_vault_secret" "postcode_lookup_api_key" {
+  name = "postcode-lookup-api-key"
+  vault_uri = "${data.azurerm_key_vault.cmc_key_vault.vault_uri}"
+}
+
+data "azurerm_key_vault_secret" "oauth_client_secret" {
+  name = "citizen-oauth-client-secret"
+  vault_uri = "${data.azurerm_key_vault.cmc_key_vault.vault_uri}"
+}
+
+data "azurerm_key_vault_secret" "staff_email" {
+  name = "staff-email"
+  vault_uri = "${data.azurerm_key_vault.cmc_key_vault.vault_uri}"
 }
 
 module "citizen-frontend" {
@@ -74,14 +85,14 @@ module "citizen-frontend" {
 
     // Application vars
     GA_TRACKING_ID = "${var.ga_tracking_id}"
-    POSTCODE_LOOKUP_API_KEY = "${data.vault_generic_secret.postcode-lookup-api-key.data["value"]}"
+    POSTCODE_LOOKUP_API_KEY = "${data.azurerm_key_vault_secret.postcode_lookup_api_key.value}"
 
     // IDAM
     IDAM_API_URL = "${var.idam_api_url}"
     IDAM_AUTHENTICATION_WEB_URL = "${var.authentication_web_url}"
     IDAM_S2S_AUTH = "${local.s2sUrl}"
-    IDAM_S2S_TOTP_SECRET = "${data.vault_generic_secret.s2s_secret.data["value"]}"
-    OAUTH_CLIENT_SECRET = "${data.vault_generic_secret.oauth-client-secret.data["value"]}"
+    IDAM_S2S_TOTP_SECRET = "${data.azurerm_key_vault_secret.s2s_secret.value}"
+    OAUTH_CLIENT_SECRET = "${data.azurerm_key_vault_secret.oauth_client_secret.value}"
 
     // Payments API
     PAY_URL = "${var.payments_api_url}"
@@ -91,8 +102,8 @@ module "citizen-frontend" {
 
     // Draft Store API
     DRAFT_STORE_URL = "${local.draftStoreUrl}"
-    DRAFT_STORE_SECRET_PRIMARY = "${data.vault_generic_secret.draft_store_secret.data["primary"]}"
-    DRAFT_STORE_SECRET_SECONDARY = "${data.vault_generic_secret.draft_store_secret.data["secondary"]}"
+    DRAFT_STORE_SECRET_PRIMARY = "${data.azurerm_key_vault_secret.draft_store_primary.value}"
+    DRAFT_STORE_SECRET_SECONDARY = "${data.azurerm_key_vault_secret.draft_store_secondary.value}"
 
     // Our service dependencies
     CLAIM_STORE_URL = "${local.claimStoreUrl}"
@@ -113,7 +124,7 @@ module "citizen-frontend" {
     FEATURE_FINE_PRINT = "${var.feature_fine_print}"
     FEATURE_RETURN_ERROR_TO_USER = "${var.feature_return_error_to_user}"
 
-    CONTACT_EMAIL = "${data.vault_generic_secret.staff_email.data["value"]}"
+    CONTACT_EMAIL = "${data.azurerm_key_vault_secret.staff_email.value}"
 
   }
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -129,13 +129,3 @@ module "citizen-frontend" {
   }
 }
 
-module "citizen-frontend-vault" {
-  source = "git@github.com:hmcts/moj-module-key-vault?ref=master"
-  name = "${local.vaultName}"
-  product = "${var.product}"
-  env = "${var.env}"
-  tenant_id = "${var.tenant_id}"
-  object_id = "${var.jenkins_AAD_objectId}"
-  resource_group_name = "${module.citizen-frontend.resource_group_name}"
-  product_group_object_id = "68839600-92da-4862-bb24-1259814d1384"
-}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -34,12 +34,12 @@ data "azurerm_key_vault_secret" "s2s_secret" {
 }
 
 data "azurerm_key_vault_secret" "draft_store_primary" {
-  name = "draft-store-primary"
+  name = "citizen-draft-store-primary"
   vault_uri = "${data.azurerm_key_vault.cmc_key_vault.vault_uri}"
 }
 
 data "azurerm_key_vault_secret" "draft_store_secondary" {
-  name = "draft-store-secondary"
+  name = "citizen-draft-store-secondary"
   vault_uri = "${data.azurerm_key_vault.cmc_key_vault.vault_uri}"
 }
 

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,5 +1,5 @@
 output "vaultUri" {
-  value = "${local.vaultUri}"
+  value = "${data.azurerm_key_vault.cmc_key_vault.vault_uri}"
 }
 
 output "vaultName" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,6 +1,8 @@
 // Infrastructural variables
-variable "product" {
-  default = "cmc"
+variable "product" {}
+
+variable "raw_product" {
+  default = "cmc" // jenkins-library overrides product for PRs and adds e.g. pr-118-cmc
 }
 
 variable "microservice" {


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-3940


### Change description
Use azure key vault for secrets instead of hashi vault

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
