### PR TITLE
ROC-4937 Add line between end of Monthly expenses and start of Monthly income

### DIFF
--- a/src/main/features/response/views/statement-of-means/check-and-send.njk
+++ b/src/main/features/response/views/statement-of-means/check-and-send.njk
@@ -255,7 +255,7 @@
 {% endif %}
 
 {% set income = draft.statementOfMeans.monthlyIncome %}
-{{ row('Monthly income', '', StatementOfMeansPaths.monthlyIncomePage.evaluateUri({ externalId: claim.externalId }), false, bold = true) }}
+{{ row('Monthly income', '', StatementOfMeansPaths.monthlyIncomePage.evaluateUri({ externalId: claim.externalId }), topBorder = true, bottomBorder = false, bold = true) }}
 {% if income.salarySource.populated %}
   {{ row(MonthlyIncomeType.JOB.displayValue | capitalize, income.salarySource.amount | numeral, '', false, bold = true) }}
 {% endif %}


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-4937

### Change description
Add `topBorder` to the monthly income header row so that it's separated from expenses regardless of which expense item comes last.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [x] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
