### PR TITLE
ROC-4593 Allow missing court's plan when decision is CLAIMANT_IN_FAVOUR_OF_DEFENDANT

### DIFF
--- a/src/main/app/claims/converters/claimantResponseConverter.ts
+++ b/src/main/app/claims/converters/claimantResponseConverter.ts
@@ -62,9 +62,6 @@ export class ClaimantResponseConverter {
     if (draftClaimantResponse.decisionType === DecisionType.COURT && !draftClaimantResponse.courtOfferedPaymentIntention) {
       throw new Error('court offered payment intention not found where decision type is COURT')
     }
-    if (draftClaimantResponse.decisionType === DecisionType.CLAIMANT_IN_FAVOUR_OF_DEFENDANT && !draftClaimantResponse.courtCalculatedPaymentIntention) {
-      throw new Error('court calculated payment intention not found where decision type is CLAIMANT_IN_FAVOUR_OF_DEFENDANT')
-    }
     if (!draftClaimantResponse.courtCalculatedPaymentIntention || !draftClaimantResponse.courtOfferedPaymentIntention) {
       return undefined
     }

--- a/src/main/features/claimant-response/routes/payment-date.ts
+++ b/src/main/features/claimant-response/routes/payment-date.ts
@@ -117,24 +117,26 @@ class PaymentDatePage extends AbstractPaymentDatePage<DraftClaimantResponse> {
     if (decisionType === DecisionType.CLAIMANT_IN_FAVOUR_OF_DEFENDANT && draft.document.alternatePaymentMethod.paymentOption.option.value === PaymentOption.BY_SPECIFIED_DATE) {
       return undefined
     }
-
-    const courtCalculatedPaymentIntention = new PaymentIntention()
     const paymentPlan: PaymentPlan = PaymentPlanHelper.createPaymentPlanFromDefendantFinancialStatement(claim)
     if (!paymentPlan) {
       return undefined
     }
 
+    const courtCalculatedPaymentIntention = new PaymentIntention()
     courtCalculatedPaymentIntention.paymentOption = PaymentOption.BY_SPECIFIED_DATE
     courtCalculatedPaymentIntention.paymentDate = paymentPlan.calculateLastPaymentDate()
     return courtCalculatedPaymentIntention
   }
 
   async saveDraft (locals: { user: User; draft: Draft<DraftClaimantResponse>, claim: Claim }): Promise<void> {
-
     const decisionType: DecisionType = CourtDecisionHelper.createCourtDecision(locals.claim, locals.draft)
     locals.draft.document.decisionType = decisionType
-    locals.draft.document.courtCalculatedPaymentIntention = this.generateCourtCalculatedPaymentIntention(locals.draft, locals.claim, decisionType)
-    locals.draft.document.courtOfferedPaymentIntention = this.generateCourtOfferedPaymentIntention(locals.draft, locals.claim, decisionType)
+
+    const courtCalculatedPaymentIntention = this.generateCourtCalculatedPaymentIntention(locals.draft, locals.claim, decisionType)
+    if (courtCalculatedPaymentIntention) {
+      locals.draft.document.courtCalculatedPaymentIntention = courtCalculatedPaymentIntention
+      locals.draft.document.courtOfferedPaymentIntention = this.generateCourtOfferedPaymentIntention(locals.draft, locals.claim, decisionType)
+    }
 
     return super.saveDraft(locals)
   }

--- a/src/test/app/claims/converters/claimantResponseConverter.ts
+++ b/src/test/app/claims/converters/claimantResponseConverter.ts
@@ -275,13 +275,5 @@ describe('claimant response converter ', () => {
       expect(() => converter.covertToClaimantResponse(draftClaimantResponse)).to.throw(Error, errMsg)
     })
 
-    it('court calculated payment intention not found where decision type is CLAIMANT_IN_FAVOUR_OF_DEFENDANT', () => {
-      const draftClaimantResponse = createDraftClaimantResponseBaseForAcceptance(YesNoOption.NO,YesNoOption.YES)
-      draftClaimantResponse.formaliseRepaymentPlan = new FormaliseRepaymentPlan(FormaliseRepaymentPlanOption.SIGN_SETTLEMENT_AGREEMENT)
-      draftClaimantResponse.decisionType = DecisionType.CLAIMANT_IN_FAVOUR_OF_DEFENDANT
-      const errMsg = 'court calculated payment intention not found where decision type is CLAIMANT_IN_FAVOUR_OF_DEFENDANT'
-      expect(() => converter.covertToClaimantResponse(draftClaimantResponse)).to.throw(Error, errMsg)
-    })
-
   })
 })


### PR DESCRIPTION
### JIRA link
ROC-4593

### Change description
Remove error thrown when repayment plan decision is for the claimant (in favour of the defendant) and no court plan is generated

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
