### PR TITLE
Fix AAT build on master

### DIFF
--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,11 +1,3 @@
-output "vaultUri" {
-  value = "${data.azurerm_key_vault.cmc_key_vault.vault_uri}"
-}
-
-output "vaultName" {
-  value = "${local.vaultName}"
-}
-
 output "idam_url" {
   value = "${var.idam_api_url}"
 }


### PR DESCRIPTION

### Change description

https://build.platform.hmcts.net/job/HMCTS_CMC/job/cmc-citizen-frontend/job/master/326/console

This new code in Jeninsfile:
```
def secrets = [
  'cmc-${env}':
    [
      secret('citizen-oauth-client-secret', 'OAUTH_CLIENT_SECRET'),
      secret('smoke-test-citizen-username', 'SMOKE_TEST_CITIZEN_USERNAME'),
      secret('smoke-test-user-password', 'SMOKE_TEST_USER_PASSWORD')
    ],
  'rpe-ft-api-${env}' :
    [
      secret('admin-username-test', 'ADMIN_USERNAME_TEST'),
      secret('admin-password-test', 'ADMIN_PASSWORD_TEST'),
      secret('editor-username-test', 'EDITOR_USERNAME_TEST'),
      secret('editor-password-test', 'EDITOR_PASSWORD_TEST')
    ]
]
```

This error:
```
org.jenkinsci.plugins.azurekeyvaultplugin.AzureKeyVaultException: Secret: admin-username-test not found in vault: https://cmc-aat.vault.azure.net/
	at org.jenkinsci.plugins.azurekeyvaultplugin.AzureKeyVaultBuildWrapper.setUp(AzureKeyVaultBuildWrapper.java:285)
	at org.jenkinsci.plugins.workflow.steps.CoreWrapperStep$Execution.start(CoreWrapperStep.java:80)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeStep(DSL.java:270)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:180)
	at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:122)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:48)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
	at com.cloudbees.groovy.cps.sandbox.DefaultInvoker.methodCall(DefaultInvoker.java:20)
	at withTeamSecrets.executeClosure(/opt/jenkins/jobs/HMCTS_CMC/jobs/cmc-citizen-frontend/branches/master/builds/326/libs/Infrastructure/vars/withTeamSecrets.groovy:28)
	at withTeamSecrets.executeClosure(/opt/jenkins/jobs/HMCTS_CMC/jobs/cmc-citizen-frontend/branches/master/builds/326/libs/Infrastructure/vars/withTeamSecrets.groovy:36)
	at ___cps.transform___(Native Method)
	at com.cloudbees.groovy.cps.impl.ContinuationGroup.methodCall(ContinuationGroup.java:57)
	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.dispatchOrArg(FunctionCallBlock.java:109)
	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.fixArg(FunctionCallBlock.java:82)
	at sun.reflect.GeneratedMethodAccessor518.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)
	at com.cloudbees.groovy.cps.impl.ClosureBlock.eval(ClosureBlock.java:46)
	at com.cloudbees.groovy.cps.Next.step(Next.java:83)
	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:174)
	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:163)
	at org.codehaus.groovy.runtime.GroovyCategorySupport$ThreadCategoryInfo.use(GroovyCategorySupport.java:122)
	at org.codehaus.groovy.runtime.GroovyCategorySupport.use(GroovyCategorySupport.java:261)
	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:163)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$101(SandboxContinuable.java:34)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.lambda$run0$0(SandboxContinuable.java:59)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox.runInSandbox(GroovySandbox.java:108)
	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:58)
	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:174)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:332)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$200(CpsThreadGroup.java:83)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:244)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:232)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:64)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:131)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:59)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Finished: FAILURE
```

### Does this PR introduce a breaking change?

- [ ] Yes
- [ x ] No
