### PR TITLE
Exclude the acb.yaml file from being ignored on acr build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,5 @@
 !default.conf.js
 !saucelabs.conf.js
 !server.js
+!acb.yaml
+!Dockerfile


### PR DESCRIPTION
### Change description

Avoid the acb.yaml file and the Dockerfile (!) to be in the ignore list of docker build. The ACR bundling takes the .dockerignore files in account and doesn't upload the acb.yaml or the Dockerfile with the existing rules, hence the build failure.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
