### PR TITLE
Fix nightly cross-browser test

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:smoke": "./bin/run-smoke-tests.sh",
     "test:integration": "TS_NODE_TRANSPILE_ONLY=true codeceptjs run-multiple parallel --verbose --config default.conf.js --reporter mocha-multi",
     "test:integration-debug": "TS_NODE_TRANSPILE_ONLY=true codeceptjs run-multiple parallel --verbose --config default.conf.js",
-    "test:cross-browser": "TS_NODE_TRANSPILE_ONLY=true codeceptjs run --verbose --config saucelabs.conf.js --reporter mocha-multi",
+    "test:crossbrowser": "TS_NODE_TRANSPILE_ONLY=true codeceptjs run --verbose --config saucelabs.conf.js --reporter mocha-multi",
     "list-supported-browsers": "node -e 'Object.keys(require(\"@hmcts/cmc-supported-browsers\").supportedBrowsers).forEach(key => console.log(key))'",
     "sonar-scan": "sonar-scanner -Dsonar.projectName='CMC :: Citizen Frontend' -Dsonar.sources=src/main -Dsonar.tests=src/test -Dsonar.exclusions=src/main/public/** -Dsonar.typescript.lcov.reportPaths=coverage-report/lcov.info"
   },


### PR DESCRIPTION

### Change description

https://build.platform.hmcts.net/job/HMCTS_Nightly_CMC/job/cmc-citizen-frontend/job/master/

```
09:19:35 [_CMC_cmc-citizen-frontend_master] Running shell script
09:19:35 + yarn test:crossbrowser
09:19:35 yarn run v1.12.3
09:19:35 error Command "test:crossbrowser" not found.
09:19:35 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
