### PR TITLE
Remove unneeded property from partial admission response

### DIFF
--- a/src/main/app/claims/models/response/partialAdmissionResponse.ts
+++ b/src/main/app/claims/models/response/partialAdmissionResponse.ts
@@ -10,7 +10,6 @@ import { PaymentDeclaration } from 'claims/models/paymentDeclaration'
 
 export interface PartialAdmissionResponse extends ResponseCommon {
   responseType: ResponseType.PART_ADMISSION
-  isAlreadyPaid: YesNoOption
   amount: number
   paymentDeclaration: PaymentDeclaration
   defence: string,
@@ -26,7 +25,6 @@ export namespace PartialAdmissionResponse {
     return {
       ...ResponseCommon.deserialize(input),
       responseType: ResponseType.PART_ADMISSION,
-      isAlreadyPaid: input.isAlreadyPaid,
       amount: input.amount,
       paymentDeclaration: input.paymentDeclaration
       && {

--- a/src/main/app/claims/responseModelConverter.ts
+++ b/src/main/app/claims/responseModelConverter.ts
@@ -114,7 +114,6 @@ export class ResponseModelConverter {
 
     return {
       responseType: ResponseType.PART_ADMISSION,
-      isAlreadyPaid: draft.partialAdmission.alreadyPaid.option.option as YesNoOption,
       amount: amount,
       paymentDeclaration: draft.partialAdmission.howMuchHaveYouPaid.date
       && draft.partialAdmission.howMuchHaveYouPaid.text

--- a/src/main/features/response/views/confirmation/part-admission-steps.njk
+++ b/src/main/features/response/views/confirmation/part-admission-steps.njk
@@ -2,16 +2,15 @@
 {% set amount = claim.response.amount | numeral %}
 {% set fullAmount = claim.totalAmountTillToday | numeral %}
 
-{% if claim.response['isAlreadyPaid'] === YesNoOption.Yes.option %}
-  <p>{{ t('If {{ claimantName }} accepts your response the claim will be settled. We’ll email you to tell you.', {claimantName: claimantName}) }}</p>
-  <p> {{ t('If they reject your response the court will review the case. You might have to go to a hearing.') }}</p>
+{% if claim.response.paymentDeclaration %}
+  <p>{{ t('If {{ claimantName }} accepts your response the claim will be settled. We’ll email you to tell you.', { claimantName: claimantName }) }}</p>
+  <p>{{ t('If they reject your response the court will review the case. You might have to go to a hearing.') }}</p>
   <p>{{ t('We’ll contact you if we set a hearing date to tell you how to prepare') }}.</p>
 {% endif %}
 
-{% if claim.response.paymentOption %}
-
-  <p>{{ t('If {{ claimantName }} accepts your admission of {{ amount }} and your offer to pay, the claim will be settled. We’ll email you to tell you.', {claimantName: claimantName, amount: amount}) }}</p>
-  <p>{{ t('If they reject it the court will review the case for the full amount of {{ fullAmount }}. You might have to go to a hearing.', {fullAmount: fullAmount }) }}</p>
+{% if claim.response.paymentIntention.paymentOption %}
+  <p>{{ t('If {{ claimantName }} accepts your admission of {{ amount }} and your offer to pay, the claim will be settled. We’ll email you to tell you.', { claimantName: claimantName, amount: amount }) }}</p>
+  <p>{{ t('If they reject it the court will review the case for the full amount of {{ fullAmount }}. You might have to go to a hearing.', { fullAmount: fullAmount }) }}</p>
   <p>{{ t('We’ll contact you if we set a hearing date to tell you how to prepare.') }}</p>
   <p>{{ t('If they do not respond within 6 months, the court will put the claim on hold.') }}</p>
 {% endif %}

--- a/src/main/features/response/views/confirmation/part-admission.njk
+++ b/src/main/features/response/views/confirmation/part-admission.njk
@@ -2,7 +2,7 @@
 {% set claimantDetailsPageURI = ClaimPaths.claimantDetailsPage.evaluateUri({ externalId: claim.externalId }) %}
 {% set amount = claim.response.amount | numeral %}
 
-{% if claim.response['isAlreadyPaid'] === YesNoOption.Yes.option %}
+{% if claim.response.paymentDeclaration %}
   <p> {{ t('You told us you’ve paid the {{ amount }} you believe you owe. We’ve sent {{ claimantName }} this response.', { claimantName: claimantName, amount: amount }) }}</p>
 {% endif %}
 
@@ -18,8 +18,7 @@
     {% set paymentMethod = 'by instalments' %}
   {% endif %}
 
-  <p>{{ t('You believe you owe {{ amount }}. We’ve emailed {{ claimantName }} your offer to pay this amount {{ paymentMethod }}.', { claimantName: claimantName, paymentMethod: paymentMethod, amount: amount    }) }}
+  <p>{{ t('You believe you owe {{ amount }}. We’ve emailed {{ claimantName }} your offer to pay this amount {{ paymentMethod }}.', { claimantName: claimantName, paymentMethod: paymentMethod, amount: amount    }) }}</p>
 
-  </p>
   <p>{{ t('We’ve also sent them your explanation of why you do not believe you owe the amount claimed.') }}</p>
 {% endif %}

--- a/src/test/data/entity/responseData.ts
+++ b/src/test/data/entity/responseData.ts
@@ -82,7 +82,6 @@ export const partialAdmissionWithImmediatePaymentData = {
   ...baseResponseData,
   ...basePartialAdmissionData,
   ...basePartialEvidencesAndTimeLines,
-  isAlreadyPaid: 'yes',
   defence: 'i have paid more than enough',
   paymentIntention: {
     paymentOption: PaymentOption.IMMEDIATELY,
@@ -95,7 +94,6 @@ export const partialAdmissionAlreadyPaidData = {
   ...baseResponseData,
   ...basePartialAdmissionData,
   ...basePartialEvidencesAndTimeLines,
-  isAlreadyPaid: 'yes',
   amount: 3000,
   defence: 'i have paid more than enough',
   paymentDeclaration: {
@@ -117,7 +115,6 @@ export const partialAdmissionWithPaymentBySetDateData = {
   ...baseResponseData,
   ...basePartialAdmissionData,
   ...basePartialEvidencesAndTimeLines,
-  isAlreadyPaid: 'yes',
   defence: 'i have paid more than enough',
   paymentIntention: {
     paymentOption: PaymentOption.BY_SPECIFIED_DATE,
@@ -143,7 +140,6 @@ export const partialAdmissionWithPaymentByInstalmentsData = {
   ...baseResponseData,
   ...basePartialAdmissionData,
   ...basePartialEvidencesAndTimeLines,
-  isAlreadyPaid: 'yes',
   defence: 'i have paid more than enough',
   paymentIntention: {
     paymentOption: PaymentOption.INSTALMENTS,


### PR DESCRIPTION
### JIRA link

None

### Change description

Removes 'isAlreadyPaid' property from partial admission response that should have been removed when structure changed.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No