### PR TITLE
Update afterCheckout statement in jenkinsfile

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -33,7 +33,7 @@ env.FEATURE_TESTING_SUPPORT = 'true'
 String notificationsChannel = '#cmc-tech-notification'
 
 withPipeline("nodejs", product, component) {
-  afterCheckout {
+  after('checkout') {
     onMaster {
       withCredentials([usernamePassword(credentialsId: 'jenkins-github-hmcts-api-token', passwordVariable: 'BEARER_TOKEN', usernameVariable: 'USERNAME')]) {
         try {


### PR DESCRIPTION

### Change description

afterCheckout changed in cnp-jenkins library. Tested in claim-store: https://github.com/hmcts/cmc-claim-store/pull/787

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
