### PR TITLE
ROC-4940 Reposition "When you'll pay" for def's check and send

### DIFF
--- a/src/main/features/response/views/check-and-send.njk
+++ b/src/main/features/response/views/check-and-send.njk
@@ -66,32 +66,7 @@
 
     {% endif %}
 
-    {% if admissionsApplicable and draft.isResponseFullyAdmitted() and draft.fullAdmission.paymentIntention.paymentOption.isOfType(DefendantPaymentType.IMMEDIATELY) %}
-
-      {{
-        whenWillYouPayRow(
-          value = t(draft.fullAdmission.paymentIntention.paymentOption.option.displayValue) | capitalize,
-          url = FullAdmissionPaths.paymentOptionPage.evaluateUri({ externalId: claim.externalId })
-        )
-      }}
-    {% endif %}
-
     {{ tableEnd() }}
-
-    {% if draft.isResponseFullyAdmitted() and not draft.fullAdmission.paymentIntention.paymentOption.isOfType(DefendantPaymentType.IMMEDIATELY) %}
-
-      {{
-        notImmediatePayment(
-          type = draft.fullAdmission.paymentIntention.paymentOption,
-          paymentDate = draft.fullAdmission.paymentIntention.paymentDate,
-          paymentPlan = draft.fullAdmission.paymentIntention.paymentPlan,
-          explanation = draft.statementOfMeans.explanation.text,
-          Paths = FullAdmissionPaths,
-          externalId = claim.externalId,
-          statementOfMeansIsApplicable = statementOfMeansIsApplicable
-        )
-      }}
-    {% endif %}
 
     {% if admissionsApplicable and draft.isResponsePartiallyAdmitted() %}
 
@@ -168,29 +143,6 @@
           )
         }}
         {{ row(label = 'Comments about their evidence (optional)', value = draft.partialAdmission.evidence.comment | default(''), bold = true) }}
-      {% else %}
-        {% if draft.partialAdmission.paymentIntention.paymentOption.isOfType(DefendantPaymentType.IMMEDIATELY) %}
-          {{ tableStart('whenWillYouPay', 'When you’ll pay') }}
-          {{
-            whenWillYouPayRow(
-              value = t(draft.partialAdmission.paymentIntention.paymentOption.option.displayValue) | capitalize,
-              url = PartAdmissionPaths.paymentOptionPage.evaluateUri({ externalId: claim.externalId })
-            )
-          }}
-          {{ tableEnd() }}
-        {% else %}
-          {{
-            notImmediatePayment(
-              type = draft.partialAdmission.paymentIntention.paymentOption,
-              paymentDate = draft.partialAdmission.paymentIntention.paymentDate,
-              paymentPlan = draft.partialAdmission.paymentIntention.paymentPlan,
-              explanation = draft.statementOfMeans.explanation.text,
-              Paths = PartAdmissionPaths,
-              externalId = claim.externalId,
-              statementOfMeansIsApplicable = statementOfMeansIsApplicable
-            )
-          }}
-        {% endif %}
       {% endif %}
     {% endif %}
 
@@ -287,8 +239,59 @@
       {% include "./statement-of-means/check-and-send.njk" %}
     {% endif %}
 
-    {% if (admissionsApplicable and (draft.isResponsePartiallyAdmitted() or (draft.isResponseRejectedFullyBecausePaidWhatOwed() and draft.rejectAllOfClaim.howMuchHaveYouPaid.amount < claim.totalAmountTillToday)))
-      or draft.isResponseRejectedFullyWithDispute() %}
+    {% if not draft.isResponsePartiallyAdmittedAndAlreadyPaid() %}
+      {% if draft.partialAdmission.paymentIntention.paymentOption.isOfType(DefendantPaymentType.IMMEDIATELY) %}
+        {{ tableStart('whenWillYouPay', 'When you’ll pay') }}
+        {{
+        whenWillYouPayRow(
+          value = t(draft.partialAdmission.paymentIntention.paymentOption.option.displayValue) | capitalize,
+          url = PartAdmissionPaths.paymentOptionPage.evaluateUri({ externalId: claim.externalId })
+        )
+        }}
+        {{ tableEnd() }}
+      {% else %}
+        {{
+        notImmediatePayment(
+          type = draft.partialAdmission.paymentIntention.paymentOption,
+          paymentDate = draft.partialAdmission.paymentIntention.paymentDate,
+          paymentPlan = draft.partialAdmission.paymentIntention.paymentPlan,
+          explanation = draft.statementOfMeans.explanation.text,
+          Paths = PartAdmissionPaths,
+          externalId = claim.externalId,
+          statementOfMeansIsApplicable = statementOfMeansIsApplicable
+        )
+        }}
+      {% endif %}
+    {% endif %}
+
+    {% if admissionsApplicable and draft.isResponseFullyAdmitted() and draft.fullAdmission.paymentIntention.paymentOption.isOfType(DefendantPaymentType.IMMEDIATELY) %}
+      {{
+      whenWillYouPayRow(
+        value = t(draft.fullAdmission.paymentIntention.paymentOption.option.displayValue) | capitalize,
+        url = FullAdmissionPaths.paymentOptionPage.evaluateUri({ externalId: claim.externalId })
+      )
+      }}
+    {% endif %}
+
+    {% if draft.isResponseFullyAdmitted() and not draft.fullAdmission.paymentIntention.paymentOption.isOfType(DefendantPaymentType.IMMEDIATELY) %}
+      {{
+      notImmediatePayment(
+        type = draft.fullAdmission.paymentIntention.paymentOption,
+        paymentDate = draft.fullAdmission.paymentIntention.paymentDate,
+        paymentPlan = draft.fullAdmission.paymentIntention.paymentPlan,
+        explanation = draft.statementOfMeans.explanation.text,
+        Paths = FullAdmissionPaths,
+        externalId = claim.externalId,
+        statementOfMeansIsApplicable = statementOfMeansIsApplicable
+      )
+      }}
+    {% endif %}
+
+    {% if (admissionsApplicable
+           and (draft.isResponsePartiallyAdmitted()
+                or (draft.isResponseRejectedFullyBecausePaidWhatOwed()
+                    and draft.rejectAllOfClaim.howMuchHaveYouPaid.amount < claim.totalAmountTillToday)))
+          or draft.isResponseRejectedFullyWithDispute() %}
       {{ tableStart('freeMediation', 'Free mediation') }}
       {{
           row(


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-4940

### Change description
Moved "when you'll pay" underneath the statement of means. Note that the prototype has some other oddities ("Opt out?" for mediation, e.g.)

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [x] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
