### PR TITLE
ROC-5111: disable healthcheck on pay service when using mockPay=true

### DIFF
--- a/src/main/routes/health.ts
+++ b/src/main/routes/health.ts
@@ -3,6 +3,7 @@ import * as config from 'config'
 import * as healthcheck from '@hmcts/nodejs-healthcheck'
 import * as fs from 'fs'
 import * as path from 'path'
+import { FeatureToggles } from 'utils/featureToggles'
 
 /* tslint:disable:no-default-export */
 export default express.Router()
@@ -25,6 +26,9 @@ function basicHealthCheck (serviceName) {
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'dockertests' || !process.env.NODE_ENV) {
     const sslDirectory = path.join(__dirname, '..', 'resources', 'localhost-ssl')
     options['ca'] = fs.readFileSync(path.join(sslDirectory, 'localhost-ca.crt'))
+  }
+  if (serviceName === 'pay' && FeatureToggles.isEnabled('mockPay')) {
+    return healthcheck.raw(() => { return healthcheck.up() })
   }
   return healthcheck.web(url(serviceName), options)
 }


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-5111

### Change description

SPROD deployment is failing because no Pay deployment is present. SPROD uses mockPay so check is irrelevant. This change will disable healthcheck when frontend configured to use mockPay.

Tested locally with mockPay on and off (switching docker pay service on and off too).

### Does this PR introduce a breaking change?

- [ ] Yes
- [ x ] No
