### PR TITLE
turn on admissions in aat (fix)

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -86,6 +86,8 @@ module "citizen-frontend" {
   website_local_cache_sizeinmb = "${var.website_local_cache_sizeinmb}"
 
   app_settings = {
+    DUMMY="force-update"
+
     // Node specific vars
     NODE_DEBUG="${var.node_debug}"
     NODE_ENV = "${var.node_env}"


### PR DESCRIPTION

### Change description

Adding a dummy setting to force terraform update with admissions turned on. 

### Does this PR introduce a breaking change?

- [ ] Yes
- [ X ] No
