### PR TITLE
ROC-4300 Update 'defendants-response' screen to show the stated paid amount

### DIFF
--- a/src/main/features/claimant-response/views/defendants-response.njk
+++ b/src/main/features/claimant-response/views/defendants-response.njk
@@ -68,7 +68,12 @@
             {{ evidenceFragment(claim.response.evidence) }}
           {% endif %}
         {% else %}
-          {{ t('{{ defendantName }} states they paid you {{ amount }}.', { defendantName: defendantName, amount: claim.totalAmountTillToday | numeral }) }}
+          {{ t('{{ defendantName }} states they paid you {{ amount }}.',
+            {
+              defendantName: defendantName,
+              amount: (claim.response.paymentDeclaration.paidAmount if claim.response.paymentDeclaration.paidAmount else claim.totalAmountTillToday) | numeral
+            }
+          ) }}
 
           {{ paymentInformationFragment(paymentDeclaration = claim.response.paymentDeclaration) }}
 

--- a/src/test/data/entity/responseData.ts
+++ b/src/test/data/entity/responseData.ts
@@ -41,6 +41,7 @@ export const defenceWithAmountClaimedAlreadyPaidData = {
   defenceType: 'ALREADY_PAID',
   paymentDeclaration: {
     paidDate: '2017-12-31',
+    paidAmount: '100',
     explanation: 'I paid in cash'
   }
 }
@@ -541,4 +542,13 @@ export const partialAdmissionWithPaymentBySetDateDataPaymentDateAfterMonth = {
     paymentDate: MomentFactory.currentDate().add(50, 'days')
   },
   amount: 3000
+}
+
+export const fullDefenceWithPaidInFullGreaterThanClaimAmount = {
+  ...defenceWithAmountClaimedAlreadyPaidData,
+  paymentDeclaration: {
+    paidDate: '2017-12-31',
+    paidAmount: '20000',
+    explanation: 'I paid in cash'
+  }
 }

--- a/src/test/features/claimant-response/routes/defendants-response.ts
+++ b/src/test/features/claimant-response/routes/defendants-response.ts
@@ -23,6 +23,7 @@ const taskListPagePath = ClaimantResponsePaths.taskListPage.evaluateUri({ extern
 const fullAdmissionResponseWithPaymentBySetDate = claimStoreServiceMock.sampleFullAdmissionWithPaymentBySetDateResponseObj
 const fullAdmissionResponseWithPaymentByInstalments = claimStoreServiceMock.sampleFullAdmissionWithPaymentByInstalmentsResponseObj
 const partialAdmissionWithPaymentBySetDate = claimStoreServiceMock.samplePartialAdmissionWithPaymentBySetDateResponseObj
+const fullDefenceWithPaidInFull = claimStoreServiceMock.sampleFullDefenceWithPaidInFullGreaterThanClaimAmount
 
 describe('Claimant response: view defendant response page', () => {
   attachDefaultHooks(app)
@@ -84,6 +85,16 @@ describe('Claimant response: view defendant response page', () => {
           .get(pagePath)
           .set('Cookie', `${cookieName}=ABC`)
           .expect(res => expect(res).to.be.successful.withText('The defendant’s response'))
+      })
+
+      it('should render paid in full with stated amount when everything is fine', async () => {
+        claimStoreServiceMock.resolveRetrieveClaimByExternalId(fullDefenceWithPaidInFull)
+        draftStoreServiceMock.resolveFind('claimantResponse')
+
+        await request(app)
+          .get(pagePath)
+          .set('Cookie', `${cookieName}=ABC`)
+          .expect(res => expect(res).to.be.successful.withText(`£20,000`))
       })
     })
 

--- a/src/test/http-mocks/claim-store.ts
+++ b/src/test/http-mocks/claim-store.ts
@@ -16,7 +16,7 @@ import {
   fullAdmissionWithSoMPaymentByInstalmentsDataWithResonablePaymentSchedule,
   fullAdmissionWithSoMPaymentByInstalmentsDataWithUnResonablePaymentSchedule,
   fullAdmissionWithSoMPaymentBySetDate,
-  fullAdmissionWithSoMReasonablePaymentBySetDateAndNoDisposableIncome,
+  fullAdmissionWithSoMReasonablePaymentBySetDateAndNoDisposableIncome, fullDefenceWithPaidInFullGreaterThanClaimAmount,
   partialAdmissionWithPaymentBySetDateCompanyData,
   partialAdmissionWithSoMPaymentBySetDateData
 } from 'test/data/entity/responseData'
@@ -291,6 +291,11 @@ export const sampleFullAdmissionWithPaymentByInstalmentsResponseObjWithReasonabl
 export const sampleFullAdmissionWithPaymentByInstalmentsResponseObjWithUnReasonablePaymentSchedule = {
   respondedAt: '2017-07-25T22:45:51.785',
   response: fullAdmissionWithSoMPaymentByInstalmentsDataWithUnResonablePaymentSchedule
+}
+
+export const sampleFullDefenceWithPaidInFullGreaterThanClaimAmount = {
+  respondedAt: '2017-07-25T22:45:51.785',
+  response: fullDefenceWithPaidInFullGreaterThanClaimAmount
 }
 
 export function mockCalculateInterestRate (expected: number): mock.Scope {


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-4300

### Change description
With https://github.com/hmcts/cmc-claim-store/pull/742 and https://github.com/hmcts/cmc-citizen-frontend/pull/1413, show the correct amount to the claimant when the defendant states paid greater than the claim amount.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
