### PR TITLE
ROC-4805 Directions questionnaire deadline after reject part admit

### DIFF
--- a/src/main/features/claimant-response/views/confirmation.njk
+++ b/src/main/features/claimant-response/views/confirmation.njk
@@ -59,7 +59,8 @@
           <a href="{{ DashboardPaths.directionsQuestionnairePage.evaluateUri({ externalId: claim.externalId }) }}">
              {{ t('complete a directions questionnaire form ')}}</a> {{ t('to tell us more about the claim.')}}
         </p>
-        <p>{{ t('Your claim won’t proceed if you don’t complete and return the form before {{ responseDeadline }}.', { responseDeadline: claim.responseDeadline | date }) }}</p>
+        <p>{{ t('Your claim won’t proceed if you don’t complete and return the form before {{ deadline }}.',
+            { deadline: claim.directionsQuestionnaireDeadline | date }) }}</p>
       {% endif %}
 
       {% include "includes/service_survey_link.njk" %}

--- a/src/main/features/dashboard/views/macro/claimStatus/partAdmitRejectionClaimant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/partAdmitRejectionClaimant.njk
@@ -17,7 +17,8 @@
     {% else %}
       <p>{{ t('You need to ' + internalLink('complete a directions questionnaire form ',
           DashboardPaths.directionsQuestionnairePage.evaluateUri({ externalId: claim.externalId })) + 'to tell us more about the claim.') | safe }}</p>
-      <p>{{ t('Your claim won’t proceed if you don’t complete and return the form before {{ responseDeadline }}.', { responseDeadline: claim.claimantRespondedAt | addDays(19) | date }) }}</p>
+      <p>{{ t('Your claim won’t proceed if you don’t complete and return the form before {{ deadline }}.',
+          { deadline: claim.directionsQuestionnaireDeadline | date }) }}</p>
     {% endif %}
 
     <p>{{ downloadResponseLink(claim) }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/partAdmitRejectionDefendant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/partAdmitRejectionDefendant.njk
@@ -18,7 +18,8 @@
       <p>{{ t('You might have to go to a hearing. We’ll contact you if we set a hearing date to tell you how to prepare.') }}</p>
       <p>{{ t('You need to ' + internalLink('complete a directions questionnaire form ',
           DashboardPaths.directionsQuestionnairePage.evaluateUri({ externalId: claim.externalId })) + 'to tell us more about the claim.') | safe }}</p>
-      <p>{{ t('Your defence won’t proceed if you don’t complete and return the form before {{ responseDeadline }}.', { responseDeadline: claim.claimantRespondedAt | addDays(19) | date }) }}</p>
+      <p>{{ t('Your defence won’t proceed if you don’t complete and return the form before {{ deadline }}.',
+          { deadline: claim.directionsQuestionnaireDeadline | date }) }}</p>
     {% endif %}
 
     <p>{{ downloadResponseLink(claim) }}</p>


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-4805

### Change description
Use the DB-stored directions questionnaire deadline rather than calculating it on the front-end or using the response deadline

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
