### PR TITLE
Add claimant response draft deletion

### DIFF
--- a/src/main/features/testing-support/views/delete-drafts.njk
+++ b/src/main/features/testing-support/views/delete-drafts.njk
@@ -19,6 +19,9 @@
         <div class="notice">
           {{ linkButton('Delete ccj drafts', 'action[ccj]', 'button button-secondary') }}
         </div>
+        <div class="notice">
+          {{ linkButton('Delete claimant response drafts', 'action[claimantResponse]', 'button button-secondary') }}
+        </div>
       </form>
     </div>
   </div>


### PR DESCRIPTION
Allows to delete claimant response drafts from the UI, missed during project setup