### PR TITLE
ROC-4052: Add `a11y` tests for claimant response feature

### DIFF
--- a/src/main/features/claimant-response/paths.ts
+++ b/src/main/features/claimant-response/paths.ts
@@ -5,7 +5,6 @@ const claimantResponsePath = '/case/:externalId/claimant-response'
 export class Paths {
   static readonly taskListPage = new RoutablePath(`${claimantResponsePath}/task-list`)
   static readonly checkAndSendPage = new RoutablePath(`${claimantResponsePath}/check-and-send`)
-  static readonly confirmationPage = new RoutablePath(`${claimantResponsePath}/confirmation`)
   static readonly incompleteSubmissionPage = new RoutablePath(`${claimantResponsePath}/incomplete-submission`)
   static readonly notImplementedYetPage = new RoutablePath(`${claimantResponsePath}/not-implemented-yet`)
 }

--- a/src/test/a11y/a11y.ts
+++ b/src/test/a11y/a11y.ts
@@ -12,6 +12,7 @@ import { Paths as EligibilityPaths } from 'eligibility/paths'
 import { ErrorPaths as ClaimIssueErrorPaths, Paths as ClaimIssuePaths } from 'claim/paths'
 import { ErrorPaths as DefendantFirstContactErrorPaths, Paths as DefendantFirstContactPaths } from 'first-contact/paths'
 import { Paths as DefendantResponsePaths, StatementOfMeansPaths, FullAdmissionPaths } from 'response/paths'
+import { Paths as ClaimantResponsePaths } from 'claimant-response/paths'
 import { Paths as CCJPaths } from 'ccj/paths'
 import { Paths as OfferPaths } from 'offer/paths'
 
@@ -92,7 +93,8 @@ const excludedPaths: DefendantResponsePaths[] = [
   DefendantResponsePaths.receiptReceiver,
   DefendantResponsePaths.legacyDashboardRedirect,
   OfferPaths.agreementReceiver,
-  DefendantFirstContactPaths.receiptReceiver
+  DefendantFirstContactPaths.receiptReceiver,
+  ClaimantResponsePaths.checkAndSendPage
 ]
 
 describe('Accessibility', () => {

--- a/src/test/a11y/a11y.ts
+++ b/src/test/a11y/a11y.ts
@@ -121,4 +121,5 @@ describe('Accessibility', () => {
   checkPaths(OfferPaths)
   checkPaths(StatementOfMeansPaths)
   checkPaths(FullAdmissionPaths)
+  checkPaths(ClaimantResponsePaths)
 })

--- a/src/test/http-mocks/draft-store.ts
+++ b/src/test/http-mocks/draft-store.ts
@@ -393,6 +393,12 @@ export function resolveFindAllDrafts (): mock.Scope {
         document: sampleCCJDraftObj,
         created: '2017-10-03T12:00:00.000',
         updated: '2017-10-03T12:01:00.000'
+      }, {
+        id: 204,
+        type: 'claimantResponse',
+        document: sampleClaimantResponseDraftObj,
+        created: '2017-10-03T12:00:00.000',
+        updated: '2017-10-03T12:01:00.000'
       }]
     })
 }


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-4052

### Change description
This PR adds `a11y` tests for claimant-response feature.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
