### PR TITLE
Changed value displayed from claim amount to claim + fees

### DIFF
--- a/src/main/features/response/routes/full-admission/payment-plan.ts
+++ b/src/main/features/response/routes/full-admission/payment-plan.ts
@@ -40,7 +40,7 @@ function renderView (form: Form<DefendantPaymentPlan>, res: express.Response): v
     paymentLength: calculatePaymentPlanLength(form.model),
     monthlyIncome: _.get(draft, 'document.statementOfMeans.monthlyIncome', 0),
     monthlyExpenses: _.get(draft, 'document.statementOfMeans.monthlyExpenses', 0),
-    totalAmount: claim.claimData.amount.totalAmount()
+    totalAmount: claim.totalAmountTillToday
   })
 }
 


### PR DESCRIPTION
### Change description

On the payment plan page, we previously displayed the initial claim amount
eg. £3141.59.
The content specified this number was meant to include the claim, claim fees and interest.
This change aligns up with what is expressed in the content


### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
