### PR TITLE
Fix user permission on docker build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN yarn install --production \
 FROM base as build
 RUN yarn install
 COPY tsconfig.json gulpfile.js server.js ./
-COPY src/main ./src/main
+COPY --chown=hmcts:hmcts src/main ./src/main
 RUN yarn setup
 
 # ---- Runtime image ----


### PR DESCRIPTION
### Change description

Allow the `hmcts` user to perform changes on the application source folder.

Here is the [related documentation](https://github.com/hmcts/cnp-node-base#yarn-install-fails-because-of-permission-issues)

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

-> The health check does respond.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
