### PR TITLE
ROC-4639: use correct decimal places for income expense calculation

### DIFF
--- a/src/main/public/js/income-expense-calculation.js
+++ b/src/main/public/js/income-expense-calculation.js
@@ -1,4 +1,6 @@
 $(document).ready(function () {
+  numeral.locale('en-gb')
+
   var feature = (function () {
     var config = {
       incomeExpenseCalculationApi: '/total-income-expense-calculation',
@@ -31,7 +33,7 @@ $(document).ready(function () {
     }
 
     var setTotalMonthlyIncomeExpense = function (totalAmount) {
-      totalMonthlyIncomeExpenseElement.text(totalAmount);
+      totalMonthlyIncomeExpenseElement.text(numeral(totalAmount).format('0,0[.]00'));  // £18 or £18.50
     }
 
     var csrfInputFieldElement,

--- a/src/main/public/js/income-expense-calculation.js
+++ b/src/main/public/js/income-expense-calculation.js
@@ -33,7 +33,7 @@ $(document).ready(function () {
     }
 
     var setTotalMonthlyIncomeExpense = function (totalAmount) {
-      totalMonthlyIncomeExpenseElement.text(numeral(totalAmount).format('0,0[.]00'));  // £18 or £18.50
+      totalMonthlyIncomeExpenseElement.text(numeral(totalAmount).format('0,0.00'));
     }
 
     var csrfInputFieldElement,

--- a/src/main/views/income-expense-scripts.njk
+++ b/src/main/views/income-expense-scripts.njk
@@ -1,1 +1,3 @@
+<script src="{{ asset_paths['js_vendor'] }}/numeral/numeral.min.js"></script>
+<script src="{{ asset_paths['js_vendor'] }}/numeral/locales.min.js"></script>
 <script src="{{ asset_paths['js'] }}/income-expense-calculation.js"></script>


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-4639

### Change description

Fixing income expense calculation formatting to 2 decimal places - as per prototype. Used in monthly income, priority debts and monthly expenses screens.

### Developer self-QA run statement

- [ X ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ X ] No
