### PR TITLE
ROC-5265 Disable rendering of new dashboard statuses

### DIFF
--- a/src/main/features/dashboard/index.ts
+++ b/src/main/features/dashboard/index.ts
@@ -12,10 +12,7 @@ import { PaymentSchedule } from 'claims/models/response/core/paymentSchedule'
 import { Paths } from 'dashboard/paths'
 import { Claim } from 'claims/models/claim'
 import { ClaimStatusFlow } from 'dashboard/helpers/claimStatusFlow'
-import { Logger } from '@hmcts/nodejs-logging'
 import { app } from 'main/app'
-
-const logger = Logger.getLogger('DashboardFeature')
 
 function requestHandler (): express.RequestHandler {
   function accessDeniedCallback (req: express.Request, res: express.Response): void {
@@ -33,7 +30,6 @@ function render (claim: Claim, type: string): string {
     const template = nunjucks.render(path.join(__dirname, './views', 'status', type, dashboardName + '.njk').toString(), { claim: claim })
     return app.settings.nunjucksEnv.filters['safe'](template)
   } catch (err) {
-    logger.error(`view not found for status: ${dashboardName}`)
     return ''
   }
 }

--- a/src/main/features/dashboard/views/index.njk
+++ b/src/main/features/dashboard/views/index.njk
@@ -6,23 +6,13 @@
 
 {% set heading = 'Your money claims account' %}
 
-{% macro backwardCompatibleDashboardFor(claim, newStatus, type) %}
-  {% if newStatus %}
-    {{ newStatus }}
-  {% elif type === 'claimant' %}
-    {{ caseStatusForClaimant(claim.status, claim) }}
-  {% else %}
-    {{ caseStatusForDefendant(claim.status, claim) }}
-  {% endif %}
-{% endmacro %}
-
 {% block content %}
   <div class="grid-row">
     <div class="column-full">
       {% if not claimDraftSaved %}
         {{ internalLink(t('Make a new money claim'), EligibilityPaths.startPage.uri, 'newclaim', 'start-now') }}
       {% endif %}
-
+      
       {% if claimsAsClaimant | length or claimDraftSaved %}
 
       <h2 class="heading-medium"> {{ t('Claims you’ve made') }}</h2>
@@ -60,13 +50,13 @@
             <td>{{ claim.claimData.defendant.name }}</td>
             <td>{{ claim.totalAmountTillToday | numeral }}</td>
             <td class="mobile-hide">
-              {{ backwardCompatibleDashboardFor(claim, claimantDashboardStatus, 'claimant') }}
+              {{ caseStatusForClaimant(claim.status, claim) }}
             </td>
           </tr>
           <tr>
             <td colspan="3" class="mobile-table-status">
               {{ t('Status:') }}
-              {{ backwardCompatibleDashboardFor(claim, claimantDashboardStatus, 'claimant') }}
+              {{ caseStatusForClaimant(claim.status, claim) }}
             </td>
           </tr>
         {% endfor %}
@@ -106,13 +96,13 @@
             <td>{{ claim.claimData.claimant.name }}</td>
             <td>{{ claim.totalAmountTillToday | numeral }}</td>
             <td class="mobile-hide">
-              {{ backwardCompatibleDashboardFor(claim, defendantDashboardStatus, 'defendant') }}
+              {{ caseStatusForDefendant(claim.status, claim) }}
             </td>
           </tr>
           <tr>
             <td colspan="3" class="mobile-table-status">
               {{ t('Status:') }}
-              {{ backwardCompatibleDashboardFor(claim, defendantDashboardStatus, 'defendant') }}
+              {{ caseStatusForDefendant(claim.status, claim) }}
             </td>
           </tr>
         {% endfor %}

--- a/src/test/features/dashboard/routes/index.ts
+++ b/src/test/features/dashboard/routes/index.ts
@@ -73,10 +73,10 @@ const testData = [
     claim: claimStoreServiceMock.sampleClaimIssueObj,
     claimOverride: {
       moreTimeRequested: true,
-      responseDeadline: MomentFactory.currentDate().add(10, 'days')
+      responseDeadline: '2099-08-08'
     },
-    claimantAssertions: ['000MC050', 'Your claim has been sent.'],
-    defendantAssertions: ['000MC050', 'Respond to claim.', '(10 days remaining)']
+    claimantAssertions: ['000MC050', 'John Doe has requested more time to respond.'],
+    defendantAssertions: ['000MC050', 'You need to respond before 4pm on 8 August 2099.']
   },
   {
     status: 'full admission, pay immediately',


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-5265


### Change description
This disables the rendering of new dashboard statuses - we need to get a vertical slice of a flow to the very end to avoid messing up with the logic. 
Ie. a settled claim is incorrectly considered issued because the entirety of the journey is not yet modelled. This is currently being addressed in https://github.com/hmcts/cmc-citizen-frontend/pull/1502 where we take full admission all the way through


### Work checklist

- [x] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
