### PR TITLE
ROC-4956 - show court repayment plan when courts offer accepted

### DIFF
--- a/src/main/app/claims/models/settlement.ts
+++ b/src/main/app/claims/models/settlement.ts
@@ -40,6 +40,17 @@ export class Settlement {
     return partyStatement ? partyStatement.offer : undefined
   }
 
+  isLastOfferMadeByCourt (): boolean {
+    if (!this.partyStatements) {
+      return undefined
+    }
+
+    const partyStatement: PartyStatement = this.partyStatements.reverse()
+      .find(statement => statement.type === StatementType.OFFER.value)
+
+    return partyStatement ? partyStatement.madeBy === MadeBy.COURT.value : undefined
+  }
+
   isOfferAccepted (): boolean {
     if (!this.partyStatements) {
       return false

--- a/src/main/features/offer/form/models/madeBy.ts
+++ b/src/main/features/offer/form/models/madeBy.ts
@@ -1,6 +1,7 @@
 export class MadeBy {
   static readonly CLAIMANT = new MadeBy('CLAIMANT', 'Claimant')
   static readonly DEFENDANT = new MadeBy('DEFENDANT', 'Defendant')
+  static readonly COURT = new MadeBy('COURT', 'Court')
 
   readonly value: string
   readonly displayValue: string

--- a/src/main/features/settlement-agreement/routes/repayment-plan-summary.ts
+++ b/src/main/features/settlement-agreement/routes/repayment-plan-summary.ts
@@ -10,13 +10,14 @@ import { PaymentIntention } from 'main/app/claims/models/response/core/paymentIn
 function renderView (form: Form<PaidAmount>, req: express.Request, res: express.Response): void {
   const claim: Claim = res.locals.claim
   let paymentIntention: PaymentIntention = claim.settlement.getLastOffer().paymentIntention
-
+  let isPaymentIntentionMadeByCourt: boolean = claim.settlement.isLastOfferMadeByCourt()
   const amountPaid = claim.claimantResponse && claim.claimantResponse.amountPaid ? claim.claimantResponse.amountPaid : 0
 
   res.render(Paths.repaymentPlanSummary.associatedView, {
     form: form,
     claim: claim,
     paymentIntention: paymentIntention,
+    isPaymentIntentionMadeByCourt: isPaymentIntentionMadeByCourt,
     remainingAmountToPay: claim.totalAmountTillDateOfIssue - amountPaid,
     requestedBy: req.params.madeBy
   })

--- a/src/main/features/settlement-agreement/views/repayment-plan-summary.njk
+++ b/src/main/features/settlement-agreement/views/repayment-plan-summary.njk
@@ -3,25 +3,46 @@
 {% from "form.njk" import csrfProtection, submitButton %}
 {% from "paymentPlanTable.njk" import paymentPlanTable %}
 
-{% set heading = 'The claimant’s repayment plan' %}
+{% set heading = 'The court’s repayment plan' if isPaymentIntentionMadeByCourt else 'The claimant’s repayment plan' %}
 {% block content %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% if paymentIntention.paymentOption === domain.PaymentOption.INSTALMENTS %}
-      <p>{{ t('They’ve suggested this repayment plan based on the financial details you gave:') }}</p>
-      {{ paymentPlanTable(
-        id = 'payment-table',
-        instalmentAmount = paymentIntention.repaymentPlan.instalmentAmount,
-        paymentSchedule = paymentIntention.repaymentPlan.paymentSchedule,
-        firstPaymentDate = paymentIntention.repaymentPlan.firstPaymentDate,
-        completionDate = paymentIntention.repaymentPlan.completionDate,
-        paymentLength = paymentIntention.repaymentPlan.paymentLength
-      ) }}
-      {% elseif paymentIntention.paymentOption === domain.PaymentOption.BY_SPECIFIED_DATE or paymentIntention.paymentOption === domain.PaymentOption.IMMEDIATELY %}
-          <p>{{ t('They’ve suggested you pay in full by {{ paymentDate }}.', { amount: remainingAmountToPay | numeral, paymentDate: paymentIntention.paymentDate | date }) }}
+      {% if isPaymentIntentionMadeByCourt %}
+        {% if paymentIntention.paymentOption === domain.PaymentOption.INSTALMENTS %}
+          <p>{{ t('The court has suggested this repayment plan based on the financial details you gave:') }}</p>
+          {{ paymentPlanTable(
+            id = 'payment-table',
+            instalmentAmount = paymentIntention.repaymentPlan.instalmentAmount,
+            paymentSchedule = paymentIntention.repaymentPlan.paymentSchedule,
+            firstPaymentDate = paymentIntention.repaymentPlan.firstPaymentDate,
+            completionDate = paymentIntention.repaymentPlan.completionDate,
+            paymentLength = paymentIntention.repaymentPlan.paymentLength
+          ) }}
+        {% elseif paymentIntention.paymentOption === domain.PaymentOption.BY_SPECIFIED_DATE or paymentIntention.paymentOption === domain.PaymentOption.IMMEDIATELY %}
           <p>
+            {{ t('They’ve suggested you pay in full by {{ paymentDate }}.', { amount: remainingAmountToPay | numeral, paymentDate: paymentIntention.paymentDate | date }) }}
+          </p>
+        {% endif %}
+        <p>{{ t('The claimant has agreed to the court’s plan and signed a settlement agreement based on the plan. You can choose to sign the agreement or not') }}</p>
+      {% else %}
+        {% if paymentIntention.paymentOption === domain.PaymentOption.INSTALMENTS %}
+          <p>{{ t('They’ve suggested this repayment plan based on the financial details you gave:') }}</p>
+          {{ paymentPlanTable(
+            id = 'payment-table',
+            instalmentAmount = paymentIntention.repaymentPlan.instalmentAmount,
+            paymentSchedule = paymentIntention.repaymentPlan.paymentSchedule,
+            firstPaymentDate = paymentIntention.repaymentPlan.firstPaymentDate,
+            completionDate = paymentIntention.repaymentPlan.completionDate,
+            paymentLength = paymentIntention.repaymentPlan.paymentLength
+          ) }}
+        {% elseif paymentIntention.paymentOption === domain.PaymentOption.BY_SPECIFIED_DATE or paymentIntention.paymentOption === domain.PaymentOption.IMMEDIATELY %}
+          <p>
+            {{ t('They’ve suggested you pay in full by {{ paymentDate }}.', { amount: remainingAmountToPay | numeral, paymentDate: paymentIntention.paymentDate | date }) }}
+          </p>
+        {% endif %}
+        <p>{{ t('The claimant signed a settlement agreement based on their plan. You can choose to sign the agreement or not.') }}</p>
       {% endif %}
-      <p>{{ t('The claimant signed a settlement agreement based on their plan. You can choose to sign the agreement or not.') }}</p>
+
       <p>{{ internalLink(t('Respond to settlement agreement'), SettlementAgreementPaths.signSettlementAgreement.evaluateUri({ externalId: claim.externalId }), "button") }}</p>
       <p>{{ t('If you do not respond, the claimant can request a County Court Judgment against you.') }}
     </div>

--- a/src/test/features/settlement-agreement/routes/repayment-plan-summary.ts
+++ b/src/test/features/settlement-agreement/routes/repayment-plan-summary.ts
@@ -1,0 +1,85 @@
+import { expect } from 'chai'
+import * as request from 'supertest'
+import * as config from 'config'
+
+import 'test/routes/expectations'
+import { attachDefaultHooks } from 'test/routes/hooks'
+
+import { checkAuthorizationGuards } from 'test/features/claimant-response/routes/checks/authorization-check'
+
+import { app } from 'main/app'
+
+import * as idamServiceMock from 'test/http-mocks/idam'
+import * as claimStoreServiceMock from 'test/http-mocks/claim-store'
+import * as settlementAgreementServiceMock from 'test/http-mocks/settlement-agreement'
+
+import { Paths } from 'settlement-agreement/paths'
+
+const cookieName: string = config.get<string>('session.cookieName')
+const externalId = claimStoreServiceMock.sampleClaimObj.externalId
+const pagePath = Paths.repaymentPlanSummary.evaluateUri({ externalId: externalId })
+
+describe('Settlement agreement: repayment plan summary page', () => {
+  attachDefaultHooks(app)
+
+  describe('on GET', () => {
+    const method = 'get'
+    checkAuthorizationGuards(app, method, pagePath)
+
+    context('when user authorised', () => {
+      beforeEach(() => {
+        idamServiceMock.resolveRetrieveUserFor(claimStoreServiceMock.sampleClaimObj.defendantId, 'citizen')
+      })
+
+      context('when response not submitted', () => {
+        it('should return 500 and render error page when cannot retrieve claim', async () => {
+          claimStoreServiceMock.rejectRetrieveClaimByExternalId('HTTP error')
+          await request(app)
+            .get(pagePath)
+            .set('Cookie', `${cookieName}=ABC`)
+            .expect(res => expect(res).to.be.serverError.withText('Error'))
+        })
+
+        it('should render claimant repayment plan by default', async () => {
+          claimStoreServiceMock.resolveRetrieveClaimByExternalId({
+            ...claimStoreServiceMock.sampleClaimObj,
+            settlement: {
+              ...settlementAgreementServiceMock.sampleSettlementAgreementOffer
+            },
+            claimantResponse: {  // guarded
+              type: 'ACCEPTATION',
+              formaliseOption: 'SETTLEMENT',
+              courtDetermination: {
+
+              }
+            }
+          })
+          await request(app)
+            .get(pagePath)
+            .set('Cookie', `${cookieName}=ABC`)
+            .expect(res => expect(res).to.be.successful.withText('The claimant’s repayment plan'))
+        })
+
+        it('should render court repayment plan when courts offer has been accepted', async () => {
+          claimStoreServiceMock.resolveRetrieveClaimByExternalId({
+            ...claimStoreServiceMock.sampleClaimObj,
+            settlement: {
+              ...settlementAgreementServiceMock.sampleSettlementAgreementOfferMadeByCourt
+            },
+            claimantResponse: {  // guarded
+              type: 'ACCEPTATION',
+              formaliseOption: 'SETTLEMENT',
+              courtDetermination: {
+
+              }
+            }
+          })
+          await request(app)
+            .get(pagePath)
+            .set('Cookie', `${cookieName}=ABC`)
+            .expect(res => expect(res).to.be.successful.withText('The court’s repayment plan'))
+        })
+      })
+    })
+  })
+})

--- a/src/test/http-mocks/settlement-agreement.ts
+++ b/src/test/http-mocks/settlement-agreement.ts
@@ -21,6 +21,20 @@ export const sampleSettlementAgreementOffer = {
   ]
 }
 
+export const sampleSettlementAgreementOfferMadeByCourt = {
+  partyStatements: [
+    {
+      type: StatementType.OFFER.value,
+      madeBy: MadeBy.COURT.value,
+      offer: { content: 'offer text', completionDate: '2017-08-08' }
+    },
+    {
+      type: StatementType.ACCEPTATION.value,
+      madeBy: MadeBy.CLAIMANT.value
+    }
+  ]
+}
+
 export const sampleSettlementAgreementAcceptation = {
   partyStatements: [
     {


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-4956

### Change description

Page text was showing as claimants offer - even when courts offer had been accepted. This determines if offer is made by court and shows appropriate copy.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
