### PR TITLE
ROC-5258 Refactor claim issue dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "ts-node": "^8.0.3",
     "tsconfig-paths": "^3.8.0",
     "typescript": "^3.3.3333",
+    "tslint-microsoft-contrib": "^6.1.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/src/main/features/dashboard/helpers/claimStatusFlow.ts
+++ b/src/main/features/dashboard/helpers/claimStatusFlow.ts
@@ -6,7 +6,7 @@ const logger = Logger.getLogger('ClaimStatusFlow')
 export class ClaimStatusFlow {
 
   static readonly flow: ClaimStatusNode = {
-    description: 'Claim Is Draft',
+    description: 'Claim Exists',
     isValidFor: () => true,
     next: [
       {
@@ -20,9 +20,13 @@ export class ClaimStatusFlow {
   static decide (flow: ClaimStatusNode, claim: Claim): string {
     if (flow.isValidFor(claim)) {
       const nextPossibleConditions = (flow.next || []).filter(state => state.isValidFor(claim))
-      if (nextPossibleConditions.length > 1) throw new Error(`Two possible paths are valid for a claim, check the flow's logic`)
+      if (nextPossibleConditions.length > 1) {
+        throw new Error(`Two possible paths are valid for a claim, check the flow's logic`)
+      }
       if (nextPossibleConditions.length === 0) {
-        if (!flow.dashboard) throw new Error(`Trying to render an intermediate state with no dashboard, check the flow's logic`)
+        if (!flow.dashboard) {
+          throw new Error(`Trying to render an intermediate state with no dashboard, check the flow's logic`)
+        }
         return flow.dashboard
       }
       return this.decide(nextPossibleConditions[0], claim)

--- a/src/main/features/dashboard/helpers/claimStatusFlow.ts
+++ b/src/main/features/dashboard/helpers/claimStatusFlow.ts
@@ -1,0 +1,49 @@
+import { Claim } from 'claims/models/claim'
+import { Logger } from '@hmcts/nodejs-logging'
+
+const logger = Logger.getLogger('ClaimStatusFlow')
+
+export class ClaimStatusFlow {
+
+  static readonly flow: ClaimStatusNode = {
+    description: 'Claim Is Draft',
+    isValidFor: () => true,
+    next: [
+      {
+        description: 'Claim Issued',
+        isValidFor: (claim) => !claim.response,
+        dashboard: 'claim_issued',
+        next: []
+      }
+    ]
+  }
+  static decide (flow: ClaimStatusNode, claim: Claim): string {
+    if (flow.isValidFor(claim)) {
+      const nextPossibleConditions = (flow.next || []).filter(state => state.isValidFor(claim))
+      if (nextPossibleConditions.length > 1) throw new Error(`Two possible paths are valid for a claim, check the flow's logic`)
+      if (nextPossibleConditions.length === 0) {
+        if (!flow.dashboard) throw new Error(`Trying to render an intermediate state with no dashboard, check the flow's logic`)
+        return flow.dashboard
+      }
+      return this.decide(nextPossibleConditions[0], claim)
+    }
+  }
+
+  // the try/catch should be removed once we don't need backward compatibility with 'old' dashboards - it's here to make sure we render the
+  // old status in case there are problems with the new one (which should be addressed)
+  public static dashboardFor (claim: Claim): string {
+    try {
+      return this.decide(ClaimStatusFlow.flow, claim)
+    } catch (err) {
+      logger.error(err)
+      return ''
+    }
+  }
+}
+
+export interface ClaimStatusNode {
+  description: string
+  dashboard?: string
+  isValidFor: (claim) => boolean
+  next: ClaimStatusNode[]
+}

--- a/src/main/features/dashboard/index.ts
+++ b/src/main/features/dashboard/index.ts
@@ -13,7 +13,7 @@ import { Paths } from 'dashboard/paths'
 import { Claim } from 'claims/models/claim'
 import { ClaimStatusFlow } from 'dashboard/helpers/claimStatusFlow'
 import { Logger } from '@hmcts/nodejs-logging'
-import { app } from '../../app'
+import { app } from 'main/app'
 
 const logger = Logger.getLogger('DashboardFeature')
 

--- a/src/main/features/dashboard/index.ts
+++ b/src/main/features/dashboard/index.ts
@@ -1,5 +1,6 @@
 import * as express from 'express'
 import * as path from 'path'
+import * as nunjucks from 'nunjucks'
 
 import { AuthorizationMiddleware } from 'idam/authorizationMiddleware'
 import { RouterFinder } from 'shared/router/routerFinder'
@@ -9,6 +10,12 @@ import { DraftClaim } from 'drafts/models/draftClaim'
 import { OAuthHelper } from 'idam/oAuthHelper'
 import { PaymentSchedule } from 'claims/models/response/core/paymentSchedule'
 import { Paths } from 'dashboard/paths'
+import { Claim } from 'claims/models/claim'
+import { ClaimStatusFlow } from 'dashboard/helpers/claimStatusFlow'
+import { Logger } from '@hmcts/nodejs-logging'
+import { app } from '../../app'
+
+const logger = Logger.getLogger('DashboardFeature')
 
 function requestHandler (): express.RequestHandler {
   function accessDeniedCallback (req: express.Request, res: express.Response): void {
@@ -18,6 +25,17 @@ function requestHandler (): express.RequestHandler {
   const requiredRoles = ['citizen']
   const unprotectedPaths = []
   return AuthorizationMiddleware.requestHandler(requiredRoles, accessDeniedCallback, unprotectedPaths)
+}
+
+function render (claim: Claim, type: string): string {
+  const dashboardName = ClaimStatusFlow.dashboardFor(claim)
+  try {
+    const template = nunjucks.render(path.join(__dirname, './views', 'status', type, dashboardName + '.njk').toString(), { claim: claim })
+    return app.settings.nunjucksEnv.filters['safe'](template)
+  } catch (err) {
+    logger.error(`view not found for status: ${dashboardName}`)
+    return ''
+  }
 }
 
 export class DashboardFeature {
@@ -34,6 +52,8 @@ export class DashboardFeature {
               return adverbial ? 'Monthly' : 'Every month'
           }
         }
+        app.settings.nunjucksEnv.filters.dashboardStatusForClaimant = (claim: Claim) => render(claim, 'claimant')
+        app.settings.nunjucksEnv.filters.dashboardStatusForDefendant = (claim: Claim) => render(claim, 'defendant')
       }
 
       if (app.settings.nunjucksEnv.globals) {

--- a/src/main/features/dashboard/views/index.njk
+++ b/src/main/features/dashboard/views/index.njk
@@ -6,6 +6,16 @@
 
 {% set heading = 'Your money claims account' %}
 
+{% macro backwardCompatibleDashboardFor(claim, newStatus, type) %}
+  {% if newStatus %}
+    {{ newStatus }}
+  {% elif type === 'claimant' %}
+    {{ caseStatusForClaimant(claim.status, claim) }}
+  {% else %}
+    {{ caseStatusForDefendant(claim.status, claim) }}
+  {% endif %}
+{% endmacro %}
+
 {% block content %}
   <div class="grid-row">
     <div class="column-full">
@@ -44,18 +54,19 @@
           </tr>
         {% endif %}
         {% for claim in claimsAsClaimant %}
+          {% set claimantDashboardStatus = claim | dashboardStatusForClaimant %}
           <tr class="claims default mobile-table">
             <td>{{ internalLink(claim.claimNumber, '/dashboard/' + claim.externalId + '/claimant') }}</td>
             <td>{{ claim.claimData.defendant.name }}</td>
             <td>{{ claim.totalAmountTillToday | numeral }}</td>
             <td class="mobile-hide">
-              {{ caseStatusForClaimant(claim.status, claim) }}
+              {{ backwardCompatibleDashboardFor(claim, claimantDashboardStatus, 'claimant') }}
             </td>
           </tr>
           <tr>
             <td colspan="3" class="mobile-table-status">
-              {{ t('Status: ') }}
-              {{ caseStatusForClaimant(claim.status, claim) }}
+              {{ t('Status:') }}
+              {{ backwardCompatibleDashboardFor(claim, claimantDashboardStatus, 'claimant') }}
             </td>
           </tr>
         {% endfor %}
@@ -89,17 +100,19 @@
           </tr>
         {% endif %}
         {% for claim in claimsAsDefendant %}
+          {% set defendantDashboardStatus = claim | dashboardStatusForDefendant %}
           <tr class="mobile-table">
             <td>{{ internalLink(claim.claimNumber, DashboardPaths.defendantPage.evaluateUri({ externalId: claim.externalId })) }}</td>
             <td>{{ claim.claimData.claimant.name }}</td>
             <td>{{ claim.totalAmountTillToday | numeral }}</td>
             <td class="mobile-hide">
-              {{ caseStatusForDefendant(claim.status, claim) }}
+              {{ backwardCompatibleDashboardFor(claim, defendantDashboardStatus, 'defendant') }}
             </td>
           </tr>
           <tr>
             <td colspan="3" class="mobile-table-status">
-              {{ t('Status:') }} {{ caseStatusForDefendant(claim.status, claim) }}
+              {{ t('Status:') }}
+              {{ backwardCompatibleDashboardFor(claim, defendantDashboardStatus, 'defendant') }}
             </td>
           </tr>
         {% endfor %}

--- a/src/main/features/dashboard/views/status/claimant/claim_issued.njk
+++ b/src/main/features/dashboard/views/status/claimant/claim_issued.njk
@@ -1,0 +1,1 @@
+{{ t('Your claim has been sent.') }}

--- a/src/main/features/dashboard/views/status/defendant/claim_issued.njk
+++ b/src/main/features/dashboard/views/status/defendant/claim_issued.njk
@@ -1,0 +1,6 @@
+{% from "timeRemaining.njk" import timeRemaining %}
+
+{{ t('Respond to claim.') }}
+<div class="mobile-inline font-xsmall">
+  {{ timeRemaining(claim.remainingDays, isAfter4pm()) }}
+</div>

--- a/src/test/features/dashboard/helpers/claimStatusFlow.ts
+++ b/src/test/features/dashboard/helpers/claimStatusFlow.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { Claim } from 'claims/models/claim'
-import { sampleClaimObj } from '../../../http-mocks/claim-store'
+import { sampleClaimObj } from 'test/http-mocks/claim-store'
 import { ClaimStatusNode, ClaimStatusFlow } from 'dashboard/helpers/claimStatusFlow'
 
 describe('The dashboard status rule engine', () => {

--- a/src/test/features/dashboard/helpers/claimStatusFlow.ts
+++ b/src/test/features/dashboard/helpers/claimStatusFlow.ts
@@ -1,0 +1,135 @@
+import { expect } from 'chai'
+import { Claim } from 'claims/models/claim'
+import { sampleClaimObj } from '../../../http-mocks/claim-store'
+import { ClaimStatusNode, ClaimStatusFlow } from 'dashboard/helpers/claimStatusFlow'
+
+describe('The dashboard status rule engine', () => {
+  describe('given the claim flow', () => {
+    it('should extract the correct dashboard for claim issued', () => {
+      const claim: Claim = new Claim().deserialize(sampleClaimObj)
+      expect(ClaimStatusFlow.dashboardFor(claim)).to.equal('claim_issued')
+    })
+  })
+
+  describe('given a generic flow', () => {
+    it('should return the dashboard of the only valid state', () => {
+      const flow: ClaimStatusNode = {
+        description: 'this is always true',
+        isValidFor: () => true,
+        dashboard: 'first',
+        next: []
+      }
+      const claim: Claim = new Claim().deserialize(sampleClaimObj)
+      expect(ClaimStatusFlow.decide(flow, claim)).to.equal(`first`)
+    })
+  })
+  it('should return the dashboard of the last valid state', () => {
+    const flow: ClaimStatusNode = {
+      description: 'this is always true',
+      isValidFor: () => true,
+      dashboard: 'first',
+      next: [{
+        description: '',
+        isValidFor: () => false,
+        dashboard: 'second',
+        next: []
+      }, {
+        description: '',
+        isValidFor: () => true,
+        dashboard: 'third',
+        next: [{
+          description: 'this is the one',
+          isValidFor: () => true,
+          dashboard: 'fourth',
+          next: []
+        }]
+      }, {
+        description: '',
+        isValidFor: () => false,
+        dashboard: 'fifth',
+        next: []
+      }]
+    }
+    const claim: Claim = new Claim().deserialize(sampleClaimObj)
+    expect(ClaimStatusFlow.decide(flow, claim)).to.equal(`fourth`)
+  })
+  it('should return the dashboard of the last valid state even if there are other states after', () => {
+    const flow: ClaimStatusNode = {
+      description: 'this is always true',
+      isValidFor: () => true,
+      dashboard: 'first',
+      next: [{
+        description: '',
+        isValidFor: () => false,
+        dashboard: 'second',
+        next: []
+      }, {
+        description: '',
+        isValidFor: () => true,
+        dashboard: 'third',
+        next: [{
+          description: 'this',
+          isValidFor: () => true,
+          dashboard: 'fourth',
+          next: [{
+            description: '',
+            isValidFor: () => false,
+            dashboard: 'fifth',
+            next: [{
+              description: 'this should not happen',
+              isValidFor: () => true,
+              dashboard: 'sixth',
+              next: []
+            }]
+          }]
+        }]
+      }, {
+        description: '',
+        isValidFor: () => false,
+        dashboard: 'seventh',
+        next: []
+      }]
+    }
+    const claim: Claim = new Claim().deserialize(sampleClaimObj)
+    expect(ClaimStatusFlow.decide(flow, claim)).to.equal(`fourth`)
+  })
+  it('should throw an error if two paths are possible', () => {
+    const flow: ClaimStatusNode = {
+      description: 'this is always true',
+      isValidFor: () => true,
+      dashboard: 'first',
+      next: [{
+        description: 'this is still true',
+        isValidFor: () => true,
+        dashboard: 'second',
+        next: []
+      }, {
+        description: 'this is true but it shouldnt be',
+        isValidFor: () => true,
+        dashboard: 'third',
+        next: []
+      }]
+    }
+    const claim: Claim = new Claim().deserialize(sampleClaimObj)
+    expect(() => ClaimStatusFlow.decide(flow, claim)).to.throw(`Two possible paths are valid for a claim, check the flow's logic`)
+  })
+  it('should throw an error if trying to render an intermediate state', () => {
+    const flow: ClaimStatusNode = {
+      description: 'this is true but has no dashboard, so it should not be picked',
+      isValidFor: () => true,
+      next: [{
+        description: 'nope',
+        isValidFor: () => false,
+        dashboard: 'second',
+        next: []
+      }, {
+        description: 'nope',
+        isValidFor: () => false,
+        dashboard: 'third',
+        next: []
+      }]
+    }
+    const claim: Claim = new Claim().deserialize(sampleClaimObj)
+    expect(() => ClaimStatusFlow.decide(flow, claim)).to.throw(`Trying to render an intermediate state with no dashboard, check the flow's logic`)
+  })
+})

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,6 @@
 {
   "extends": "tslint-config-standard",
+  "rulesDirectory": ["node_modules/tslint-microsoft-contrib"],
   "rules": {
     "member-ordering": [
       true,
@@ -21,6 +22,7 @@
     ],
     "no-default-export": true,
     "no-floating-promises": false,
-    "no-console": true
+    "no-console": true,
+    "mocha-avoid-only": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7824,6 +7824,13 @@ tslint-eslint-rules@^5.3.1:
     tslib "1.9.0"
     tsutils "2.8.0"
 
+tslint-microsoft-contrib@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.1.0.tgz#cc487575f2cdb8fe3774bf3f2ba61ff61dc7856e"
+  integrity sha512-8DgmiPTgNQSYTjrKKv/h1aHnDd7EkGAjTxatrjfSDp5jUXENGI7Qj7qi7T8xBdTZN9Z3nb80u0NhdBBOMcQFHg==
+  dependencies:
+    tsutils "^2.27.2 <2.29.0"
+
 tslint@^5.12.0:
   version "5.12.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.12.0.tgz#47f2dba291ed3d580752d109866fb640768fca36"
@@ -7854,6 +7861,13 @@ tsutils@2.8.0:
 tsutils@^2.27.2:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  dependencies:
+    tslib "^1.8.1"
+
+"tsutils@^2.27.2 <2.29.0":
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.28.0.tgz#6bd71e160828f9d019b6f4e844742228f85169a1"
+  integrity sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-5258


### Change description
- Introducing a new way of discerning the dashboard status from a claim. It will still be picked based on the state of a claim (as it is now), but will be calculated using a 'flowchart'-like data structure instead of complex if-elses. This should make everything more testable and also it should be easier to follow what's going on.
- Added some additional guards to make sure we default to the old way if the new rule engine can't find a dashboard status / the rule engine itself is wrong. Those will be removed once we have migrated all the statuses and we are confident the rule engine works.
- Added a tslint rule to stop committing `.only` in tests (guilty!)


In more detail: 
- Each element of this flowchart has a `description` (for documentation purposes), an optional `dashboard` (the string name of the `njk` template containing the status), a `condition` (a function which is true when the claim is in that status) and `next` states.
 Basically, the code will go through the flowchart, given a certain claim. It will evaluate the condition of each state, and if it's a leaf (there are no next states, or all of next states are `false`) then it will return the dashboard, otherwise it will go to the next valid state and so on.
 - Only one of the flowchart paths should be valid at any given time - if there are two possible paths, it means that either the conditions in the flowcharts are wrong, or the claim is in a weird state
 - Each dashboard status should go to a separate nunjucks template. This will make things easier to reason about as the logic is 100% in typescript, rather than in two places. To not take this to the extreme, tho, there shouldn't be a problem having super simple conditions in nunjucks - when the logic becomes too cumbersome, it should definitely be moved in the "rule engine"


### Work checklist

- [x] Unit tests added where applicable
- [x] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
