### PR TITLE
ROC-3658: Fix full admission payment option hints and line resending on check and send page

### DIFF
--- a/src/main/features/response/routes/full-admission/payment-option.ts
+++ b/src/main/features/response/routes/full-admission/payment-option.ts
@@ -12,7 +12,15 @@ import { FeatureToggleGuard } from 'main/app/guards/featureToggleGuard'
 import { ResponseDraft } from 'response/draft/responseDraft'
 import { Draft } from '@hmcts/draft-store-client'
 import { Claim } from 'main/app/claims/models/claim'
-import { StatementOfMeansFeature } from 'response/helpers/statementOfMeansFeature'
+import { FeatureToggles } from 'utils/featureToggles'
+
+function isApplicableFor (draft: ResponseDraft): boolean {
+  if (!FeatureToggles.isEnabled('statementOfMeans')) {
+    return false
+  }
+  return draft.isResponseFullyAdmitted()
+    && !draft.defendantDetails.partyDetails.isBusiness()
+}
 
 function renderView (form: Form<DefendantPaymentOption>, res: express.Response) {
   const draft: Draft<ResponseDraft> = res.locals.responseDraft
@@ -21,7 +29,7 @@ function renderView (form: Form<DefendantPaymentOption>, res: express.Response) 
     form: form,
     claim: claim,
     draft: draft.document,
-    statementOfMeansIsApplicable: StatementOfMeansFeature.isApplicableFor(draft.document)
+    statementOfMeansIsApplicable: isApplicableFor(draft.document)
   })
 }
 

--- a/src/main/features/response/views/statement-of-means/check-and-send.njk
+++ b/src/main/features/response/views/statement-of-means/check-and-send.njk
@@ -110,13 +110,11 @@
 {% if draft.statementOfMeans.employment.selfEmployed %}
   {{ row('What are you self-employed as?', '', StatementOfMeansPaths.selfEmploymentPage.evaluateUri({ externalId: claim.externalId }), false, bold = true) }}
   {{ row('Job title', draft.statementOfMeans.selfEmployment.jobTitle, '', false, bold = true ) }}
-  {{ row('Annual turnover', draft.statementOfMeans.selfEmployment.annualTurnover | numeral, '', not draft.statementOfMeans.onTaxPayments, bold = true ) }}
-  {% if draft.statementOfMeans.onTaxPayments %}
-    {{ row('Are you behind on tax', 'Yes' if draft.statementOfMeans.onTaxPayments.declared else 'No', '', false, bold = true ) }}
-    {% if draft.statementOfMeans.onTaxPayments.declared %}
-      {{ row('Amount you owe?', draft.statementOfMeans.onTaxPayments.amountYouOwe | numeral, '', false, bold = true ) }}
-      {{ row('Reason', draft.statementOfMeans.onTaxPayments.reason, bold = true) }}
-    {% endif %}
+  {{ row('Annual turnover', draft.statementOfMeans.selfEmployment.annualTurnover | numeral, '', false, bold = true ) }}
+  {{ row('Are you behind on tax', 'Yes' if draft.statementOfMeans.onTaxPayments.declared else 'No', '', not draft.statementOfMeans.onTaxPayments.declared, bold = true ) }}
+  {% if draft.statementOfMeans.onTaxPayments.declared %}
+    {{ row('Amount you owe?', draft.statementOfMeans.onTaxPayments.amountYouOwe | numeral, '', false, bold = true ) }}
+    {{ row('Reason', draft.statementOfMeans.onTaxPayments.reason, bold = true) }}
   {% endif %}
 {% endif %}
 


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-3658

### Change description

This PR fixes two flaws found in testing:

1. Payment option hints were not displayed for pay by set date and pay by instalments radio options. The reason was that used `isApplicableFor` function expected option to be selected which it was impossible on the screen that helps user make decision around payment option.

![screen shot 2018-06-27 at 10 59 07](https://user-images.githubusercontent.com/1724691/41979228-742d1a2e-7a1b-11e8-89fa-ff2b45217c9e.png)

2. Horizontal line was not present on check and send page when defendant was self employed but not behind on tax payments.

![screen shot 2018-06-27 at 11 18 34](https://user-images.githubusercontent.com/1724691/41979239-822717c4-7a1b-11e8-98b6-3b1e02272976.png)

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No