### PR TITLE
Remove scenario hooks and replace generators with async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "tslint": "^5.5.0",
     "tslint-config-standard": "^7.0.0",
     "urlencode": "^1.1.0",
-    "webdriverio": "^4.11.0"
+    "webdriverio": "^4.13.1"
   },
   "nyc": {
     "extension": [

--- a/src/integration-test/tests/citizen/ccj/ccj_test.ts
+++ b/src/integration-test/tests/citizen/ccj/ccj_test.ts
@@ -11,13 +11,13 @@ const ccjSteps: CountyCourtJudgementSteps = new CountyCourtJudgementSteps()
 
 Feature('CCJ').retry(3)
 
-Scenario('Request judgment as an individual with no defendant email and pay by instalments @citizen @quick', function * (I: I) {
-  const email: string = yield I.createCitizenUser()
+Scenario('Request judgment as an individual with no defendant email and pay by instalments @citizen @quick', async (I: I) => {
+  const email: string = await I.createCitizenUser()
   const claimantType: PartyType = PartyType.INDIVIDUAL
   const defendantType: PartyType = PartyType.INDIVIDUAL
   const hasDefendantEmail = false
 
-  const claimRef: string = yield I.createClaim(createClaimData(claimantType, defendantType, hasDefendantEmail, InterestType.NO_INTEREST), email)
+  const claimRef: string = await I.createClaim(createClaimData(claimantType, defendantType, hasDefendantEmail, InterestType.NO_INTEREST), email)
 
   userSteps.login(email)
   ccjSteps.requestCCJ(claimRef, defendantType)
@@ -26,12 +26,12 @@ Scenario('Request judgment as an individual with no defendant email and pay by i
   I.see('County Court Judgment requested', 'h1.bold-large')
 })
 
-Scenario('Request judgment as a Company, pay by set date @citizen', function* (I: I) {
-  const email: string = yield I.createCitizenUser()
+Scenario('Request judgment as a Company, pay by set date @citizen', async (I: I) => {
+  const email: string = await I.createCitizenUser()
   const claimantType: PartyType = PartyType.COMPANY
   const defendantType: PartyType = PartyType.COMPANY
 
-  const claimRef: string = yield I.createClaim(createClaimData(claimantType, defendantType, true, InterestType.NO_INTEREST), email)
+  const claimRef: string = await I.createClaim(createClaimData(claimantType, defendantType, true, InterestType.NO_INTEREST), email)
 
   userSteps.login(email)
   ccjSteps.requestCCJ(claimRef, defendantType)
@@ -40,12 +40,12 @@ Scenario('Request judgment as a Company, pay by set date @citizen', function* (I
   I.see('County Court Judgment requested', 'h1.bold-large')
 })
 
-Scenario('Request judgment as a sole trader, pay immediately @citizen', function* (I: I) {
-  const email: string = yield I.createCitizenUser()
+Scenario('Request judgment as a sole trader, pay immediately @citizen', async (I: I) => {
+  const email: string = await I.createCitizenUser()
   const claimantType: PartyType = PartyType.SOLE_TRADER
   const defendantType: PartyType = PartyType.ORGANISATION
 
-  const claimRef: string = yield I.createClaim(createClaimData(claimantType, defendantType, true, InterestType.NO_INTEREST), email)
+  const claimRef: string = await I.createClaim(createClaimData(claimantType, defendantType, true, InterestType.NO_INTEREST), email)
 
   userSteps.login(email)
   ccjSteps.requestCCJ(claimRef, defendantType)

--- a/src/integration-test/tests/citizen/claim/enterDetails_test.ts
+++ b/src/integration-test/tests/citizen/claim/enterDetails_test.ts
@@ -10,8 +10,8 @@ const interestSteps: InterestSteps = new InterestSteps()
 
 Feature('Claimant Enter details of claim').retry(3)
 
-Scenario('I can prepare a claim with default interest @citizen', function* (I: I) {
-  const email: string = yield I.createCitizenUser()
+Scenario('I can prepare a claim with default interest @citizen', async (I: I) => {
+  const email: string = await I.createCitizenUser()
   userSteps.login(email)
   claimSteps.completeEligibility()
   userSteps.selectClaimAmount()
@@ -26,8 +26,8 @@ Scenario('I can prepare a claim with default interest @citizen', function* (I: I
   I.see('Prepare your claim')
 })
 
-Scenario('I can prepare a claim with no interest @citizen', function* (I: I) {
-  const email: string = yield I.createCitizenUser()
+Scenario('I can prepare a claim with no interest @citizen', async (I: I) => {
+  const email: string = await I.createCitizenUser()
   userSteps.login(email)
 
   claimSteps.completeEligibility()
@@ -43,8 +43,8 @@ Scenario('I can prepare a claim with no interest @citizen', function* (I: I) {
   I.see('Prepare your claim')
 })
 
-Scenario('I can prepare a claim with different interest rate and date @citizen', function* (I: I) {
-  const email: string = yield I.createCitizenUser()
+Scenario('I can prepare a claim with different interest rate and date @citizen', async (I: I) => {
+  const email: string = await I.createCitizenUser()
   userSteps.login(email)
 
   claimSteps.completeEligibility()
@@ -59,8 +59,8 @@ Scenario('I can prepare a claim with different interest rate and date @citizen',
   I.see('Prepare your claim')
 })
 
-Scenario('I can prepare a claim with a manually entered interest amount and a daily amount added @citizen', function* (I: I) {
-  const email: string = yield I.createCitizenUser()
+Scenario('I can prepare a claim with a manually entered interest amount and a daily amount added @citizen', async (I: I) => {
+  const email: string = await I.createCitizenUser()
   userSteps.login(email)
 
   claimSteps.completeEligibility()
@@ -77,6 +77,6 @@ Scenario('I can prepare a claim with a manually entered interest amount and a da
 
 // The @citizen-smoke-test tag used for running smoke tests with pre-registered user
 
-Scenario('I can enter a claim details and navigate up to payment page @citizen-smoke-test', function* (I: I) {
+Scenario('I can enter a claim details and navigate up to payment page @citizen-smoke-test', (I: I) => {
   claimSteps.makeAClaimAndNavigateUpToPayment(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL, true)
 })

--- a/src/integration-test/tests/citizen/claim/fees_test.ts
+++ b/src/integration-test/tests/citizen/claim/fees_test.ts
@@ -11,8 +11,8 @@ const claimantClaimAmountPage: ClaimantClaimAmountPage = new ClaimantClaimAmount
 
 Feature('Claimant enter details of claim: fees').retry(3)
 
-Scenario('I can see the Claim amount page calculates properly and shows the correct fees table @citizen', function* (I: I) {
-  const email: string = yield I.createCitizenUser()
+Scenario('I can see the Claim amount page calculates properly and shows the correct fees table @citizen', async (I: I) => {
+  const email: string = await I.createCitizenUser()
   userSteps.login(email)
 
   claimSteps.completeEligibility()

--- a/src/integration-test/tests/citizen/claim/pages/claimant-claim-confirmed.ts
+++ b/src/integration-test/tests/citizen/claim/pages/claimant-claim-confirmed.ts
@@ -8,7 +8,7 @@ const fields = {
 
 export class ClaimantClaimConfirmedPage {
 
-  getClaimReference (): string {
+  getClaimReference (): Promise<string> {
     return I.grabTextFrom(fields.claimReference)
   }
 }

--- a/src/integration-test/tests/citizen/claim/payment_test.ts
+++ b/src/integration-test/tests/citizen/claim/payment_test.ts
@@ -8,8 +8,8 @@ const paymentSteps: PaymentSteps = new PaymentSteps()
 
 Feature('Claim issue').retry(3)
 
-Scenario('I can cancel payment, attempt payment with declined card and finally issue claim using working card @citizen @quick', function* (I: I) {
-  const email: string = yield I.createCitizenUser()
+Scenario('I can cancel payment, attempt payment with declined card and finally issue claim using working card @citizen @quick', async (I: I) => {
+  const email: string = await I.createCitizenUser()
 
   claimSteps.makeAClaimAndSubmitStatementOfTruth(email, PartyType.INDIVIDUAL, PartyType.INDIVIDUAL, true)
 

--- a/src/integration-test/tests/citizen/claim/steps/claim.ts
+++ b/src/integration-test/tests/citizen/claim/steps/claim.ts
@@ -204,7 +204,7 @@ export class ClaimSteps {
     this.checkClaimFactsAreTrueAndSubmit(claimantType, defendantType, enterDefendantEmail)
   }
 
-  makeAClaimAndSubmit (email: string, claimantType: PartyType, defendantType: PartyType, enterDefendantEmail: boolean = true): string {
+  makeAClaimAndSubmit (email: string, claimantType: PartyType, defendantType: PartyType, enterDefendantEmail: boolean = true): Promise<string> {
     this.makeAClaimAndSubmitStatementOfTruth(email, claimantType, defendantType, enterDefendantEmail)
     paymentSteps.payWithWorkingCard()
     this.reloadPage() // reload gets over the ESOCKETTIMEDOUT Error

--- a/src/integration-test/tests/citizen/dashboard/dashboard_test.ts
+++ b/src/integration-test/tests/citizen/dashboard/dashboard_test.ts
@@ -14,7 +14,7 @@ Scenario('Check newly created claim is in my account dashboard with correct clai
   const email: string = await I.createCitizenUser()
   const claimData: ClaimData = createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL)
 
-  const claimRef: string = claimSteps.makeAClaimAndSubmit(email, PartyType.COMPANY, PartyType.INDIVIDUAL, false)
+  const claimRef: string = await claimSteps.makeAClaimAndSubmit(email, PartyType.COMPANY, PartyType.INDIVIDUAL, false)
 
   I.click('My account')
   I.see('Your money claims account')

--- a/src/integration-test/tests/citizen/dashboard/dashboard_test.ts
+++ b/src/integration-test/tests/citizen/dashboard/dashboard_test.ts
@@ -14,7 +14,7 @@ Scenario('Check newly created claim is in my account dashboard with correct clai
   const email: string = await I.createCitizenUser()
   const claimData: ClaimData = createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL)
 
-  const claimRef: string = await claimSteps.makeAClaimAndSubmit(email, PartyType.COMPANY, PartyType.INDIVIDUAL, false)
+  const claimRef: string = claimSteps.makeAClaimAndSubmit(email, PartyType.COMPANY, PartyType.INDIVIDUAL, false)
 
   I.click('My account')
   I.see('Your money claims account')

--- a/src/integration-test/tests/citizen/dashboard/dashboard_test.ts
+++ b/src/integration-test/tests/citizen/dashboard/dashboard_test.ts
@@ -10,11 +10,11 @@ const dashboardClaimDetails: DashboardClaimDetails = new DashboardClaimDetails()
 
 Feature('Dashboard').retry(3)
 
-Scenario('Check newly created claim is in my account dashboard with correct claim amount @citizen', function* (I: I) {
-  const email: string = yield I.createCitizenUser()
+Scenario('Check newly created claim is in my account dashboard with correct claim amount @citizen', async (I: I) => {
+  const email: string = await I.createCitizenUser()
   const claimData: ClaimData = createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL)
 
-  const claimRef: string = yield claimSteps.makeAClaimAndSubmit(email, PartyType.COMPANY, PartyType.INDIVIDUAL, false)
+  const claimRef: string = await claimSteps.makeAClaimAndSubmit(email, PartyType.COMPANY, PartyType.INDIVIDUAL, false)
 
   I.click('My account')
   I.see('Your money claims account')

--- a/src/integration-test/tests/citizen/defence/defence_claim_details_test.ts
+++ b/src/integration-test/tests/citizen/defence/defence_claim_details_test.ts
@@ -10,14 +10,14 @@ const defendantDetails: DashboardClaimDetails = new DashboardClaimDetails()
 
 Feature('Respond to claim: claim details').retry(3)
 
-Scenario('I can view the claim details from a link on the dashboard @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can view the claim details from a link on the dashboard @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
   const claimData: ClaimData = createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL)
-  const claimRef: string = yield I.createClaim(claimData, claimantEmail)
+  const claimRef: string = await I.createClaim(claimData, claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.defendantViewCaseTaskList(defendantEmail)
   I.click(claimRef)
   I.click('Respond to claim')
@@ -25,14 +25,14 @@ Scenario('I can view the claim details from a link on the dashboard @citizen', f
   defendantDetails.checkClaimData(claimRef, claimData)
 })
 
-Scenario('I can view the claim details from a link on the dashboard for interest breakdown @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can view the claim details from a link on the dashboard for interest breakdown @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
   const claimData: ClaimData = createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL, true, InterestType.BREAKDOWN)
-  const claimRef: string = yield I.createClaim(claimData, claimantEmail)
+  const claimRef: string = await I.createClaim(claimData, claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.defendantViewCaseTaskList(defendantEmail)
   I.click(claimRef)
   I.click('Respond to claim')

--- a/src/integration-test/tests/citizen/defence/defence_handoff_test.ts
+++ b/src/integration-test/tests/citizen/defence/defence_handoff_test.ts
@@ -8,31 +8,31 @@ const helperSteps: Helper = new Helper()
 
 Feature('Respond to claim: handoff journey').retry(3)
 
-Scenario('I can see send your response by email page when I reject all of the claim with counter claim @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can see send your response by email page when I reject all of the claim with counter claim @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
   const claimData: ClaimData = createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL)
   const defendant: Party = claimData.defendants[0]
   const claimant: Party = claimData.claimants[0]
 
-  const claimRef: string = yield I.createClaim(claimData, claimantEmail)
+  const claimRef: string = await I.createClaim(claimData, claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.finishResponseWithHandOff(claimRef, defendant, claimant, defendantEmail, DefenceType.FULL_REJECTION_WITH_COUNTER_CLAIM)
 })
 
-Scenario('I can see send your response by email page when I reject all of the claim with amount paid less than claimed amount @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can see send your response by email page when I reject all of the claim with amount paid less than claimed amount @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
   const claimData: ClaimData = createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL)
   const defendant: Party = claimData.defendants[0]
   const claimant: Party = claimData.claimants[0]
 
-  const claimRef: string = yield I.createClaim(claimData, claimantEmail)
+  const claimRef: string = await I.createClaim(claimData, claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.finishResponseWithHandOff(claimRef, defendant, claimant,
     defendantEmail, DefenceType.FULL_REJECTION_BECAUSE_ALREADY_PAID_LESS_THAN_CLAIMED_AMOUNT
   )

--- a/src/integration-test/tests/citizen/defence/defence_test.ts
+++ b/src/integration-test/tests/citizen/defence/defence_test.ts
@@ -9,24 +9,24 @@ const helperSteps: Helper = new Helper()
 
 Feature('Respond to claim: online journey').retry(3)
 
-Scenario('I can complete the journey when I fully reject the claim as I dispute the claim @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can complete the journey when I fully reject the claim as I dispute the claim @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
-  const claimRef: string = yield I.createClaim(createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL), claimantEmail)
+  const claimRef: string = await I.createClaim(createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL), claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.finishResponse(claimRef, defendantEmail, PartyType.INDIVIDUAL, DefenceType.FULL_REJECTION_WITH_DISPUTE)
 })
 
-Scenario('I can complete the journey when I fully reject the claim as I have already paid @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can complete the journey when I fully reject the claim as I have already paid @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
   const claimModel: ClaimData = createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL)
 
-  const claimRef: string = yield I.createClaim(claimModel, claimantEmail)
+  const claimRef: string = await I.createClaim(claimModel, claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.finishResponse(claimRef, defendantEmail, PartyType.INDIVIDUAL, DefenceType.FULL_REJECTION_BECAUSE_FULL_AMOUNT_IS_PAID)
 
   I.click('My account')
@@ -34,14 +34,14 @@ Scenario('I can complete the journey when I fully reject the claim as I have alr
   I.see(`We’ve emailed ${claimModel.claimants[0].name} telling them when and how you said you paid the claim`)
 })
 
-Scenario('I can fill out forms for I admit part of the claim @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can fill out forms for I admit part of the claim @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
   const claimData: ClaimData = createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL)
-  const claimRef: string = yield I.createClaim(claimData, claimantEmail)
+  const claimRef: string = await I.createClaim(claimData, claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
 
   helperSteps.finishResponse(claimRef, defendantEmail, PartyType.INDIVIDUAL, DefenceType.PART_ADMISSION)
 })

--- a/src/integration-test/tests/citizen/defence/full_admission_test.ts
+++ b/src/integration-test/tests/citizen/defence/full_admission_test.ts
@@ -12,7 +12,7 @@ const defenceSteps: DefenceSteps = new DefenceSteps()
 
 Feature('Fully admit all of the claim').retry(3)
 
-Before(async (I: I) => {
+async function prepareClaim (I: I) {
   const claimantEmail: string = await I.createCitizenUser()
   const defendantEmail: string = await I.createCitizenUser()
 
@@ -22,16 +22,22 @@ Before(async (I: I) => {
   await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.linkClaimToDefendant(defendantEmail)
   helperSteps.startResponseFromDashboard(claimRef)
-})
+}
 
-Scenario('I can complete the journey when I fully admit all of the claim with immediate payment @citizen', (I: I) => {
+Scenario('I can complete the journey when I fully admit all of the claim with immediate payment @citizen', async (I: I) => {
+  await prepareClaim(I)
+
   defenceSteps.makeFullAdmission(PartyType.INDIVIDUAL, PaymentOption.IMMEDIATELY)
 })
 
-Scenario('I can complete the journey when I fully admit all of the claim with full payment by set date @citizen', (I: I) => {
+Scenario('I can complete the journey when I fully admit all of the claim with full payment by set date @citizen', async (I: I) => {
+  await prepareClaim(I)
+
   defenceSteps.makeFullAdmission(PartyType.INDIVIDUAL, PaymentOption.BY_SET_DATE)
 })
 
-Scenario('I can complete the journey when I fully admit all of the claim with full payment by instalments @citizen', (I: I) => {
+Scenario('I can complete the journey when I fully admit all of the claim with full payment by instalments @citizen', async (I: I) => {
+  await prepareClaim(I)
+
   defenceSteps.makeFullAdmission(PartyType.INDIVIDUAL, PaymentOption.INSTALMENTS)
 })

--- a/src/integration-test/tests/citizen/defence/full_admission_test.ts
+++ b/src/integration-test/tests/citizen/defence/full_admission_test.ts
@@ -12,26 +12,26 @@ const defenceSteps: DefenceSteps = new DefenceSteps()
 
 Feature('Fully admit all of the claim').retry(3)
 
-Before(function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Before(async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
   const claimData: ClaimData = createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL)
-  const claimRef: string = yield I.createClaim(claimData, claimantEmail)
+  const claimRef: string = await I.createClaim(claimData, claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.linkClaimToDefendant(defendantEmail)
   helperSteps.startResponseFromDashboard(claimRef)
 })
 
-Scenario('I can complete the journey when I fully admit all of the claim with immediate payment @citizen', function* (I: I) {
+Scenario('I can complete the journey when I fully admit all of the claim with immediate payment @citizen', (I: I) => {
   defenceSteps.makeFullAdmission(PartyType.INDIVIDUAL, PaymentOption.IMMEDIATELY)
 })
 
-Scenario('I can complete the journey when I fully admit all of the claim with full payment by set date @citizen', function* (I: I) {
+Scenario('I can complete the journey when I fully admit all of the claim with full payment by set date @citizen', (I: I) => {
   defenceSteps.makeFullAdmission(PartyType.INDIVIDUAL, PaymentOption.BY_SET_DATE)
 })
 
-Scenario('I can complete the journey when I fully admit all of the claim with full payment by instalments @citizen', function* (I: I) {
+Scenario('I can complete the journey when I fully admit all of the claim with full payment by instalments @citizen', (I: I) => {
   defenceSteps.makeFullAdmission(PartyType.INDIVIDUAL, PaymentOption.INSTALMENTS)
 })

--- a/src/integration-test/tests/citizen/defence/part_admission_test.ts
+++ b/src/integration-test/tests/citizen/defence/part_admission_test.ts
@@ -10,18 +10,18 @@ const defenceSteps: DefenceSteps = new DefenceSteps()
 
 Feature('Partially admit the claim').retry(3)
 
-Before(function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Before(async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
   const claimData: ClaimData = createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL)
-  const claimRef: string = yield I.createClaim(claimData, claimantEmail)
+  const claimRef: string = await I.createClaim(claimData, claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.linkClaimToDefendant(defendantEmail)
   helperSteps.startResponseFromDashboard(claimRef)
 })
 
-Scenario('I can complete the journey when I partially admit the claim with payment already made @citizen', function* (I: I) {
+Scenario('I can complete the journey when I partially admit the claim with payment already made @citizen', (I: I) => {
   defenceSteps.makePartialAdmission(PartyType.INDIVIDUAL)
 })

--- a/src/integration-test/tests/citizen/defence/part_admission_test.ts
+++ b/src/integration-test/tests/citizen/defence/part_admission_test.ts
@@ -10,7 +10,7 @@ const defenceSteps: DefenceSteps = new DefenceSteps()
 
 Feature('Partially admit the claim').retry(3)
 
-Before(async (I: I) => {
+async function prepareClaim (I: I) {
   const claimantEmail: string = await I.createCitizenUser()
   const defendantEmail: string = await I.createCitizenUser()
 
@@ -20,8 +20,10 @@ Before(async (I: I) => {
   await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.linkClaimToDefendant(defendantEmail)
   helperSteps.startResponseFromDashboard(claimRef)
-})
+}
 
-Scenario('I can complete the journey when I partially admit the claim with payment already made @citizen', (I: I) => {
+Scenario('I can complete the journey when I partially admit the claim with payment already made @citizen', async (I: I) => {
+  await prepareClaim(I)
+
   defenceSteps.makePartialAdmission(PartyType.INDIVIDUAL)
 })

--- a/src/integration-test/tests/citizen/endToEnd/endToend_test.ts
+++ b/src/integration-test/tests/citizen/endToEnd/endToend_test.ts
@@ -8,62 +8,62 @@ const helperSteps: Helper = new Helper()
 Feature('E2E tests for Claim and Defence response').retry(3)
 
 // Warning : Changing the text description of this scenario, could cause failure when running ZAP security test
-Scenario('I can as an Individual make a claim against an Individual Without a defendant email address and are able to pay on the Gov Pay page @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can as an Individual make a claim against an Individual Without a defendant email address and are able to pay on the Gov Pay page @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
-  const claimRef: string = yield I.createClaim(createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL, false), claimantEmail)
+  const claimRef: string = await I.createClaim(createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL, false), claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.finishResponse(claimRef, defendantEmail, PartyType.INDIVIDUAL)
 })
 
-Scenario('I can as Sole Trader make a claim against an Individual and are able to pay on the Gov Pay page @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail = yield I.createCitizenUser()
+Scenario('I can as Sole Trader make a claim against an Individual and are able to pay on the Gov Pay page @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail = await I.createCitizenUser()
 
-  const claimRef = yield I.createClaim(createClaimData(PartyType.SOLE_TRADER, PartyType.INDIVIDUAL), claimantEmail)
+  const claimRef = await I.createClaim(createClaimData(PartyType.SOLE_TRADER, PartyType.INDIVIDUAL), claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.finishResponse(claimRef, defendantEmail, PartyType.INDIVIDUAL)
 })
 
-Scenario('I can as a Company make a claim against an Individual and are able to pay on the Gov Pay page @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can as a Company make a claim against an Individual and are able to pay on the Gov Pay page @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
-  const claimRef: string = yield I.createClaim(createClaimData(PartyType.COMPANY, PartyType.INDIVIDUAL), claimantEmail)
+  const claimRef: string = await I.createClaim(createClaimData(PartyType.COMPANY, PartyType.INDIVIDUAL), claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.finishResponse(claimRef, defendantEmail, PartyType.INDIVIDUAL)
 })
 
-Scenario('I can as a Individual make a claim against a Company and are able to pay on the Gov Pay page @citizen @quick', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can as a Individual make a claim against a Company and are able to pay on the Gov Pay page @citizen @quick', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
-  const claimRef: string = yield I.createClaim(createClaimData(PartyType.INDIVIDUAL, PartyType.COMPANY), claimantEmail)
+  const claimRef: string = await I.createClaim(createClaimData(PartyType.INDIVIDUAL, PartyType.COMPANY), claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.finishResponse(claimRef, defendantEmail, PartyType.COMPANY)
 })
 
-Scenario('I can as a Company make a claim against a company and are able to pay on the Gov Pay page @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can as a Company make a claim against a company and are able to pay on the Gov Pay page @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
-  const claimRef: string = yield I.createClaim(createClaimData(PartyType.COMPANY, PartyType.COMPANY), claimantEmail)
+  const claimRef: string = await I.createClaim(createClaimData(PartyType.COMPANY, PartyType.COMPANY), claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.finishResponse(claimRef, defendantEmail, PartyType.COMPANY)
 })
 
-Scenario('I can as a Organisation make a claim against an Individual and are able to pay on the Gov Pay page @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can as a Organisation make a claim against an Individual and are able to pay on the Gov Pay page @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
-  const claimRef: string = yield I.createClaim(createClaimData(PartyType.ORGANISATION, PartyType.INDIVIDUAL), claimantEmail)
+  const claimRef: string = await I.createClaim(createClaimData(PartyType.ORGANISATION, PartyType.INDIVIDUAL), claimantEmail)
 
-  yield helperSteps.enterPinNumber(claimRef, claimantEmail)
+  await helperSteps.enterPinNumber(claimRef, claimantEmail)
   helperSteps.finishResponse(claimRef, defendantEmail, PartyType.INDIVIDUAL)
 })

--- a/src/integration-test/tests/citizen/govukAccessRoutes/respondToClaim_test.ts
+++ b/src/integration-test/tests/citizen/govukAccessRoutes/respondToClaim_test.ts
@@ -7,13 +7,13 @@ const accessRoutesSteps: AccessRoutesSteps = new AccessRoutesSteps()
 
 Feature('GovUK access routes - respond to claim').retry(3)
 
-Scenario('I can enter a CCBC reference and get sent to MCOL @citizen', function* (I: I) {
+Scenario('I can enter a CCBC reference and get sent to MCOL @citizen', (I: I) => {
   accessRoutesSteps.respondToClaimMcol()
 })
 
-Scenario('I can enter a moneyclaims reference and get sent to enter a pin @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const claimRef: string = yield I.createClaim(createClaimData(PartyType.SOLE_TRADER, PartyType.INDIVIDUAL), claimantEmail)
+Scenario('I can enter a moneyclaims reference and get sent to enter a pin @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const claimRef: string = await I.createClaim(createClaimData(PartyType.SOLE_TRADER, PartyType.INDIVIDUAL), claimantEmail)
 
   accessRoutesSteps.respondToClaimMoneyClaims(claimRef)
 })

--- a/src/integration-test/tests/citizen/govukAccessRoutes/returnToClaim_test.ts
+++ b/src/integration-test/tests/citizen/govukAccessRoutes/returnToClaim_test.ts
@@ -7,22 +7,22 @@ const accessRoutesSteps: AccessRoutesSteps = new AccessRoutesSteps()
 
 Feature('GovUK access routes - return to claim').retry(3)
 
-Scenario('I can enter a CCBC reference and get sent to MCOL @citizen', function* (I: I) {
+Scenario('I can enter a CCBC reference and get sent to MCOL @citizen', (I: I) => {
   accessRoutesSteps.returnToClaimMcol()
 })
 
-Scenario('I can enter a moneyclaims reference and login to see the dashboard @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const claimRef = yield I.createClaim(createClaimData(PartyType.SOLE_TRADER, PartyType.INDIVIDUAL), claimantEmail)
+Scenario('I can enter a moneyclaims reference and login to see the dashboard @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const claimRef = await I.createClaim(createClaimData(PartyType.SOLE_TRADER, PartyType.INDIVIDUAL), claimantEmail)
   accessRoutesSteps.returnToClaimMoneyClaims(claimRef, claimantEmail)
 })
 
-Scenario('I can select don’t have a claim number and choose to go to moneyclaims, login and see the dashboard @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  yield I.createClaim(createClaimData(PartyType.SOLE_TRADER, PartyType.INDIVIDUAL), claimantEmail)
+Scenario('I can select don’t have a claim number and choose to go to moneyclaims, login and see the dashboard @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  await I.createClaim(createClaimData(PartyType.SOLE_TRADER, PartyType.INDIVIDUAL), claimantEmail)
   accessRoutesSteps.dontHaveAReferenceMoneyClaims(claimantEmail)
 })
 
-Scenario('I can select don’t have a claim number and choose to go to MCOL @citizen', function* (I: I) {
+Scenario('I can select don’t have a claim number and choose to go to MCOL @citizen', (I: I) => {
   accessRoutesSteps.dontHaveAReferenceMcol()
 })

--- a/src/integration-test/tests/citizen/offers/offers_test.ts
+++ b/src/integration-test/tests/citizen/offers/offers_test.ts
@@ -9,11 +9,11 @@ const offerSteps: OfferSteps = new OfferSteps()
 
 Feature('Offers').retry(3)
 
-Scenario('I can as a defendant make an offer, accept offer and counter sign the agreement @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can as a defendant make an offer, accept offer and counter sign the agreement @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
-  const claimRef: string = yield I.createClaim(createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL), claimantEmail)
+  const claimRef: string = await I.createClaim(createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL), claimantEmail)
 
   I.linkDefendantToClaim(claimRef, claimantEmail, defendantEmail)
   I.respondToClaim(claimRef, claimantEmail, createResponseData(PartyType.INDIVIDUAL), defendantEmail)
@@ -33,11 +33,11 @@ Scenario('I can as a defendant make an offer, accept offer and counter sign the 
   I.see('You’ve both signed a legal agreement. The claim is now settled.')
 })
 
-Scenario('I can make an offer as a defendant to a claimant and have the claimant reject it @citizen', function* (I: I) {
-  const claimantEmail: string = yield I.createCitizenUser()
-  const defendantEmail: string = yield I.createCitizenUser()
+Scenario('I can make an offer as a defendant to a claimant and have the claimant reject it @citizen', async (I: I) => {
+  const claimantEmail: string = await I.createCitizenUser()
+  const defendantEmail: string = await I.createCitizenUser()
 
-  const claimRef: string = yield I.createClaim(createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL), claimantEmail)
+  const claimRef: string = await I.createClaim(createClaimData(PartyType.INDIVIDUAL, PartyType.INDIVIDUAL), claimantEmail)
 
   I.linkDefendantToClaim(claimRef, claimantEmail, defendantEmail)
   I.respondToClaim(claimRef, claimantEmail, createResponseData(PartyType.INDIVIDUAL), defendantEmail)

--- a/src/integration-test/tests/citizen/testingSupport/testingSupport_test.ts
+++ b/src/integration-test/tests/citizen/testingSupport/testingSupport_test.ts
@@ -12,8 +12,8 @@ const claimantCheckAndSendPage: ClaimantCheckAndSendPage = new ClaimantCheckAndS
 
 Feature('Testing support').retry(3)
 
-Scenario('I create a claim draft using testing support and submit it @citizen', function* (I: I) {
-  const email: string = yield I.createCitizenUser()
+Scenario('I create a claim draft using testing support and submit it @citizen', async (I: I) => {
+  const email: string = await I.createCitizenUser()
 
   userSteps.login(email)
   testingSupportSteps.createClaimDraft()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
       "es2017.object",
       "dom"
     ],
-    "target": "es6",
+    "target": "es2017",
     "module": "commonjs",
     "baseUrl": "src" ,
     "paths": {

--- a/types/steps-override.d.ts
+++ b/types/steps-override.d.ts
@@ -6,9 +6,9 @@ declare const Feature: (string: string) => Feature;
 
 declare namespace CodeceptJS {
   export interface I {
-    createCitizenUser: () => string
-    createSolicitorUser: () => string
-    createClaim: (claimData: ClaimData, submitterEmail: string) => string
+    createCitizenUser: () => Promise[string]
+    createSolicitorUser: () => Promise[string]
+    createClaim: (claimData: ClaimData, submitterEmail: string) => Promise[string]
     linkDefendantToClaim: (claimRef: string, claimantEmail: string, defendantEmail: string) => void
     respondToClaim: (referenceNumber: string, ownerEmail: string, responseData: ResponseData, defendantEmail: string) => void
     retrievePin (letterHolderId: string): () => string

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,10 +753,10 @@ async@^1.4.0:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 async@^2.0.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
-    lodash "^4.14.0"
+    lodash "^4.17.10"
 
 async@~1.0.0:
   version "1.0.0"
@@ -770,9 +770,9 @@ atob@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
 
-atob@~1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
+atob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -822,6 +822,10 @@ bach@^1.0.0:
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+base64-js@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
 
 base64url@2.0.0, base64url@^2.0.0:
   version "2.0.0"
@@ -996,6 +1000,17 @@ browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
 
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
+
+buffer-alloc@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
+  dependencies:
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
+
 buffer-crc32@^0.2.1, buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -1007,6 +1022,10 @@ buffer-equal-constant-time@1.0.1:
 buffer-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
+
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
 
 buffer-from@^1.0.0:
   version "1.0.0"
@@ -1024,6 +1043,13 @@ buffer-to-vinyl@^1.0.0:
     readable-stream "^2.0.2"
     uuid "^2.0.1"
     vinyl "^1.0.0"
+
+buffer@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.1.0.tgz#c913e43678c7cb7c8bd16afbcddb6c5505e8f9fe"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 build-url@^1.0.9:
   version "1.0.10"
@@ -1619,8 +1645,10 @@ crc32-stream@^2.0.0:
     readable-stream "^2.0.0"
 
 crc@^3.4.4:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/crc/-/crc-3.5.0.tgz#98b8ba7d489665ba3979f59b21381374101a1964"
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/crc/-/crc-3.7.0.tgz#58b7083e32ba4b276e1f4cbce1a78b39a6ab63f9"
+  dependencies:
+    buffer "^5.1.0"
 
 create-error-class@^3.0.0, create-error-class@^3.0.1:
   version "3.0.2"
@@ -1678,7 +1706,7 @@ csrf@~3.0.3:
     tsscmp "1.0.5"
     uid-safe "2.1.4"
 
-css-parse@~2.0.0:
+css-parse@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/css-parse/-/css-parse-2.0.0.tgz#a468ee667c16d81ccf05c58c38d2a97c780dbfd4"
   dependencies:
@@ -1696,12 +1724,12 @@ css-value@~0.0.1:
   resolved "https://registry.yarnpkg.com/css-value/-/css-value-0.0.1.tgz#5efd6c2eea5ea1fd6b6ac57ec0427b18452424ea"
 
 css@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/css/-/css-2.2.1.tgz#73a4c81de85db664d4ee674f7d47085e3b2d55dc"
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.3.tgz#f861f4ba61e79bedc962aa548e5780fd95cbc6be"
   dependencies:
     inherits "^2.0.1"
     source-map "^0.1.38"
-    source-map-resolve "^0.3.0"
+    source-map-resolve "^0.5.1"
     urix "^0.1.0"
 
 csurf@^1.9.0:
@@ -2120,8 +2148,8 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 ejs@~2.5.6:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
+  version "2.5.9"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.9.tgz#7ba254582a560d267437109a68354112475b0ce5"
 
 encodeurl@~1.0.1:
   version "1.0.1"
@@ -2774,6 +2802,10 @@ front-matter@2.1.2:
   dependencies:
     js-yaml "^3.4.6"
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+
 fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
@@ -2864,9 +2896,15 @@ gaze@^0.5.1:
   dependencies:
     globule "~0.1.0"
 
-gaze@^1.0.0, gaze@~1.1.2:
+gaze@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/gaze/-/gaze-1.1.2.tgz#847224677adb8870d679257ed3388fdb61e40105"
+  dependencies:
+    globule "^1.0.0"
+
+gaze@~1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/gaze/-/gaze-1.1.3.tgz#c441733e13b927ac8c0ff0b4c3b033f28812924a"
   dependencies:
     globule "^1.0.0"
 
@@ -3663,6 +3701,10 @@ iconv-lite@~0.4.11:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.1.4:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
 
 ienoopen@1.0.0:
   version "1.0.0"
@@ -4689,7 +4731,11 @@ lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.3:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^4.14.0, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.4:
+lodash@^4.17.10, lodash@^4.8.0:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
+lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -6199,6 +6245,18 @@ readable-stream@^2.0.1, readable-stream@^2.0.4, readable-stream@^2.2.2:
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
+readable-stream@^2.3.0:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
 readable-stream@~1.1.9:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
@@ -6356,7 +6414,7 @@ request-promise@^4.x:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@2, request@^2.74.0, request@^2.81.0, request@^2.83.0, request@~2.83.0:
+request@2, request@^2.74.0, request@^2.81.0, request@^2.83.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:
@@ -6486,7 +6544,7 @@ resolve-options@^1.1.0:
   dependencies:
     value-or-function "^3.0.0"
 
-resolve-url@^0.2.1, resolve-url@~0.2.1:
+resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
@@ -6522,9 +6580,9 @@ retry@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
 
-rgb2hex@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/rgb2hex/-/rgb2hex-0.1.0.tgz#ccd55f860ae0c5c4ea37504b958e442d8d12325b"
+rgb2hex@~0.1.4:
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/rgb2hex/-/rgb2hex-0.1.9.tgz#5d3e0e14b0177b568e6f0d5b43e34fbfdb670346"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -6845,20 +6903,21 @@ sonarqube-scanner@^2.0.1:
     read-pkg "2.0.0"
     slug "0.9.1"
 
-source-map-resolve@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.3.1.tgz#610f6122a445b8dd51535a2a71b783dfc1248761"
-  dependencies:
-    atob "~1.1.0"
-    resolve-url "~0.2.1"
-    source-map-url "~0.3.0"
-    urix "~0.1.0"
-
 source-map-resolve@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
   dependencies:
     atob "^2.0.0"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
+source-map-resolve@^0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
+  dependencies:
+    atob "^2.1.1"
     decode-uri-component "^0.2.0"
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
@@ -6874,10 +6933,6 @@ source-map-support@^0.5.6:
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
-
-source-map-url@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
 
 source-map@^0.1.38:
   version "0.1.43"
@@ -7054,6 +7109,12 @@ string_decoder@~0.10.x:
 string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -7249,13 +7310,25 @@ tar-pack@^3.4.0:
     tar "^2.2.1"
     uid-number "^0.0.6"
 
-tar-stream@^1.1.1, tar-stream@^1.5.0:
+tar-stream@^1.1.1:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.5.tgz#5cad84779f45c83b1f2508d96b09d88c7218af55"
   dependencies:
     bl "^1.0.0"
     end-of-stream "^1.0.0"
     readable-stream "^2.0.0"
+    xtend "^4.0.0"
+
+tar-stream@^1.5.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.1.tgz#f84ef1696269d6223ca48f6e1eeede3f7e81f395"
+  dependencies:
+    bl "^1.0.0"
+    buffer-alloc "^1.1.0"
+    end-of-stream "^1.0.0"
+    fs-constants "^1.0.0"
+    readable-stream "^2.3.0"
+    to-buffer "^1.1.0"
     xtend "^4.0.0"
 
 tar@^2.0.0, tar@^2.2.1:
@@ -7373,6 +7446,10 @@ to-absolute-glob@^2.0.0:
 to-boolean@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/to-boolean/-/to-boolean-1.0.0.tgz#840653cc95abde6ae7fa259e7d74868a91232e3f"
+
+to-buffer@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -7695,7 +7772,7 @@ update-notifier@^2.3.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-urix@^0.1.0, urix@~0.1.0:
+urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
 
@@ -7930,16 +8007,16 @@ ware@^1.2.0:
     wrap-fn "^0.1.0"
 
 wdio-dot-reporter@~0.0.8:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/wdio-dot-reporter/-/wdio-dot-reporter-0.0.9.tgz#929b2adafd49d6b0534fda068e87319b47e38fe5"
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/wdio-dot-reporter/-/wdio-dot-reporter-0.0.10.tgz#facfb7c9c5984149951f59cbc3cd0752101cf0e0"
 
-webdriverio@^4.11.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-4.12.0.tgz#e340def272183c8168a4dd0b382322f9d7bee10d"
+webdriverio@^4.13.1:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-4.13.1.tgz#624ef4ca569f3c9a5e8e9b11302b4431eda1fb8a"
   dependencies:
     archiver "~2.1.0"
     babel-runtime "^6.26.0"
-    css-parse "~2.0.0"
+    css-parse "^2.0.0"
     css-value "~0.0.1"
     deepmerge "~2.0.1"
     ejs "~2.5.6"
@@ -7951,8 +8028,8 @@ webdriverio@^4.11.0:
     npm-install-package "~2.1.0"
     optimist "~0.6.1"
     q "~1.5.0"
-    request "~2.83.0"
-    rgb2hex "~0.1.0"
+    request "^2.83.0"
+    rgb2hex "~0.1.4"
     safe-buffer "~5.1.1"
     supports-color "~5.0.0"
     url "~0.11.0"


### PR DESCRIPTION
### JIRA link

None

### Change description

The main change is to replace scenario hooks with regular method calls as failures in hooks are not eligible for retries. Unfortunately to enable these method calls I needed to use async / await approach, otherwise I was getting wired results.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No