### PR TITLE
Defendant confirmation page changes

### DIFF
--- a/src/main/features/response/views/confirmation.njk
+++ b/src/main/features/response/views/confirmation.njk
@@ -11,7 +11,7 @@
       <div class="govuk-box-highlight">
         <h1 class="bold-large">{{ t('You’ve submitted your response') }}</h1>
         <p class="reference-number">
-          <span>{{ t('Your claim reference:') }}</span>
+          <span>{{ t('Claim number:') }}</span>
           <span class="block bold-large">{{ claim.claimNumber }}</span>
         </p>
         <p>
@@ -22,7 +22,6 @@
         </p>
       </div>
 
-      <h2 class="bold-large form-group">{{ t('Your response') }}</h2>
 
       {% if claim.response.responseType === domain.ResponseType.FULL_ADMISSION %}
         {% include "./confirmation/full-admission.njk" %}

--- a/src/main/features/response/views/confirmation/full-defence-steps.njk
+++ b/src/main/features/response/views/confirmation/full-defence-steps.njk
@@ -1,10 +1,12 @@
 {% set claimantName = claim.claimData.claimant.name %}
 
 <p>{{ t('If {{ claimantName }} accepts your defence the claim will be cancelled.', { claimantName: claimantName }) | safe }}</p>
-<p>{{ t('If they reject your defence the case will be reviewed and might go to a hearing.') }}</p>
+<p>{{ t('If they reject your response the court will review the case. You might have to go to a hearing.') }}</p>
+
+
 
 <h2 class="heading-medium">{{ t('Settle out of court') }}</h2>
-<p>{{ t('You may still <a href="{{ link }}">settle the claim out of court</a>. For example you could offer to fix goods you sold the claimant or suggest a payment.',
+<p>{{ t('You can still <a href="{{ link }}">settle the claim out of court</a>. For example you could offer to repair goods you sold the claimant or suggest a payment.',
     { link: OfferPaths.settleOutOfCourtPage.evaluateUri({ externalId: claim.externalId }) }) | safe }}</p>
 <p>{{ t('You can avoid getting a County Court Judgment if the claimant accepts your offer.') }}</p>
 

--- a/src/main/features/response/views/confirmation/full-defence-steps.njk
+++ b/src/main/features/response/views/confirmation/full-defence-steps.njk
@@ -3,8 +3,6 @@
 <p>{{ t('If {{ claimantName }} accepts your defence the claim will be cancelled.', { claimantName: claimantName }) | safe }}</p>
 <p>{{ t('If they reject your response the court will review the case. You might have to go to a hearing.') }}</p>
 
-
-
 <h2 class="heading-medium">{{ t('Settle out of court') }}</h2>
 <p>{{ t('You can still <a href="{{ link }}">settle the claim out of court</a>. For example you could offer to repair goods you sold the claimant or suggest a payment.',
     { link: OfferPaths.settleOutOfCourtPage.evaluateUri({ externalId: claim.externalId }) }) | safe }}</p>

--- a/src/main/features/response/views/confirmation/full-defence.njk
+++ b/src/main/features/response/views/confirmation/full-defence.njk
@@ -1,2 +1,1 @@
-<p>{{ t('We’ve emailed {{ claimant }} your defence, explaining why you reject the claim.', { claimant: claim.claimData.claimant.name }) }}</p>
-<p>{{ t('View the <a href="{{ link }}">claim against you and your response.</a>', { link: DashboardPaths.dashboardPage.uri }) | safe }}</p>
+<p>{{ t('We’ve emailed {{ claimant }} your response, explaining why you reject the claim.', { claimant: claim.claimData.claimant.name }) }}</p>


### PR DESCRIPTION
1. Changed 'your claim reference to claim number'
2. Removed the 'your response' heading from below the green box
3. Changed 'defence' to 'response' in the line underneat the green box.
4. Deleted the line that appears linking them to the dashboard which read 'view the claim against you and your response' - we already link to the dashboard further down the page.
5. Made the info about the case being reviewed and the hearing less passive, the court will review the case and you might have to go to a hearing.
6. Changed 'may' to 'can' in the settle section.
7. Changed 'fix' to 'repair'

### JIRA link



### Change description



### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
