### PR TITLE
Add missing payment intention for defendant offer

### DIFF
--- a/src/main/features/claimant-response/helpers/settlementHelper.ts
+++ b/src/main/features/claimant-response/helpers/settlementHelper.ts
@@ -47,14 +47,14 @@ export function prepareDefendantOffer (claim: Claim, paymentPlan: PaymentPlan): 
   if (response.paymentIntention.paymentDate) {
     const completionDate: Moment = response.paymentIntention.paymentDate
     const content: string = `${response.defendant.name} will pay the full amount, no later than ${MomentFormatter.formatLongDate(completionDate)}`
-    return new Offer(content, completionDate)
+    return new Offer(content, completionDate, response.paymentIntention)
   } else if (response.paymentIntention.repaymentPlan) {
     const instalmentAmount: string = NumberFormatter.formatMoney(response.paymentIntention.repaymentPlan.instalmentAmount)
     const paymentSchedule: string = PaymentScheduleTypeViewFilter.render(response.paymentIntention.repaymentPlan.paymentSchedule)
     const firstPaymentDate: string = MomentFormatter.formatLongDate(response.paymentIntention.repaymentPlan.firstPaymentDate)
     const completionDate: Moment = paymentPlan.getLastPaymentDate(response.paymentIntention.repaymentPlan.firstPaymentDate)
     const content: string = `${response.defendant.name} will pay instalments of ${instalmentAmount} ${paymentSchedule}. The first instalment will be paid by ${firstPaymentDate}.`
-    return new Offer(content, completionDate)
+    return new Offer(content, completionDate, response.paymentIntention)
   }
   throw new Error('Invalid paymentIntention')
 }

--- a/src/test/features/claimant-response/helpers/settlementHelper.ts
+++ b/src/test/features/claimant-response/helpers/settlementHelper.ts
@@ -34,6 +34,12 @@ describe('settlementHelper', () => {
       expect(partyStatement).is.not.undefined
       expect(partyStatement.madeBy).to.be.eql('DEFENDANT')
       expect(partyStatement.type).to.be.eql('OFFER')
+      expect(partyStatement.offer).is.not.undefined
+      expect(partyStatement.offer.paymentIntention).is.not.undefined
+      expect(partyStatement.offer.paymentIntention.paymentOption).to.be.eql('INSTALMENTS')
+      expect(partyStatement.offer.paymentIntention.repaymentPlan).is.not.undefined
+      expect(partyStatement.offer.paymentIntention.paymentDate).is.undefined
+
     })
 
     it('should return defendant party statement by set date option', () => {
@@ -45,6 +51,10 @@ describe('settlementHelper', () => {
       expect(partyStatement.offer).is.not.undefined
       expect(partyStatement.offer.content).to.be.eql('John Smith will pay the full amount, no later than 31 December 2050')
       expect(partyStatement.offer.completionDate).to.be.eql(MomentFactory.parse('2050-12-31'))
+      expect(partyStatement.offer.paymentIntention).is.not.undefined
+      expect(partyStatement.offer.paymentIntention.paymentOption).to.be.eql('BY_SPECIFIED_DATE')
+      expect(partyStatement.offer.paymentIntention.paymentDate).is.not.undefined
+      expect(partyStatement.offer.paymentIntention.repaymentPlan).is.undefined
 
     })
 


### PR DESCRIPTION
This PR adds missing `paymentIntention` in defendant offer for settlement through admissions.