### PR TITLE
Fix rounding error to calculate number of instalments

### DIFF
--- a/src/main/app/common/paymentPlan.ts
+++ b/src/main/app/common/paymentPlan.ts
@@ -9,7 +9,7 @@ class PaymentPlan {
     totalAmount: number,
     instalmentAmount: number,
     private frequencyInWeeks: number) {
-    this.numberOfInstalments = totalAmount / instalmentAmount
+    this.numberOfInstalments = Math.ceil(totalAmount / instalmentAmount)
   }
 
   getPaymentLength (): string {

--- a/src/main/app/common/paymentPlan.ts
+++ b/src/main/app/common/paymentPlan.ts
@@ -9,7 +9,7 @@ class PaymentPlan {
     totalAmount: number,
     instalmentAmount: number,
     private frequencyInWeeks: number) {
-    this.numberOfInstalments = Math.ceil(totalAmount / instalmentAmount)
+    this.numberOfInstalments = totalAmount / instalmentAmount
   }
 
   getPaymentLength (): string {

--- a/src/test/features/response/routes/full-admission/payment-plan.ts
+++ b/src/test/features/response/routes/full-admission/payment-plan.ts
@@ -7,7 +7,7 @@ import 'test/routes/expectations'
 import { checkAuthorizationGuards } from 'test/features/response/routes/checks/authorization-check'
 import { checkNotDefendantInCaseGuard } from 'test/features/response/routes/checks/not-defendant-in-case-check'
 
-import { Paths, FullAdmissionPaths } from 'response/paths'
+import { FullAdmissionPaths, Paths } from 'response/paths'
 
 import { app } from 'main/app'
 
@@ -64,15 +64,6 @@ describe('Defendant: payment page', () => {
             .expect(res => expect(res).to.be.successful.withText('Your repayment plan'))
         })
 
-        it('should calculate length of payment with given payment plan', async () => {
-          claimStoreServiceMock.resolveRetrieveClaimByExternalId()
-          draftStoreServiceMock.resolveFind('response:full-admission')
-
-          await request(app)
-            .get(pagePath)
-            .set('Cookie', `${cookieName}=ABC`)
-            .expect(res => expect(res).to.be.successful.withText('2 years 10 months'))
-        })
       })
     })
   })

--- a/src/test/features/response/routes/full-admission/payment-plan.ts
+++ b/src/test/features/response/routes/full-admission/payment-plan.ts
@@ -71,7 +71,7 @@ describe('Defendant: payment page', () => {
           await request(app)
             .get(pagePath)
             .set('Cookie', `${cookieName}=ABC`)
-            .expect(res => expect(res).to.be.successful.withText('2 years 9 months 4 weeks'))
+            .expect(res => expect(res).to.be.successful.withText('2 years 10 months'))
         })
       })
     })


### PR DESCRIPTION
There is already a route test for the payment-plan page for when `response:full-admission` is used
This test isn't the right place to be testing the logic of the calculation so there is no value in keeping it there