### PR TITLE
Update @types/node

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -323,8 +323,8 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
 
 "@types/node@<10.0.0":
-  version "9.6.40"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.40.tgz#2d69cefbc090cb0bb824542a4c575b14dde7d3aa"
+  version "9.6.41"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.41.tgz#e57c3152eb2e7ec748c733cebd0c095b437c5d37"
 
 "@types/nunjucks@^3.1.0":
   version "3.1.0"


### PR DESCRIPTION
dependancy bot PR fails sonar due to @ symbol in branch name. 