### PR TITLE
Bug - Fix route test date mishap and unblock pipeline

### DIFF
--- a/src/test/features/claim/routes/claimant-dob.ts
+++ b/src/test/features/claim/routes/claimant-dob.ts
@@ -57,11 +57,10 @@ describe('Claim issue: claimant date of birth page', () => {
       it('should render page with error when DOB is less than 18', async () => {
         draftStoreServiceMock.resolveFind('claim')
         const date: Moment = MomentFactory.currentDate().subtract(1, 'year')
-
         await request(app)
           .post(ClaimPaths.claimantDateOfBirthPage.uri)
           .set('Cookie', `${cookieName}=ABC`)
-          .send({ known: 'true', date: { day: date.date(), month: date.month(), year: date.year() } })
+          .send({ known: 'true', date: { day: date.date(), month: date.month() + 1, year: date.year() } })
           .expect(res => expect(res).to.be.successful.withText('Please enter a date of birth before', 'div class="error-summary"'))
       })
 


### PR DESCRIPTION
### JIRA link
no ticket

### Change description
A bit of an 'ooof' moment. Using month() makes the `LocalDate` for that test be ```LocalDate { year: 2018, month: 2, day: 29 }``` which is not a valid date, so the validation is different than expected. 
This breaks the pipeline on the 29th of March of all non leap years _<nerdface.jpg>_ 💃 


### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
