### PR TITLE
Fix broken master :(

### DIFF
--- a/src/test/features/dashboard/routes/index.ts
+++ b/src/test/features/dashboard/routes/index.ts
@@ -237,7 +237,7 @@ describe('Dashboard page', () => {
             })
 
             it('should show the correct status when the claim is marked as states paid rejected', async () => {
-              // draftStoreServiceMock.resolveFindNoDraftFound()
+              draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByClaimantId(partAdmissionClaim,
                 {
                   response: { ...partialAdmissionAlreadyPaidData },
@@ -252,7 +252,7 @@ describe('Dashboard page', () => {
             })
 
             it('should show the correct status when the claim is marked as states paid accepted', async () => {
-              // draftStoreServiceMock.resolveFindNoDraftFound()
+              draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByClaimantId(partAdmissionClaim,
                 {
                   response: { ...partialAdmissionAlreadyPaidData },
@@ -277,7 +277,7 @@ describe('Dashboard page', () => {
               }
             }
             it('should show the correct status when the claim is marked as states paid rejected', async () => {
-              // draftStoreServiceMock.resolveFindNoDraftFound()
+              draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByClaimantId(fullDefenceClaim,
                 {
                   response: { ...defenceWithAmountClaimedAlreadyPaidData },
@@ -292,7 +292,7 @@ describe('Dashboard page', () => {
             })
 
             it('should show the correct status when the claim is marked as states paid accepted', async () => {
-              // draftStoreServiceMock.resolveFindNoDraftFound()
+              draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByClaimantId(fullDefenceClaim,
                 {
                   response: { ...defenceWithAmountClaimedAlreadyPaidData },
@@ -341,7 +341,7 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText(...data.defendantAssertions))
             })
             it('should show the correct status when the claim is marked as states paid rejected', async () => {
-              // draftStoreServiceMock.resolveFindNoDraftFound()
+              draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim,
                 {
                   response: { ...partialAdmissionAlreadyPaidData },
@@ -356,7 +356,7 @@ describe('Dashboard page', () => {
 
             })
             it('should show the correct status when the claim is marked as states paid accepted', async () => {
-              // draftStoreServiceMock.resolveFindNoDraftFound()
+              draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim,
                 {
                   response: { ...partialAdmissionAlreadyPaidData },
@@ -381,7 +381,7 @@ describe('Dashboard page', () => {
               }
             }
             it('should show the correct status when the claim is marked as states paid rejected', async () => {
-              // draftStoreServiceMock.resolveFindNoDraftFound()
+              draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', fullDefenceClaim,
                 {
                   response: { ...defenceWithAmountClaimedAlreadyPaidData },
@@ -397,7 +397,7 @@ describe('Dashboard page', () => {
             })
 
             it('should show the correct status when the claim is marked as states paid accepted', async () => {
-              // draftStoreServiceMock.resolveFindNoDraftFound()
+              draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', fullDefenceClaim,
                 {
                   response: { ...defenceWithAmountClaimedAlreadyPaidData },

--- a/src/test/features/dashboard/routes/index.ts
+++ b/src/test/features/dashboard/routes/index.ts
@@ -237,6 +237,7 @@ describe('Dashboard page', () => {
             })
 
             it('should show the correct status when the claim is marked as states paid rejected', async () => {
+              // draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByClaimantId(partAdmissionClaim,
                 {
                   response: { ...partialAdmissionAlreadyPaidData },
@@ -251,6 +252,7 @@ describe('Dashboard page', () => {
             })
 
             it('should show the correct status when the claim is marked as states paid accepted', async () => {
+              // draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByClaimantId(partAdmissionClaim,
                 {
                   response: { ...partialAdmissionAlreadyPaidData },
@@ -275,6 +277,7 @@ describe('Dashboard page', () => {
               }
             }
             it('should show the correct status when the claim is marked as states paid rejected', async () => {
+              // draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByClaimantId(fullDefenceClaim,
                 {
                   response: { ...defenceWithAmountClaimedAlreadyPaidData },
@@ -289,6 +292,7 @@ describe('Dashboard page', () => {
             })
 
             it('should show the correct status when the claim is marked as states paid accepted', async () => {
+              // draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByClaimantId(fullDefenceClaim,
                 {
                   response: { ...defenceWithAmountClaimedAlreadyPaidData },
@@ -337,6 +341,7 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText(...data.defendantAssertions))
             })
             it('should show the correct status when the claim is marked as states paid rejected', async () => {
+              // draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim,
                 {
                   response: { ...partialAdmissionAlreadyPaidData },
@@ -351,6 +356,7 @@ describe('Dashboard page', () => {
 
             })
             it('should show the correct status when the claim is marked as states paid accepted', async () => {
+              // draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', partAdmissionClaim,
                 {
                   response: { ...partialAdmissionAlreadyPaidData },
@@ -375,6 +381,7 @@ describe('Dashboard page', () => {
               }
             }
             it('should show the correct status when the claim is marked as states paid rejected', async () => {
+              // draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', fullDefenceClaim,
                 {
                   response: { ...defenceWithAmountClaimedAlreadyPaidData },
@@ -390,6 +397,7 @@ describe('Dashboard page', () => {
             })
 
             it('should show the correct status when the claim is marked as states paid accepted', async () => {
+              // draftStoreServiceMock.resolveFindNoDraftFound()
               claimStoreServiceMock.resolveRetrieveByDefendantId('000MC001', '1', fullDefenceClaim,
                 {
                   response: { ...defenceWithAmountClaimedAlreadyPaidData },


### PR DESCRIPTION

### Change description

Master pipeline failing with broken `yarn test:coverage` stage:

```
13:40:16 [Unit tests and Sonar scan]   2 failing
13:40:16 [Unit tests and Sonar scan] 
13:40:16 [Unit tests and Sonar scan]   1) Dashboard page
13:40:16 [Unit tests and Sonar scan]        on GET
13:40:16 [Unit tests and Sonar scan]          when user authorised
13:40:16 [Unit tests and Sonar scan]            Dashboard Status
13:40:16 [Unit tests and Sonar scan]              as a claimant
13:40:16 [Unit tests and Sonar scan]                should show the correct status when the claim is marked as states paid rejected:
13:40:16 [Unit tests and Sonar scan]      AssertionError: expected response status code to be in '200' range but got 500 - see response extract below:
13:40:16 [Unit tests and Sonar scan] {
13:40:16 [Unit tests and Sonar scan]   statusCode: 500,
13:40:16 [Unit tests and Sonar scan]   headers: {
13:40:16 [Unit tests and Sonar scan]     content-language: "en",
13:40:16 [Unit tests and Sonar scan]     set-cookie: [
13:40:16 [Unit tests and Sonar scan]       "lang=en; path=/; expires=Sun, 22 Mar 2020 13:40:13 GMT"
13:40:16 [Unit tests and Sonar scan]     ],
13:40:16 [Unit tests and Sonar scan]     x-dns-prefetch-control: "off",
13:40:16 [Unit tests and Sonar scan]     x-frame-options: "SAMEORIGIN",
13:40:16 [Unit tests and Sonar scan]     strict-transport-security: "max-age=15552000; includeSubDomains",
13:40:16 [Unit tests and Sonar scan]     x-download-options: "noopen",
13:40:16 [Unit tests and Sonar scan]     x-content-type-options: "nosniff",
13:40:16 [Unit tests and Sonar scan]     x-xss-protection: "1; mode=block",
13:40:16 [Unit tests and Sonar scan]     surrogate-control: "no-store",
13:40:16 [Unit tests and Sonar scan]     cache-control: "no-store, no-cache, must-revalidate, proxy-revalidate",
13:40:16 [Unit tests and Sonar scan]     pragma: "no-cache",
13:40:16 [Unit tests and Sonar scan]     expires: "0",
13:40:16 [Unit tests and Sonar scan]     content-security-policy: "default-src 'none'; font-src 'self' data:; img-src 'self' *.google-analytics.com; style-src 'self'; script-src 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'self' *.google-analytics.com; connect-src 'self'; object-src 'self'; frame-ancestors 'none'",
13:40:16 [Unit tests and Sonar scan]     x-content-security-policy: "default-src 'none'; font-src 'self' data:; img-src 'self' *.google-analytics.com; style-src 'self'; script-src 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'self' *.google-analytics.com; connect-src 'self'; object-src 'self'; frame-ancestors 'none'",
13:40:16 [Unit tests and Sonar scan]     x-webkit-csp: "default-src 'none'; font-src 'self' data:; img-src 'self' *.google-analytics.com; style-src 'self'; script-src 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'self' *.google-analytics.com; connect-src 'self'; object-src 'self'; frame-ancestors 'none'",
13:40:16 [Unit tests and Sonar scan]     referrer-policy: "origin",
13:40:16 [Unit tests and Sonar scan]     content-type: "text/html; charset=utf-8",
13:40:16 [Unit tests and Sonar scan]     content-length: "6517",
13:40:16 [Unit tests and Sonar scan]     etag: "W/\"1975-DoLv32m1NHgUHLmVjWDlKGK0N6Y\"",
13:40:16 [Unit tests and Sonar scan]     date: "Fri, 22 Mar 2019 13:40:13 GMT",
13:40:16 [Unit tests and Sonar scan]     connection: "close"
13:40:16 [Unit tests and Sonar scan]   },
13:40:16 [Unit tests and Sonar scan]   text: ""
13:40:16 [Unit tests and Sonar scan] }
13:40:16 [Unit tests and Sonar scan]       at request.get.set.expect.res (src/test/features/dashboard/routes/index.ts:249:49)
13:40:16 [Unit tests and Sonar scan]       at Test._assertFunction (node_modules/supertest/lib/test.js:283:11)
13:40:16 [Unit tests and Sonar scan]       at Test.assert (node_modules/supertest/lib/test.js:173:18)
13:40:16 [Unit tests and Sonar scan]       at Server.localAssert (node_modules/supertest/lib/test.js:131:12)
13:40:16 [Unit tests and Sonar scan]       at emitCloseNT (net.js:1664:8)
13:40:16 [Unit tests and Sonar scan]       at _combinedTickCallback (internal/process/next_tick.js:136:11)
13:40:16 [Unit tests and Sonar scan]       at process._tickCallback (internal/process/next_tick.js:181:9)
13:40:16 [Unit tests and Sonar scan] 
13:40:16 [Unit tests and Sonar scan]   2) Dashboard page
13:40:16 [Unit tests and Sonar scan]        "after each" hook for "should show the correct status when the claim is marked as states paid rejected":
13:40:16 [Unit tests and Sonar scan] 
13:40:16 [Unit tests and Sonar scan]       At least one mock were declared but not used
13:40:16 [Unit tests and Sonar scan]       + expected - actual
13:40:16 [Unit tests and Sonar scan] 
13:40:16 [Unit tests and Sonar scan]       -[
13:40:16 [Unit tests and Sonar scan]       -  "GET http://cmc-claim-store-aat.service.core-compute-aat.internal:80/claims//\\/defendant\\/[0-9]+/"
13:40:16 [Unit tests and Sonar scan]       -  "GET http://cmc-claim-store-aat.service.core-compute-aat.internal:80/claims//\\/claimant\\/[0-9]+/"
13:40:16 [Unit tests and Sonar scan]       -]
13:40:16 [Unit tests and Sonar scan]       +[]
13:40:16 [Unit tests and Sonar scan]       
13:40:16 [Unit tests and Sonar scan]       at Context.afterEach (src/test/hooks.ts:17:85)
13:40:16 [Unit tests and Sonar scan] 
13:40:16 [Unit tests and Sonar scan] 
13:40:16 [Unit tests and Sonar scan] 
13:40:17 [Unit tests and Sonar scan] [mochawesome] Report JSON saved to /opt/jenkins/workspace/_CMC_cmc-citizen-frontend_master/mochawesome-report/mochawesome.json
13:40:17 [Unit tests and Sonar scan] 
13:40:17 [Unit tests and Sonar scan] [mochawesome] Report HTML saved to /opt/jenkins/workspace/_CMC_cmc-citizen-frontend_master/mochawesome-report/mochawesome.html
13:40:17 [Unit tests and Sonar scan] 
13:40:19 [Unit tests and Sonar scan] 
13:40:19 [Unit tests and Sonar scan] =============================== Coverage summary ===============================
13:40:19 [Unit tests and Sonar scan] Statements   : 94.65% ( 7718/8154 )
13:40:19 [Unit tests and Sonar scan] Branches     : 85.11% ( 1801/2116 )
13:40:19 [Unit tests and Sonar scan] Functions    : 94.45% ( 1480/1567 )
13:40:19 [Unit tests and Sonar scan] Lines        : 94.67% ( 7601/8029 )
13:40:19 [Unit tests and Sonar scan] ================================================================================
13:40:19 [Unit tests and Sonar scan] error Command failed with exit code 1.
```
