### PR TITLE
Remove trailing slash from nightly test_url

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -3,7 +3,7 @@
 properties([
   pipelineTriggers([cron('H 05 * * *')]),
   parameters([
-    string(name: 'URL_TO_TEST', defaultValue: 'https://cmc-citizen-frontend-aat.service.core-compute-aat.internal/', description: 'The URL you want to run these tests against'),
+    string(name: 'URL_TO_TEST', defaultValue: 'https://cmc-citizen-frontend-aat.service.core-compute-aat.internal', description: 'The URL you want to run these tests against'),
   ])
 ])
 


### PR DESCRIPTION

### Change description

Nightly functional tests throw: `401 - {"error":"redirect_uri is not white listed","code":"INCORRECT_CREDENTIALS"}` ... the redirect_uri needs to be exact and comparing to TEST_URL in normal pipeline - only diff is trailing slash.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
