### PR TITLE
ROC-5625 Add route tests for claim issued and admissions, and fix UI bug

### DIFF
--- a/src/main/features/dashboard/views/macro/claimStatus/claimPartAdmittedDefendant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/claimPartAdmittedDefendant.njk
@@ -9,7 +9,7 @@
 
 {% macro partAdmittedClaimantAcceptsDefendantDashboard(claim) %}
   {{ t('{{ claimantName }} accepted your admission of {{ amount }}',
-    { amount: claim.response.amount, claimantName: claim.claimData.claimant.name }) }}
+    { amount: claim.response.amount | numeral, claimantName: claim.claimData.claimant.name }) }}
 {% endmacro %}
 
 {% macro claimPartAdmittedAlreadyPaidForDefendantClaimDetails(claim) %}

--- a/src/test/data/entity/responseData.ts
+++ b/src/test/data/entity/responseData.ts
@@ -51,7 +51,32 @@ export const baseFullAdmissionData = {
   freeMediation: 'no'
 }
 
-const basePartialAdmissionData = {
+export const basePayImmediatelyData = {
+  paymentIntention: {
+    paymentOption: PaymentOption.IMMEDIATELY,
+    paymentDate: MomentFactory.currentDate().add(5, 'days')
+  }
+}
+
+export const basePayByInstalmentsData = {
+  paymentIntention: {
+    paymentOption: PaymentOption.INSTALMENTS,
+    repaymentPlan: {
+      instalmentAmount: 100,
+      firstPaymentDate: '2050-12-31',
+      paymentSchedule: PaymentSchedule.EACH_WEEK,
+      completionDate: '2051-12-31',
+      paymentLength: '1'
+    }
+  }
+}
+export const basePayBySetDateData = {
+  paymentIntention: {
+    paymentOption: PaymentOption.BY_SPECIFIED_DATE,
+    paymentDate: '2050-12-31'
+  }
+}
+export const basePartialAdmissionData = {
   responseType: 'PART_ADMISSION',
   freeMediation: 'no'
 }
@@ -80,10 +105,7 @@ const basePartialEvidencesAndTimeLines = {
 export const fullAdmissionWithImmediatePaymentData = {
   ...baseResponseData,
   ...baseFullAdmissionData,
-  paymentIntention: {
-    paymentOption: PaymentOption.IMMEDIATELY,
-    paymentDate: MomentFactory.currentDate().add(5, 'days')
-  }
+  ...basePayImmediatelyData
 }
 
 export const partialAdmissionWithImmediatePaymentData = {
@@ -91,10 +113,7 @@ export const partialAdmissionWithImmediatePaymentData = {
   ...basePartialAdmissionData,
   ...basePartialEvidencesAndTimeLines,
   defence: 'i have paid more than enough',
-  paymentIntention: {
-    paymentOption: PaymentOption.IMMEDIATELY,
-    paymentDate: MomentFactory.currentDate().add(5, 'days')
-  },
+  ...basePayImmediatelyData,
   amount: 3000
 }
 
@@ -132,10 +151,7 @@ export const partialAdmissionAlreadyPaidData = {
 export const fullAdmissionWithPaymentBySetDateData = {
   ...baseResponseData,
   ...baseFullAdmissionData,
-  paymentIntention: {
-    paymentOption: PaymentOption.BY_SPECIFIED_DATE,
-    paymentDate: '2050-12-31'
-  }
+  ...basePayBySetDateData
 }
 
 export const fullAdmissionWithPaymentBySetDateDataInNext2days = {
@@ -161,41 +177,20 @@ export const partialAdmissionWithPaymentBySetDateData = {
   ...basePartialAdmissionData,
   ...basePartialEvidencesAndTimeLines,
   defence: 'i have paid more than enough',
-  paymentIntention: {
-    paymentOption: PaymentOption.BY_SPECIFIED_DATE,
-    paymentDate: '2050-12-31'
-  },
+  ...basePayBySetDateData,
   amount: 3000
 }
 
 export const fullAdmissionWithPaymentByInstalmentsData = {
   ...baseResponseData,
   ...baseFullAdmissionData,
-  paymentIntention: {
-    paymentOption: PaymentOption.INSTALMENTS,
-    repaymentPlan: {
-      instalmentAmount: 100,
-      firstPaymentDate: '2050-12-31',
-      paymentSchedule: PaymentSchedule.EACH_WEEK,
-      completionDate: '2051-12-31',
-      paymentLength: '1'
-    }
-  }
+  ...basePayByInstalmentsData
 }
 
 export const fullAdmissionWithPaymentByInstalmentsDataCompany = {
   ...baseCompanyResponseData,
   ...baseFullAdmissionData,
-  paymentIntention: {
-    paymentOption: PaymentOption.INSTALMENTS,
-    repaymentPlan: {
-      instalmentAmount: 100,
-      firstPaymentDate: '2050-12-31',
-      paymentSchedule: PaymentSchedule.EACH_WEEK,
-      completionDate: '2051-12-31',
-      paymentLength: '1'
-    }
-  }
+  ...basePayByInstalmentsData
 }
 
 export const fullAdmissionWithPaymentByInstalmentsDataWithReasonablePaymentSchedule = {
@@ -233,16 +228,7 @@ export const partialAdmissionWithPaymentByInstalmentsData = {
   ...basePartialAdmissionData,
   ...basePartialEvidencesAndTimeLines,
   defence: 'i have paid more than enough',
-  paymentIntention: {
-    paymentOption: PaymentOption.INSTALMENTS,
-    repaymentPlan: {
-      instalmentAmount: 100,
-      firstPaymentDate: '2050-12-31',
-      paymentSchedule: PaymentSchedule.EACH_WEEK,
-      completionDate: '2051-12-31',
-      paymentLength: '1'
-    }
-  },
+  ...basePayByInstalmentsData,
   amount: 3000
 }
 
@@ -424,10 +410,7 @@ export const partialAdmissionWithImmediatePaymentCompanyData = {
   ...basePartialAdmissionData,
   ...basePartialEvidencesAndTimeLines,
   defence: 'i have paid more than enough',
-  paymentIntention: {
-    paymentOption: PaymentOption.IMMEDIATELY,
-    paymentDate: MomentFactory.currentDate().add(5, 'days')
-  },
+  ...basePayImmediatelyData,
   amount: 3000
 }
 
@@ -436,28 +419,7 @@ export const partialAdmissionWithPaymentBySetDateCompanyData = {
   ...basePartialAdmissionData,
   ...basePartialEvidencesAndTimeLines,
   defence: 'i have paid more than enough',
-  paymentIntention: {
-    paymentOption: PaymentOption.BY_SPECIFIED_DATE,
-    paymentDate: '2050-12-31'
-  },
-  amount: 3000
-}
-
-export const partialAdmissionWithPaymentByInstalmentsCompanyData = {
-  ...baseCompanyResponseData,
-  ...basePartialAdmissionData,
-  ...basePartialEvidencesAndTimeLines,
-  defence: 'i have paid more than enough',
-  paymentIntention: {
-    paymentOption: PaymentOption.INSTALMENTS,
-    repaymentPlan: {
-      instalmentAmount: 100,
-      firstPaymentDate: '2050-12-31',
-      paymentSchedule: PaymentSchedule.EACH_WEEK,
-      completionDate: '2051-12-31',
-      paymentLength: '1'
-    }
-  },
+  ...basePayBySetDateData,
   amount: 3000
 }
 
@@ -472,35 +434,6 @@ export const fullAdmissionWithPaymentByInstalmentsDataPaymentDateBeforeMonth = {
       paymentSchedule: PaymentSchedule.EACH_WEEK
     }
   }
-}
-
-export const fullAdmissionWithPaymentByInstalmentsDataPaymentDateAfterMonth = {
-  ...baseResponseData,
-  ...baseFullAdmissionData,
-  paymentIntention: {
-    paymentOption: PaymentOption.INSTALMENTS,
-    repaymentPlan: {
-      instalmentAmount: 100,
-      firstPaymentDate: MomentFactory.currentDate().add(50, 'days'),
-      paymentSchedule: PaymentSchedule.EACH_WEEK
-    }
-  }
-}
-
-export const partialAdmissionWithPaymentByInstalmentsDataPaymentDateBeforeMonth = {
-  ...baseResponseData,
-  ...basePartialAdmissionData,
-  ...basePartialEvidencesAndTimeLines,
-  defence: 'i have paid more than enough',
-  paymentIntention: {
-    paymentOption: PaymentOption.INSTALMENTS,
-    repaymentPlan: {
-      instalmentAmount: 100,
-      firstPaymentDate: MomentFactory.currentDate().add(10, 'days'),
-      paymentSchedule: PaymentSchedule.EACH_WEEK
-    }
-  },
-  amount: 3000
 }
 
 export const partialAdmissionWithPaymentByInstalmentsDataPaymentDateAfterMonth = {
@@ -519,15 +452,6 @@ export const partialAdmissionWithPaymentByInstalmentsDataPaymentDateAfterMonth =
   amount: 3000
 }
 
-export const fullAdmissionWithPaymentBySetDateDataPaymentDateBeforeMonth = {
-  ...baseResponseData,
-  ...baseFullAdmissionData,
-  paymentIntention: {
-    paymentOption: PaymentOption.BY_SPECIFIED_DATE,
-    paymentDate: MomentFactory.currentDate().add(10, 'days')
-  }
-}
-
 export const fullAdmissionWithPaymentBySetDateDataPaymentDateAfterMonth = {
   ...baseResponseData,
   ...baseFullAdmissionData,
@@ -544,18 +468,6 @@ export const partialAdmissionWithPaymentBySetDateDataPaymentDateBeforeMonth = {
   paymentIntention: {
     paymentOption: PaymentOption.BY_SPECIFIED_DATE,
     paymentDate: MomentFactory.currentDate().add(10, 'days')
-  },
-  amount: 3000
-}
-
-export const partialAdmissionWithPaymentBySetDateDataPaymentDateAfterMonth = {
-  ...baseResponseData,
-  ...basePartialAdmissionData,
-  ...basePartialEvidencesAndTimeLines,
-  defence: 'i have paid more than enough',
-  paymentIntention: {
-    paymentOption: PaymentOption.BY_SPECIFIED_DATE,
-    paymentDate: MomentFactory.currentDate().add(50, 'days')
   },
   amount: 3000
 }

--- a/src/test/features/dashboard/routes/index.ts
+++ b/src/test/features/dashboard/routes/index.ts
@@ -340,7 +340,7 @@ describe('Dashboard page', () => {
               await request(app)
                 .get(Paths.dashboardPage.uri)
                 .set('Cookie', `${cookieName}=ABC`)
-                .expect(res => expect(res).to.be.successful.withText('John Smith accepted your admission of 30'))
+                .expect(res => expect(res).to.be.successful.withText('John Smith accepted your admission of £30'))
             })
 
             it('should show pay immediately statuses when the claim is marked as pay immediately and the offer is accepted and response is after the deadline', async () => {

--- a/src/test/features/dashboard/routes/index.ts
+++ b/src/test/features/dashboard/routes/index.ts
@@ -11,8 +11,26 @@ import { app } from 'main/app'
 
 import * as idamServiceMock from 'test/http-mocks/idam'
 import * as draftStoreServiceMock from 'test/http-mocks/draft-store'
-import * as claimStoreServiceMock from 'test/http-mocks/claim-store'
 import { checkAuthorizationGuards } from 'test/features/dashboard/routes/checks/authorization-check'
+import {
+  rejectRetrieveByClaimantId,
+  resolveRetrieveByClaimantId,
+  resolveRetrieveByClaimantIdToEmptyList,
+  resolveRetrieveByDefendantId,
+  resolveRetrieveByDefendantIdToEmptyList,
+  sampleClaimIssueObj,
+  sampleClaimObj
+} from 'test/http-mocks/claim-store'
+import { MomentFactory } from 'shared/momentFactory'
+import {
+  baseFullAdmissionData,
+  basePartialAdmissionData,
+  basePayByInstalmentsData,
+  basePayBySetDateData,
+  basePayImmediatelyData,
+  baseResponseData
+} from 'test/data/entity/responseData'
+import { baseAcceptationClaimantResponseData } from 'test/data/entity/claimantResponseData'
 
 const cookieName: string = config.get<string>('session.cookieName')
 
@@ -29,7 +47,7 @@ describe('Dashboard page', () => {
 
       it('should return 500 and render error page when cannot retrieve claims', async () => {
         draftStoreServiceMock.resolveFind('claim')
-        claimStoreServiceMock.rejectRetrieveByClaimantId('HTTP error')
+        rejectRetrieveByClaimantId('HTTP error')
 
         await request(app)
           .get(Paths.dashboardPage.uri)
@@ -39,8 +57,8 @@ describe('Dashboard page', () => {
 
       context('when no claims issued', () => {
         beforeEach(() => {
-          claimStoreServiceMock.resolveRetrieveByClaimantIdToEmptyList()
-          claimStoreServiceMock.resolveRetrieveByDefendantIdToEmptyList()
+          resolveRetrieveByClaimantIdToEmptyList()
+          resolveRetrieveByDefendantIdToEmptyList()
         })
 
         it('should render page with start claim button when everything is fine', async () => {
@@ -55,8 +73,8 @@ describe('Dashboard page', () => {
 
       context('when at least one claim issued', () => {
         beforeEach(() => {
-          claimStoreServiceMock.resolveRetrieveByClaimantId()
-          claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1')
+          resolveRetrieveByClaimantId()
+          resolveRetrieveByDefendantId('000MC001', '1')
         })
 
         it('should render page with continue claim button when everything is fine', async () => {
@@ -77,7 +95,292 @@ describe('Dashboard page', () => {
             .expect(res => expect(res).to.be.successful.withText('Your money claims account', 'Make a new money claim'))
         })
       })
-    })
 
+      context('when checking the status of a claim', () => {
+        beforeEach(() => {
+          draftStoreServiceMock.resolveFindNoDraftFound()
+        })
+
+        context('as a claimant', () => {
+          beforeEach(() => {
+            resolveRetrieveByDefendantIdToEmptyList()
+          })
+
+          it('should show claim issued statuses when the claim is issued', async () => {
+            resolveRetrieveByClaimantId(sampleClaimIssueObj, {
+              responseDeadline: MomentFactory.currentDate().add(1, 'days')
+            })
+            await request(app)
+              .get(Paths.dashboardPage.uri)
+              .set('Cookie', `${cookieName}=ABC`)
+              .expect(res => expect(res).to.be.successful.withText('Your claim has been sent.'))
+          })
+
+          context('when the claim is in full admission', () => {
+            const fullAdmissionClaim = {
+              ...sampleClaimObj,
+              responseDeadline: MomentFactory.currentDate().add(1, 'days'),
+              response: {
+                ...baseResponseData,
+                ...baseFullAdmissionData
+              }
+            }
+            it('should show pay immediately statuses when the claim is marked as pay immediately', async () => {
+              resolveRetrieveByClaimantId(fullAdmissionClaim, {
+                response: { ...fullAdmissionClaim.response, ...basePayImmediatelyData }
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('The defendant admits they owe all the money. They’ve said that they will pay immediately.'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay immediately and payment is past the deadline', async () => {
+              resolveRetrieveByClaimantId(fullAdmissionClaim, {
+                responseDeadline: MomentFactory.currentDate().subtract(1, 'days'),
+                response: { ...fullAdmissionClaim.response, ...basePayImmediatelyData }
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('The defendant has not responded to your claim. You can request a County Court Judgment against them.'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay by set date', async () => {
+              resolveRetrieveByClaimantId(fullAdmissionClaim, {
+                response: { ...fullAdmissionClaim.response, ...basePayBySetDateData }
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('The defendant has offered to pay by a set date. You can accept or reject their offer.'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay by instalments', async () => {
+              resolveRetrieveByClaimantId(fullAdmissionClaim, {
+                response: { ...fullAdmissionClaim.response, ...basePayByInstalmentsData }
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('The defendant has offered to pay in instalments. You can accept or reject their offer.'))
+            })
+          })
+          context('when the claim is in partial admission', () => {
+            const partAdmissionClaim = {
+              ...sampleClaimObj,
+              responseDeadline: MomentFactory.currentDate().add(1, 'days'),
+              response: {
+                ...baseResponseData,
+                ...basePartialAdmissionData,
+                amount: 30
+              }
+            }
+            it('should show pay immediately statuses when the claim is marked as pay immediately', async () => {
+              resolveRetrieveByClaimantId(partAdmissionClaim, {
+                response: { ...partAdmissionClaim.response, ...basePayImmediatelyData }
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('The defendant believes they owe you £30. You can accept or reject that this is the amount owed.'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay immediately and the offer is accepted', async () => {
+              resolveRetrieveByClaimantId(partAdmissionClaim, {
+                response: { ...partAdmissionClaim.response, ...basePayImmediatelyData },
+                claimantResponse: baseAcceptationClaimantResponseData
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('You’ve accepted the defendant’s part admission. They said they’d pay immediately.'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay immediately and the offer is accepted and response is after the deadline', async () => {
+              resolveRetrieveByClaimantId(partAdmissionClaim, {
+                response: { ...partAdmissionClaim.response, ...basePayImmediatelyData },
+                claimantResponse: baseAcceptationClaimantResponseData,
+                responseDeadline: MomentFactory.currentDate().subtract(1, 'days')
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('The defendant has not responded to your claim. You can request a County Court Judgment against them.'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay by set date', async () => {
+              resolveRetrieveByClaimantId(partAdmissionClaim, {
+                response: { ...partAdmissionClaim.response, ...basePayBySetDateData }
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('The defendant believes they owe you £30. You can accept or reject that this is the amount owed.'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay by instalments', async () => {
+              resolveRetrieveByClaimantId(partAdmissionClaim, {
+                response: { ...partAdmissionClaim.response, ...basePayByInstalmentsData }
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('The defendant believes they owe you £30. You can accept or reject that this is the amount owed.'))
+            })
+          })
+        })
+
+        context('as a defendant', () => {
+          beforeEach(() => {
+            resolveRetrieveByClaimantIdToEmptyList()
+          })
+
+          it('should show claim issued statuses when the claim is issued', async () => {
+            resolveRetrieveByDefendantId('000MC001', '1', sampleClaimIssueObj, {
+              responseDeadline: MomentFactory.currentDate().add(1, 'days')
+            })
+
+            await request(app)
+              .get(Paths.dashboardPage.uri)
+              .set('Cookie', `${cookieName}=ABC`)
+              .expect(res => expect(res).to.be.successful.withText('Respond to claim.', '(1 day remaining)'))
+          })
+
+          context('when the claim is in full admission', () => {
+            const fullAdmissionClaim = {
+              ...sampleClaimObj,
+              responseDeadline: MomentFactory.currentDate().add(1, 'days'),
+              response: {
+                ...baseResponseData,
+                ...baseFullAdmissionData
+              }
+            }
+            it('should show pay immediately statuses when the claim is marked as pay immediately', async () => {
+              resolveRetrieveByDefendantId('000MC001', '1', fullAdmissionClaim, {
+                response: { ...fullAdmissionClaim.response, ...basePayImmediatelyData }
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('You’ve admitted all of the claim and said you’ll pay the full amount immediately.'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay immediately and payment is past the deadline', async () => {
+              resolveRetrieveByDefendantId('000MC001', '1', fullAdmissionClaim, {
+                response: { ...fullAdmissionClaim.response, ...basePayImmediatelyData },
+                responseDeadline: MomentFactory.currentDate().subtract(1, 'days')
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('You haven’t responded to the claim.', 'John Smith can now ask for a County Court Judgment (CCJ) against you.', 'You can still respond to this claim before they ask for a CCJ.'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay by set date', async () => {
+              resolveRetrieveByDefendantId('000MC001', '1', fullAdmissionClaim, {
+                response: { ...fullAdmissionClaim.response, ...basePayBySetDateData }
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('You’ve admitted all of the claim and offered to pay the full amount by 31 December 2050.'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay by instalments', async () => {
+              resolveRetrieveByDefendantId('000MC001', '1', fullAdmissionClaim, {
+                response: { ...fullAdmissionClaim.response, ...basePayByInstalmentsData }
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('You’ve admitted all of the claim and offered to pay the full amount in instalments.'))
+            })
+          })
+          context('when the claim is in partial admission', () => {
+            const partAdmissionClaim = {
+              ...sampleClaimObj,
+              responseDeadline: MomentFactory.currentDate().add(1, 'days'),
+              response: {
+                ...baseResponseData,
+                ...basePartialAdmissionData,
+                amount: 30
+              }
+            }
+            it('should show pay immediately statuses when the claim is marked as pay immediately', async () => {
+              resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
+                response: { ...partAdmissionClaim.response, ...basePayImmediatelyData }
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('You’ve admitted part of the claim.'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay immediately and the offer is accepted', async () => {
+              resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
+                response: { ...partAdmissionClaim.response, ...basePayImmediatelyData },
+                claimantResponse: baseAcceptationClaimantResponseData
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('John Smith accepted your admission of 30'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay immediately and the offer is accepted and response is after the deadline', async () => {
+              resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
+                response: { ...partAdmissionClaim.response, ...basePayImmediatelyData },
+                claimantResponse: baseAcceptationClaimantResponseData,
+                responseDeadline: MomentFactory.currentDate().subtract(1, 'days')
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('You haven’t responded to the claim.', 'John Smith can now ask for a County Court Judgment (CCJ) against you.', 'You can still respond to this claim before they ask for a CCJ.'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay by set date', async () => {
+              resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
+                response: { ...partAdmissionClaim.response, ...basePayBySetDateData }
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('You’ve admitted part of the claim.'))
+            })
+
+            it('should show pay immediately statuses when the claim is marked as pay by instalments', async () => {
+              resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
+                response: { ...partAdmissionClaim.response, ...basePayByInstalmentsData }
+
+              })
+
+              await request(app)
+                .get(Paths.dashboardPage.uri)
+                .set('Cookie', `${cookieName}=ABC`)
+                .expect(res => expect(res).to.be.successful.withText('You’ve admitted part of the claim.'))
+            })
+          })
+        })
+      })
+    })
   })
 })

--- a/src/test/features/dashboard/routes/index.ts
+++ b/src/test/features/dashboard/routes/index.ts
@@ -11,16 +11,8 @@ import { app } from 'main/app'
 
 import * as idamServiceMock from 'test/http-mocks/idam'
 import * as draftStoreServiceMock from 'test/http-mocks/draft-store'
+import * as claimStoreServiceMock from 'test/http-mocks/claim-store'
 import { checkAuthorizationGuards } from 'test/features/dashboard/routes/checks/authorization-check'
-import {
-  rejectRetrieveByClaimantId,
-  resolveRetrieveByClaimantId,
-  resolveRetrieveByClaimantIdToEmptyList,
-  resolveRetrieveByDefendantId,
-  resolveRetrieveByDefendantIdToEmptyList,
-  sampleClaimIssueObj,
-  sampleClaimObj
-} from 'test/http-mocks/claim-store'
 import { MomentFactory } from 'shared/momentFactory'
 import {
   baseFullAdmissionData,
@@ -47,7 +39,7 @@ describe('Dashboard page', () => {
 
       it('should return 500 and render error page when cannot retrieve claims', async () => {
         draftStoreServiceMock.resolveFind('claim')
-        rejectRetrieveByClaimantId('HTTP error')
+        claimStoreServiceMock.rejectRetrieveByClaimantId('HTTP error')
 
         await request(app)
           .get(Paths.dashboardPage.uri)
@@ -57,8 +49,8 @@ describe('Dashboard page', () => {
 
       context('when no claims issued', () => {
         beforeEach(() => {
-          resolveRetrieveByClaimantIdToEmptyList()
-          resolveRetrieveByDefendantIdToEmptyList()
+          claimStoreServiceMock.resolveRetrieveByClaimantIdToEmptyList()
+          claimStoreServiceMock.resolveRetrieveByDefendantIdToEmptyList()
         })
 
         it('should render page with start claim button when everything is fine', async () => {
@@ -73,8 +65,8 @@ describe('Dashboard page', () => {
 
       context('when at least one claim issued', () => {
         beforeEach(() => {
-          resolveRetrieveByClaimantId()
-          resolveRetrieveByDefendantId('000MC001', '1')
+          claimStoreServiceMock.resolveRetrieveByClaimantId()
+          claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1')
         })
 
         it('should render page with continue claim button when everything is fine', async () => {
@@ -103,11 +95,11 @@ describe('Dashboard page', () => {
 
         context('as a claimant', () => {
           beforeEach(() => {
-            resolveRetrieveByDefendantIdToEmptyList()
+            claimStoreServiceMock.resolveRetrieveByDefendantIdToEmptyList()
           })
 
-          it('should show claim issued statuses when the claim is issued', async () => {
-            resolveRetrieveByClaimantId(sampleClaimIssueObj, {
+          it('should show the correct status when the claim is issued', async () => {
+            claimStoreServiceMock.resolveRetrieveByClaimantId(claimStoreServiceMock.sampleClaimIssueObj, {
               responseDeadline: MomentFactory.currentDate().add(1, 'days')
             })
             await request(app)
@@ -118,15 +110,15 @@ describe('Dashboard page', () => {
 
           context('when the claim is in full admission', () => {
             const fullAdmissionClaim = {
-              ...sampleClaimObj,
+              ...claimStoreServiceMock.sampleClaimObj,
               responseDeadline: MomentFactory.currentDate().add(1, 'days'),
               response: {
                 ...baseResponseData,
                 ...baseFullAdmissionData
               }
             }
-            it('should show pay immediately statuses when the claim is marked as pay immediately', async () => {
-              resolveRetrieveByClaimantId(fullAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay immediately', async () => {
+              claimStoreServiceMock.resolveRetrieveByClaimantId(fullAdmissionClaim, {
                 response: { ...fullAdmissionClaim.response, ...basePayImmediatelyData }
               })
 
@@ -136,8 +128,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('The defendant admits they owe all the money. They’ve said that they will pay immediately.'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay immediately and payment is past the deadline', async () => {
-              resolveRetrieveByClaimantId(fullAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay immediately and payment is past the deadline', async () => {
+              claimStoreServiceMock.resolveRetrieveByClaimantId(fullAdmissionClaim, {
                 responseDeadline: MomentFactory.currentDate().subtract(1, 'days'),
                 response: { ...fullAdmissionClaim.response, ...basePayImmediatelyData }
               })
@@ -148,8 +140,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('The defendant has not responded to your claim. You can request a County Court Judgment against them.'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay by set date', async () => {
-              resolveRetrieveByClaimantId(fullAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay by set date', async () => {
+              claimStoreServiceMock.resolveRetrieveByClaimantId(fullAdmissionClaim, {
                 response: { ...fullAdmissionClaim.response, ...basePayBySetDateData }
               })
 
@@ -159,8 +151,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('The defendant has offered to pay by a set date. You can accept or reject their offer.'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay by instalments', async () => {
-              resolveRetrieveByClaimantId(fullAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay by instalments', async () => {
+              claimStoreServiceMock.resolveRetrieveByClaimantId(fullAdmissionClaim, {
                 response: { ...fullAdmissionClaim.response, ...basePayByInstalmentsData }
               })
 
@@ -172,7 +164,7 @@ describe('Dashboard page', () => {
           })
           context('when the claim is in partial admission', () => {
             const partAdmissionClaim = {
-              ...sampleClaimObj,
+              ...claimStoreServiceMock.sampleClaimObj,
               responseDeadline: MomentFactory.currentDate().add(1, 'days'),
               response: {
                 ...baseResponseData,
@@ -180,8 +172,8 @@ describe('Dashboard page', () => {
                 amount: 30
               }
             }
-            it('should show pay immediately statuses when the claim is marked as pay immediately', async () => {
-              resolveRetrieveByClaimantId(partAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay immediately', async () => {
+              claimStoreServiceMock.resolveRetrieveByClaimantId(partAdmissionClaim, {
                 response: { ...partAdmissionClaim.response, ...basePayImmediatelyData }
               })
 
@@ -191,8 +183,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('The defendant believes they owe you £30. You can accept or reject that this is the amount owed.'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay immediately and the offer is accepted', async () => {
-              resolveRetrieveByClaimantId(partAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay immediately and the offer is accepted', async () => {
+              claimStoreServiceMock.resolveRetrieveByClaimantId(partAdmissionClaim, {
                 response: { ...partAdmissionClaim.response, ...basePayImmediatelyData },
                 claimantResponse: baseAcceptationClaimantResponseData
               })
@@ -203,8 +195,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('You’ve accepted the defendant’s part admission. They said they’d pay immediately.'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay immediately and the offer is accepted and response is after the deadline', async () => {
-              resolveRetrieveByClaimantId(partAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay immediately and the offer is accepted and response is after the deadline', async () => {
+              claimStoreServiceMock.resolveRetrieveByClaimantId(partAdmissionClaim, {
                 response: { ...partAdmissionClaim.response, ...basePayImmediatelyData },
                 claimantResponse: baseAcceptationClaimantResponseData,
                 responseDeadline: MomentFactory.currentDate().subtract(1, 'days')
@@ -216,8 +208,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('The defendant has not responded to your claim. You can request a County Court Judgment against them.'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay by set date', async () => {
-              resolveRetrieveByClaimantId(partAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay by set date', async () => {
+              claimStoreServiceMock.resolveRetrieveByClaimantId(partAdmissionClaim, {
                 response: { ...partAdmissionClaim.response, ...basePayBySetDateData }
               })
 
@@ -227,8 +219,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('The defendant believes they owe you £30. You can accept or reject that this is the amount owed.'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay by instalments', async () => {
-              resolveRetrieveByClaimantId(partAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay by instalments', async () => {
+              claimStoreServiceMock.resolveRetrieveByClaimantId(partAdmissionClaim, {
                 response: { ...partAdmissionClaim.response, ...basePayByInstalmentsData }
               })
 
@@ -242,11 +234,11 @@ describe('Dashboard page', () => {
 
         context('as a defendant', () => {
           beforeEach(() => {
-            resolveRetrieveByClaimantIdToEmptyList()
+            claimStoreServiceMock.resolveRetrieveByClaimantIdToEmptyList()
           })
 
-          it('should show claim issued statuses when the claim is issued', async () => {
-            resolveRetrieveByDefendantId('000MC001', '1', sampleClaimIssueObj, {
+          it('should show the correct status when the claim is issued', async () => {
+            claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', claimStoreServiceMock.sampleClaimIssueObj, {
               responseDeadline: MomentFactory.currentDate().add(1, 'days')
             })
 
@@ -258,15 +250,15 @@ describe('Dashboard page', () => {
 
           context('when the claim is in full admission', () => {
             const fullAdmissionClaim = {
-              ...sampleClaimObj,
+              ...claimStoreServiceMock.sampleClaimObj,
               responseDeadline: MomentFactory.currentDate().add(1, 'days'),
               response: {
                 ...baseResponseData,
                 ...baseFullAdmissionData
               }
             }
-            it('should show pay immediately statuses when the claim is marked as pay immediately', async () => {
-              resolveRetrieveByDefendantId('000MC001', '1', fullAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay immediately', async () => {
+              claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', fullAdmissionClaim, {
                 response: { ...fullAdmissionClaim.response, ...basePayImmediatelyData }
               })
 
@@ -276,8 +268,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('You’ve admitted all of the claim and said you’ll pay the full amount immediately.'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay immediately and payment is past the deadline', async () => {
-              resolveRetrieveByDefendantId('000MC001', '1', fullAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay immediately and payment is past the deadline', async () => {
+              claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', fullAdmissionClaim, {
                 response: { ...fullAdmissionClaim.response, ...basePayImmediatelyData },
                 responseDeadline: MomentFactory.currentDate().subtract(1, 'days')
               })
@@ -288,8 +280,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('You haven’t responded to the claim.', 'John Smith can now ask for a County Court Judgment (CCJ) against you.', 'You can still respond to this claim before they ask for a CCJ.'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay by set date', async () => {
-              resolveRetrieveByDefendantId('000MC001', '1', fullAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay by set date', async () => {
+              claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', fullAdmissionClaim, {
                 response: { ...fullAdmissionClaim.response, ...basePayBySetDateData }
               })
 
@@ -299,8 +291,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('You’ve admitted all of the claim and offered to pay the full amount by 31 December 2050.'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay by instalments', async () => {
-              resolveRetrieveByDefendantId('000MC001', '1', fullAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay by instalments', async () => {
+              claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', fullAdmissionClaim, {
                 response: { ...fullAdmissionClaim.response, ...basePayByInstalmentsData }
               })
 
@@ -312,7 +304,7 @@ describe('Dashboard page', () => {
           })
           context('when the claim is in partial admission', () => {
             const partAdmissionClaim = {
-              ...sampleClaimObj,
+              ...claimStoreServiceMock.sampleClaimObj,
               responseDeadline: MomentFactory.currentDate().add(1, 'days'),
               response: {
                 ...baseResponseData,
@@ -320,8 +312,8 @@ describe('Dashboard page', () => {
                 amount: 30
               }
             }
-            it('should show pay immediately statuses when the claim is marked as pay immediately', async () => {
-              resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay immediately', async () => {
+              claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
                 response: { ...partAdmissionClaim.response, ...basePayImmediatelyData }
               })
 
@@ -331,8 +323,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('You’ve admitted part of the claim.'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay immediately and the offer is accepted', async () => {
-              resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay immediately and the offer is accepted', async () => {
+              claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
                 response: { ...partAdmissionClaim.response, ...basePayImmediatelyData },
                 claimantResponse: baseAcceptationClaimantResponseData
               })
@@ -343,8 +335,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('John Smith accepted your admission of £30'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay immediately and the offer is accepted and response is after the deadline', async () => {
-              resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
+            it('should show show the correct status when the claim is marked as pay immediately and the offer is accepted and response is after the deadline', async () => {
+              claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
                 response: { ...partAdmissionClaim.response, ...basePayImmediatelyData },
                 claimantResponse: baseAcceptationClaimantResponseData,
                 responseDeadline: MomentFactory.currentDate().subtract(1, 'days')
@@ -356,8 +348,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('You haven’t responded to the claim.', 'John Smith can now ask for a County Court Judgment (CCJ) against you.', 'You can still respond to this claim before they ask for a CCJ.'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay by set date', async () => {
-              resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay by set date', async () => {
+              claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
                 response: { ...partAdmissionClaim.response, ...basePayBySetDateData }
               })
 
@@ -367,8 +359,8 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText('You’ve admitted part of the claim.'))
             })
 
-            it('should show pay immediately statuses when the claim is marked as pay by instalments', async () => {
-              resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
+            it('should show the correct status when the claim is marked as pay by instalments', async () => {
+              claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim, {
                 response: { ...partAdmissionClaim.response, ...basePayByInstalmentsData }
 
               })

--- a/src/test/http-mocks/claim-store.ts
+++ b/src/test/http-mocks/claim-store.ts
@@ -408,10 +408,10 @@ export function resolveRetrieveClaimByExternalIdTo404HttpCode (reason: string = 
     .reply(HttpStatus.NOT_FOUND, reason)
 }
 
-export function resolveRetrieveByClaimantId (claimOverride?: object) {
+export function resolveRetrieveByClaimantId (claim: object = sampleClaimObj, claimOverride?: object) {
   mock(`${serviceBaseURL}/claims`)
     .get(new RegExp('/claimant/[0-9]+'))
-    .reply(HttpStatus.OK, [{ ...sampleClaimObj, ...claimOverride }])
+    .reply(HttpStatus.OK, [{ ...claim, ...claimOverride }])
 }
 
 export function resolveRetrieveByClaimantIdToEmptyList () {
@@ -456,10 +456,10 @@ export function rejectRetrieveByLetterHolderId (reason: string) {
     .reply(HttpStatus.INTERNAL_SERVER_ERROR, reason)
 }
 
-export function resolveRetrieveByDefendantId (referenceNumber: string, defendantId?: string) {
+export function resolveRetrieveByDefendantId (referenceNumber: string, defendantId?: string, claim: object = sampleClaimObj, claimOverride?: any) {
   mock(`${serviceBaseURL}/claims`)
     .get(new RegExp('/defendant/[0-9]+'))
-    .reply(HttpStatus.OK, [{ ...sampleClaimObj, referenceNumber: referenceNumber, defendantId: defendantId }])
+    .reply(HttpStatus.OK, [{ ...claim, referenceNumber: referenceNumber, defendantId: defendantId, ...claimOverride }])
 }
 
 export function rejectRetrieveByDefendantId (reason: string) {
@@ -638,10 +638,4 @@ export function resolveSavePaidInFull () {
   mock(`${serviceBaseURL}/claims`)
     .put(new RegExp('/' + externalIdPattern + '/paid-in-full'))
     .reply(HttpStatus.OK)
-}
-
-export function resolveRetrieveBySampleDataClaimant (sampleData?: object) {
-  mock(`${serviceBaseURL}/claims`)
-    .get(new RegExp('/claimant/[0-9]+'))
-    .reply(HttpStatus.OK, [{ ...sampleData }])
 }


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-5265

### Change description

- Adding a first battery of route tests covering a few cases in admissions. This will help to set up a pattern to follow for adding subsequent route tests.
- Also, fixing a UI bug surfaced by the route tests themselves. We were missing a `| numeral` filter in a template, so we were rendering a money amount as a simple integer

### Work checklist

- [x] Unit tests added where applicable
- [x] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
