### PR TITLE
[PREVIEW] - ROC-3971 Added white space

### DIFF
--- a/src/main/views/macro/externalLink.njk
+++ b/src/main/views/macro/externalLink.njk
@@ -1,4 +1,3 @@
 {% macro externalLink(text, href) %}
   <a href="{{ href }}" target="_blank">{{ text }}</a>
-  <span class="font-xsmall">{{ t('(opens in a new window)') }}</span>
-{% endmacro %}
+  <span class="font-xsmall">{{ t('(opens in a new window)') }}</span>{% endmacro %}


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-3971


### Change description
As the macro returns the entire contents before the endmacro tag it is including the carriage return which is being turned into a space character in the html thus leading to an extra space when used inline.


### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
