### PR TITLE
Fix image to match integration tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
-    image: hmcts/cmc-citizen-frontend
+    image: hmcts.azurecr.io/hmcts/cmc-citizen-frontend
   citizen-integration-tests:
     build:
       context: .


### PR DESCRIPTION

### Change description

Fix local docker-compose image to match image in cmc-integration-tests.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
