### PR TITLE
Use payment intention object in full admission response

### DIFF
--- a/src/main/app/claims/models/response/core/paymentIntention.ts
+++ b/src/main/app/claims/models/response/core/paymentIntention.ts
@@ -1,0 +1,25 @@
+import { Moment } from 'moment'
+
+import { PaymentOption } from 'claims/models/response/core/paymentOption'
+import { RepaymentPlan } from 'claims/models/response/core/repaymentPlan'
+import { MomentFactory } from 'shared/momentFactory'
+
+export interface PaymentIntention {
+  paymentOption?: PaymentOption
+  paymentDate?: Moment
+  repaymentPlan?: RepaymentPlan
+}
+
+export namespace PaymentIntention {
+  export function deserialize (input: any): PaymentIntention {
+    return input && {
+      paymentOption: input.paymentOption as PaymentOption,
+      paymentDate: input.paymentDate && MomentFactory.parse(input.paymentDate),
+      repaymentPlan: input.repaymentPlan && {
+        instalmentAmount: input.repaymentPlan.instalmentAmount,
+        firstPaymentDate: MomentFactory.parse(input.repaymentPlan.firstPaymentDate),
+        paymentSchedule: input.repaymentPlan.paymentSchedule
+      }
+    }
+  }
+}

--- a/src/main/app/claims/models/response/fullAdmissionResponse.ts
+++ b/src/main/app/claims/models/response/fullAdmissionResponse.ts
@@ -1,19 +1,16 @@
-import { Moment } from 'moment'
+import { PaymentIntention } from 'claims/models/response/partialAdmissionResponse'
 import { MomentFactory } from 'shared/momentFactory'
 
 import { ResponseCommon } from 'claims/models/response/responseCommon'
 import { ResponseType } from 'claims/models/response/responseType'
 
 import { PaymentOption } from 'claims/models/response/core/paymentOption'
-import { RepaymentPlan } from 'claims/models/response/core/repaymentPlan'
 
 import { StatementOfMeans } from 'claims/models/response/statement-of-means/statementOfMeans'
 
 export interface FullAdmissionResponse extends ResponseCommon {
   responseType: ResponseType.FULL_ADMISSION
-  paymentOption: PaymentOption
-  paymentDate?: Moment
-  repaymentPlan?: RepaymentPlan
+  paymentIntention?: PaymentIntention
   statementOfMeans?: StatementOfMeans
 }
 
@@ -22,12 +19,14 @@ export namespace FullAdmissionResponse {
     return {
       ...ResponseCommon.deserialize(input),
       responseType: ResponseType.FULL_ADMISSION,
-      paymentOption: input.paymentOption as PaymentOption,
-      paymentDate: input.paymentDate && MomentFactory.parse(input.paymentDate),
-      repaymentPlan: input.repaymentPlan && {
-        instalmentAmount: input.repaymentPlan.instalmentAmount,
-        firstPaymentDate: MomentFactory.parse(input.repaymentPlan.firstPaymentDate),
-        paymentSchedule: input.repaymentPlan.paymentSchedule
+      paymentIntention: input.paymentIntention && {
+        paymentOption: input.paymentIntention.paymentOption as PaymentOption,
+        paymentDate: input.paymentIntention.paymentDate && MomentFactory.parse(input.paymentIntention.paymentDate),
+        repaymentPlan: input.paymentIntention.repaymentPlan && {
+          instalmentAmount: input.paymentIntention.repaymentPlan.instalmentAmount,
+          firstPaymentDate: MomentFactory.parse(input.paymentIntention.repaymentPlan.firstPaymentDate),
+          paymentSchedule: input.paymentIntention.repaymentPlan.paymentSchedule
+        }
       },
       statementOfMeans: input.statementOfMeans
     }

--- a/src/main/app/claims/models/response/fullAdmissionResponse.ts
+++ b/src/main/app/claims/models/response/fullAdmissionResponse.ts
@@ -1,11 +1,7 @@
-import { PaymentIntention } from 'claims/models/response/partialAdmissionResponse'
-import { MomentFactory } from 'shared/momentFactory'
-
 import { ResponseCommon } from 'claims/models/response/responseCommon'
 import { ResponseType } from 'claims/models/response/responseType'
 
-import { PaymentOption } from 'claims/models/response/core/paymentOption'
-
+import { PaymentIntention } from 'claims/models/response/core/paymentIntention'
 import { StatementOfMeans } from 'claims/models/response/statement-of-means/statementOfMeans'
 
 export interface FullAdmissionResponse extends ResponseCommon {
@@ -19,15 +15,7 @@ export namespace FullAdmissionResponse {
     return {
       ...ResponseCommon.deserialize(input),
       responseType: ResponseType.FULL_ADMISSION,
-      paymentIntention: input.paymentIntention && {
-        paymentOption: input.paymentIntention.paymentOption as PaymentOption,
-        paymentDate: input.paymentIntention.paymentDate && MomentFactory.parse(input.paymentIntention.paymentDate),
-        repaymentPlan: input.paymentIntention.repaymentPlan && {
-          instalmentAmount: input.paymentIntention.repaymentPlan.instalmentAmount,
-          firstPaymentDate: MomentFactory.parse(input.paymentIntention.repaymentPlan.firstPaymentDate),
-          paymentSchedule: input.paymentIntention.repaymentPlan.paymentSchedule
-        }
-      },
+      paymentIntention: PaymentIntention.deserialize(input.paymentIntention),
       statementOfMeans: input.statementOfMeans
     }
   }

--- a/src/main/app/claims/models/response/partialAdmissionResponse.ts
+++ b/src/main/app/claims/models/response/partialAdmissionResponse.ts
@@ -53,8 +53,7 @@ export namespace PartialAdmissionResponse {
         rows: input.evidence && input.evidence.rows || [],
         comment: input.evidence && input.evidence.comment || undefined
       } as DefendantEvidence,
-      paymentIntention: input.paymentIntention
-      && {
+      paymentIntention: input.paymentIntention && {
         paymentOption: input.paymentIntention.paymentOption as PaymentOption,
         paymentDate: input.paymentIntention.paymentDate && MomentFactory.parse(input.paymentIntention.paymentDate),
         repaymentPlan: input.paymentIntention.repaymentPlan && {

--- a/src/main/app/claims/models/response/partialAdmissionResponse.ts
+++ b/src/main/app/claims/models/response/partialAdmissionResponse.ts
@@ -1,23 +1,12 @@
-import { Moment } from 'moment'
-import { MomentFactory } from 'shared/momentFactory'
-
 import { ResponseCommon } from 'claims/models/response/responseCommon'
 import { ResponseType } from 'claims/models/response/responseType'
 
-import { PaymentOption } from 'claims/models/response/core/paymentOption'
-import { RepaymentPlan } from 'claims/models/response/core/repaymentPlan'
-
+import { PaymentIntention } from 'claims/models/response/core/paymentIntention'
 import { StatementOfMeans } from 'claims/models/response/statement-of-means/statementOfMeans'
 import { DefendantEvidence } from 'response/form/models/defendantEvidence'
 import { DefendantTimeline } from 'response/form/models/defendantTimeline'
 import { YesNoOption } from 'claims/models/response/core/yesNoOption'
 import { PaymentDeclaration } from 'claims/models/paymentDeclaration'
-
-export interface PaymentIntention {
-  paymentOption?: PaymentOption
-  paymentDate?: Moment
-  repaymentPlan?: RepaymentPlan
-}
 
 export interface PartialAdmissionResponse extends ResponseCommon {
   responseType: ResponseType.PART_ADMISSION
@@ -53,15 +42,7 @@ export namespace PartialAdmissionResponse {
         rows: input.evidence && input.evidence.rows || [],
         comment: input.evidence && input.evidence.comment || undefined
       } as DefendantEvidence,
-      paymentIntention: input.paymentIntention && {
-        paymentOption: input.paymentIntention.paymentOption as PaymentOption,
-        paymentDate: input.paymentIntention.paymentDate && MomentFactory.parse(input.paymentIntention.paymentDate),
-        repaymentPlan: input.paymentIntention.repaymentPlan && {
-          instalmentAmount: input.paymentIntention.repaymentPlan.instalmentAmount,
-          firstPaymentDate: MomentFactory.parse(input.paymentIntention.repaymentPlan.firstPaymentDate),
-          paymentSchedule: input.paymentIntention.repaymentPlan.paymentSchedule
-        }
-      },
+      paymentIntention: PaymentIntention.deserialize(input.paymentIntention),
       statementOfMeans: input.statementOfMeans
     }
   }

--- a/src/main/app/claims/responseModelConverter.ts
+++ b/src/main/app/claims/responseModelConverter.ts
@@ -92,12 +92,14 @@ export class ResponseModelConverter {
     return {
       responseType: ResponseType.FULL_ADMISSION,
       defendant: this.convertPartyDetails(draft.defendantDetails),
-      paymentOption: draft.fullAdmission.paymentOption.option.value as PaymentOption,
-      paymentDate: this.convertPaymentDate(draft.fullAdmission.paymentOption, draft.fullAdmission.paymentDate),
-      repaymentPlan: draft.fullAdmission.paymentPlan && {
-        instalmentAmount: draft.fullAdmission.paymentPlan.instalmentAmount,
-        firstPaymentDate: draft.fullAdmission.paymentPlan.firstPaymentDate.toMoment(),
-        paymentSchedule: draft.fullAdmission.paymentPlan.paymentSchedule.value as PaymentSchedule
+      paymentIntention: draft.fullAdmission.paymentOption && {
+        paymentOption: draft.fullAdmission.paymentOption.option.value as PaymentOption,
+        paymentDate: this.convertPaymentDate(draft.fullAdmission.paymentOption, draft.fullAdmission.paymentDate),
+        repaymentPlan: draft.fullAdmission.paymentPlan && {
+          instalmentAmount: draft.fullAdmission.paymentPlan.instalmentAmount,
+          firstPaymentDate: draft.fullAdmission.paymentPlan.firstPaymentDate.toMoment(),
+          paymentSchedule: draft.fullAdmission.paymentPlan.paymentSchedule.value as PaymentSchedule
+        }
       },
       statementOfMeans: this.convertStatementOfMeans(draft),
       statementOfTruth: this.convertStatementOfTruth(draft)

--- a/src/main/app/claims/responseModelConverter.ts
+++ b/src/main/app/claims/responseModelConverter.ts
@@ -48,6 +48,7 @@ import { PartialAdmissionResponse } from 'claims/models/response/partialAdmissio
 import { PayBySetDate as PaymentDate } from 'forms/models/payBySetDate'
 import { YesNoOption as DraftYesNoOption } from 'models/yesNoOption'
 import { PaymentIntention } from 'claims/models/response/core/paymentIntention'
+import { DefendantPaymentPlan } from 'response/form/models/defendantPaymentPlan'
 
 export class ResponseModelConverter {
 
@@ -264,7 +265,7 @@ export class ResponseModelConverter {
     return party
   }
 
-  private static convertPaymentIntention (paymentOption: DefendantPaymentOption, paymentDate: PaymentDate, paymentPlan: any): PaymentIntention {
+  private static convertPaymentIntention (paymentOption: DefendantPaymentOption, paymentDate: PaymentDate, paymentPlan: DefendantPaymentPlan): PaymentIntention {
     return {
       paymentOption: paymentOption.option.value as PaymentOption,
       paymentDate: this.convertPaymentDate(paymentOption, paymentDate),

--- a/src/main/features/claimant-response/helpers/taskListBuilder.ts
+++ b/src/main/features/claimant-response/helpers/taskListBuilder.ts
@@ -36,7 +36,7 @@ export class TaskListBuilder {
       )
     }
 
-    if (claim.response && claim.response.responseType === ResponseType.FULL_ADMISSION && claim.response.paymentOption !== PaymentOption.IMMEDIATELY) {
+    if (claim.response && claim.response.responseType === ResponseType.FULL_ADMISSION && claim.response.paymentIntention.paymentOption !== PaymentOption.IMMEDIATELY) {
       tasks.push(
         new TaskListItem(
           'Accept or reject their repayment plan',

--- a/src/main/features/claimant-response/helpers/taskListBuilder.ts
+++ b/src/main/features/claimant-response/helpers/taskListBuilder.ts
@@ -36,7 +36,9 @@ export class TaskListBuilder {
       )
     }
 
-    if (claim.response && claim.response.responseType === ResponseType.FULL_ADMISSION && claim.response.paymentIntention.paymentOption !== PaymentOption.IMMEDIATELY) {
+    if (claim.response
+      && claim.response.responseType === ResponseType.FULL_ADMISSION
+      && claim.response.paymentIntention.paymentOption !== PaymentOption.IMMEDIATELY) {
       tasks.push(
         new TaskListItem(
           'Accept or reject their repayment plan',

--- a/src/main/features/response/views/confirmation/full-admission-steps.njk
+++ b/src/main/features/response/views/confirmation/full-admission-steps.njk
@@ -1,11 +1,11 @@
 {% set claimantName = claim.claimData.claimant.name %}
 {% set claimantDetailsPageURI = ClaimPaths.claimantDetailsPage.evaluateUri({ externalId: claim.externalId }) %}
 
-{% if claim.response.paymentOption === domain.PaymentOption.IMMEDIATELY %}
+{% if claim.response.paymentIntention.paymentOption === domain.PaymentOption.IMMEDIATELY %}
   <p>{{ t('When {{ claimantName }} gets your payment they should tell you and the court you’ve paid.', { claimantName: claimantName }) }}</p>
 {% endif %}
 
-{% if claim.response.paymentOption === domain.PaymentOption.BY_SPECIFIED_DATE %}
+{% if claim.response.paymentIntention.paymentOption === domain.PaymentOption.BY_SPECIFIED_DATE %}
   <p>{{ t('If {{ claimantName }} accepts your offer to pay, you need to <a href="{{ link }}">contact them for payment details</a> and to arrange payment.', { claimantName: claimantName, link: claimantDetailsPageURI }) | safe }}</p>
 
   <p>{{ t('If they reject your offer to pay by a set date then the court will decide how you must pay.') }}</p>
@@ -13,7 +13,7 @@
   <p>{{ t('If they do not respond within 6 months, the court will put the claim on hold.') }}</p>
 {% endif %}
 
-{% if claim.response.paymentOption === domain.PaymentOption.INSTALMENTS %}
+{% if claim.response.paymentIntention.paymentOption === domain.PaymentOption.INSTALMENTS %}
   <p>{{ t('You should:') }}</p>
 
   <ul class="list list-bullet">

--- a/src/main/features/response/views/confirmation/full-admission.njk
+++ b/src/main/features/response/views/confirmation/full-admission.njk
@@ -1,13 +1,13 @@
 {% set claimantName = claim.claimData.claimant.name %}
 {% set claimantDetailsPageURI = ClaimPaths.claimantDetailsPage.evaluateUri({ externalId: claim.externalId }) %}
 
-{% if claim.response.paymentOption === domain.PaymentOption.IMMEDIATELY %}
+{% if claim.response.paymentIntention.paymentOption === domain.PaymentOption.IMMEDIATELY %}
   <p>{{ t('We’ve emailed {{ claimantName }} to tell them you’ll pay immediately.', { claimantName: claimantName }) }}</p>
 
   <p>{{ t('You need to make sure that:') }}</p>
 
   <ul class="list list-bullet">
-    <li>{{ t('they get the money before 4pm on {{ paymentDate }} - they can request a County Court Judgment against you if not', { paymentDate: claim.response.paymentDate | date }) }}</li>
+    <li>{{ t('they get the money before 4pm on {{ paymentDate }} - they can request a County Court Judgment against you if not', { paymentDate: claim.response.paymentIntention.paymentDate | date }) }}</li>
     <li>{{ t('any cheques or bank transfers are clear in their account by the deadline') }}</li>
     <li>{{ t('you get a receipt for any payments') }}</li>
   </ul>
@@ -15,11 +15,11 @@
   <p>{{ t('<a href="{{ link }}">Contact {{ claimantName }}</a> if you need their payment details.', { claimantName: claimantName, link: claimantDetailsPageURI }) | safe }}</p>
 {% endif %}
 
-{% if claim.response.paymentOption === domain.PaymentOption.BY_SPECIFIED_DATE %}
+{% if claim.response.paymentIntention.paymentOption === domain.PaymentOption.BY_SPECIFIED_DATE %}
   <p>{{ t('We’ve emailed {{ claimantName }} your offer to pay by {{ paymentDate }} and your explanation of why you can’t pay before then.',
-      { claimantName: claimantName, paymentDate: claim.response.paymentDate | date }) }}</p>
+      { claimantName: claimantName, paymentDate: claim.response.paymentIntention.paymentDate | date }) }}</p>
 {% endif %}
 
-{% if claim.response.paymentOption === domain.PaymentOption.INSTALMENTS %}
+{% if claim.response.paymentIntention.paymentOption === domain.PaymentOption.INSTALMENTS %}
   <p>{{ t('We’ve emailed {{ claimantName }} to tell them you’ve suggested paying by instalments.', { claimantName: claimantName }) }}</p>
 {% endif %}

--- a/src/test/data/entity/responseData.ts
+++ b/src/test/data/entity/responseData.ts
@@ -72,8 +72,10 @@ const basePartialEvidencesAndTimeLines = {
 export const fullAdmissionWithImmediatePaymentData = {
   ...baseResponseData,
   ...baseFullAdmissionData,
-  paymentOption: PaymentOption.IMMEDIATELY,
-  paymentDate: MomentFactory.currentDate().add(5, 'days')
+  paymentIntention: {
+    paymentOption: PaymentOption.IMMEDIATELY,
+    paymentDate: MomentFactory.currentDate().add(5, 'days')
+  }
 }
 
 export const partialAdmissionWithImmediatePaymentData = {
@@ -105,8 +107,10 @@ export const partialAdmissionAlreadyPaidData = {
 export const fullAdmissionWithPaymentBySetDateData = {
   ...baseResponseData,
   ...baseFullAdmissionData,
-  paymentOption: PaymentOption.BY_SPECIFIED_DATE,
-  paymentDate: '2050-12-31'
+  paymentIntention: {
+    paymentOption: PaymentOption.BY_SPECIFIED_DATE,
+    paymentDate: '2050-12-31'
+  }
 }
 
 export const partialAdmissionWithPaymentBySetDateData = {
@@ -125,11 +129,13 @@ export const partialAdmissionWithPaymentBySetDateData = {
 export const fullAdmissionWithPaymentByInstalmentsData = {
   ...baseResponseData,
   ...baseFullAdmissionData,
-  paymentOption: PaymentOption.INSTALMENTS,
-  repaymentPlan: {
-    instalmentAmount: 100,
-    firstPaymentDate: '2050-12-31',
-    paymentSchedule: PaymentSchedule.EACH_WEEK
+  paymentIntention: {
+    paymentOption: PaymentOption.INSTALMENTS,
+    repaymentPlan: {
+      instalmentAmount: 100,
+      firstPaymentDate: '2050-12-31',
+      paymentSchedule: PaymentSchedule.EACH_WEEK
+    }
   }
 }
 


### PR DESCRIPTION
### JIRA link

None

### Change description

This PR makes full admission catchup in terms of how payment intention is represented in domain model.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No