### PR TITLE
ROC-4951: Consent to new features always returns true

### DIFF
--- a/src/main/features/claim/routes/pay.ts
+++ b/src/main/features/claim/routes/pay.ts
@@ -82,7 +82,8 @@ async function successHandler (res, next) {
 
   if (!claimIsAlreadyFullyPersisted) {
     const roles: string[] = await claimStoreClient.retrieveUserRoles(user)
-    if (roles.length > 0 && await featureTogglesClient.isAdmissionsAllowed(user, roles)) {
+
+    if (await featureTogglesClient.isAdmissionsAllowed(user, roles)) {
       await claimStoreClient.saveClaim(draft, user, 'admissions')
     } else {
       await claimStoreClient.saveClaim(draft, user)


### PR DESCRIPTION
ROC-4951: Consent to new features always returns true : 
Doesn't always return true but a role is always returned so removed un-necessary condition checking roles length

### JIRA link

https://tools.hmcts.net/jira/browse/ROC-4951

### Change description

ROC-4951: Consent to new features always returns true : 
Doesn't always return true but a role is always returned so removed un-necessary condition checking roles length



### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
