### PR TITLE
[PREVIEW] Fix check-and-send page for partial admission

### DIFF
--- a/src/main/features/response/views/check-and-send.njk
+++ b/src/main/features/response/views/check-and-send.njk
@@ -154,51 +154,47 @@
         )
       }}
 
-      {{
-        timelineCheckAndSend(
-          header = 'Timeline of what happened (optional)',
-          timeline = draft.partialAdmission.timeline.getPopulatedRowsOnly(),
-          url = ResponsePaths.timelinePage.evaluateUri({ externalId: claim.externalId }),
-          bottomBorder = false
-        )
-      }}
-      {{ row(label = 'Comments about their timeline (optional)', value = draft.partialAdmission.timeline.comment | default(''), bold = true) }}
-
-      {{
-        evidenceCheckAndSend(
-          header = 'Your evidence (optional)',
-          evidence = draft.partialAdmission.evidence.getPopulatedRowsOnly(),
-          url = ResponsePaths.evidencePage.evaluateUri({ externalId: claim.externalId }),
-          bottomBorder = false
-        )
-      }}
-
-      {{ row(label = 'Comments about their evidence (optional)', value = draft.partialAdmission.evidence.comment | default(''), bold = true) }}
-
-      {% if draft.partialAdmission.paymentOption.isOfType(DefendantPaymentType.IMMEDIATELY) %}
-        {{ tableStart('whenWillYouPay', 'When you’ll pay') }}
-
+      {% if draft.isResponsePartiallyAdmittedAndAlreadyPaid() %}
         {{
-          whenWillYouPayRow(
-            value = t(draft.partialAdmission.paymentOption.option.displayValue) | capitalize,
-            url = PartAdmissionPaths.paymentOptionPage.evaluateUri({ externalId: claim.externalId })
+          timelineCheckAndSend(
+            header = 'Timeline of what happened (optional)',
+            timeline = draft.partialAdmission.timeline.getPopulatedRowsOnly(),
+            url = ResponsePaths.timelinePage.evaluateUri({ externalId: claim.externalId }),
+            bottomBorder = false
           )
         }}
-        {{ tableEnd() }}
-
+        {{ row(label = 'Comments about their timeline (optional)', value = draft.partialAdmission.timeline.comment | default(''), bold = true) }}
+        {{
+          evidenceCheckAndSend(
+            header = 'Your evidence (optional)',
+            evidence = draft.partialAdmission.evidence.getPopulatedRowsOnly(),
+            url = ResponsePaths.evidencePage.evaluateUri({ externalId: claim.externalId }),
+            bottomBorder = false
+          )
+        }}
+        {{ row(label = 'Comments about their evidence (optional)', value = draft.partialAdmission.evidence.comment | default(''), bold = true) }}
       {% else %}
-
-        {{
-          notImmediatePayment(
-            type = draft.partialAdmission.paymentOption,
-            paymentDate = draft.partialAdmission.paymentDate,
-            paymentPlan = draft.partialAdmission.paymentPlan,
-            explanation = draft.statementOfMeans.explanation.text,
-            Paths = PartAdmissionPaths,
-            externalId = claim.externalId
-          )
-        }}
-
+        {% if draft.partialAdmission.paymentOption.isOfType(DefendantPaymentType.IMMEDIATELY) %}
+          {{ tableStart('whenWillYouPay', 'When you’ll pay') }}
+          {{
+            whenWillYouPayRow(
+              value = t(draft.partialAdmission.paymentOption.option.displayValue) | capitalize,
+              url = PartAdmissionPaths.paymentOptionPage.evaluateUri({ externalId: claim.externalId })
+            )
+          }}
+          {{ tableEnd() }}
+        {% else %}
+          {{
+            notImmediatePayment(
+              type = draft.partialAdmission.paymentOption,
+              paymentDate = draft.partialAdmission.paymentDate,
+              paymentPlan = draft.partialAdmission.paymentPlan,
+              explanation = draft.statementOfMeans.explanation.text,
+              Paths = PartAdmissionPaths,
+              externalId = claim.externalId
+            )
+          }}
+        {% endif %}
       {% endif %}
     {% endif %}
 


### PR DESCRIPTION
### JIRA link

None

### Change description

The fix displays payemnt details only when amount has bot been paid.
In remaining cases just timeline and evindence is displayed.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No