### PR TITLE
Fix e2e picking up 'INCOMPLETE' task as 'COMPLETE'

### DIFF
--- a/src/integration-test/tests/citizen/claimantResponse/steps/claimant-reponse.ts
+++ b/src/integration-test/tests/citizen/claimantResponse/steps/claimant-reponse.ts
@@ -296,7 +296,7 @@ export class ClaimantResponseSteps {
     testData: EndToEndTestData,
     claimantResponseTestData: ClaimantResponseTestData
   ): void {
-    I.dontSee('COMPLETE')
+    I.dontSeeElement({ css: 'div.task-finished:not(.unfinished)>strong' })
     taskListPage.selectTaskViewDefendantResponse()
     defendantsResponsePage.submit()
     taskListPage.selectTaskAcceptOrRejectTheirRepaymentPlan()


### PR DESCRIPTION
### Change description
Change check for I.dontSeeText('COMPLETE') in e2e tests for a CSS selector that selects the COMPLETE task
