### PR TITLE
Move nightly env vars to correct scope

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -46,11 +46,12 @@ env.FEATURE_TESTING_SUPPORT = 'true'
 // SAUCELABS config - configured on Jenkins (also IDAM_URL above used)
 env.SAUCELABS_BROWSER = 'chrome_win_latest'
 env.SAUCELABS_TUNNEL_IDENTIFIER = 'reformtunnel'
-env.TEST_URL = params.URL_TO_TEST //required
-env.CITIZEN_APP_URL = params.URL_TO_TEST //required
 env.CHUNKS = 3
 
 withNightlyPipeline("nodejs", product, component) {
+  env.TEST_URL = params.URL_TO_TEST //required
+  env.CITIZEN_APP_URL = params.URL_TO_TEST //required
+
   loadVaultSecrets(secrets)
   enableCrossBrowserTest()
   enableSecurityScan()


### PR DESCRIPTION

### Change description

Revert any changes to location of these env vars - back to where they were when e2e were running successfully. Scope must matter!

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
