### PR TITLE
ROC-5873 Remove link to CCJ on claimant's offer accepted claim status page

### DIFF
--- a/src/main/features/dashboard/views/macro/claimStatus/offerAccepted.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/offerAccepted.njk
@@ -18,10 +18,6 @@
     <p>{{ t('You’ve agreed to the offer made by {{ defendantName }} and signed an agreement to settle your claim. ', { defendantName: defendantName }) }}</p>
     <p>{{ t('We’ve asked {{ defendantName}} to sign the agreement.', { defendantName: defendantName }) }}</p>
   </div>
-  <h2 class="heading-small">{{ t('Request County Court Judgment') }}</h2>
-  <p>{{ t('If the defendant doesn’t pay or breaks the terms of the settlement agreement, you can '
-      + internalLink('request a County Court Judgment. ', CCJPaths.paidAmountPage.evaluateUri({
-        externalId:claim.externalId }) )) | safe }}</p>
 {% endmacro %}
 
 {% macro offerAcceptedForDefendantDashboard() %}

--- a/src/test/features/dashboard/routes/claimStatus/full-defence.ts
+++ b/src/test/features/dashboard/routes/claimStatus/full-defence.ts
@@ -253,9 +253,7 @@ const testData = [
       'Download their response',
       'Settle out of court',
       'You’ve agreed to the offer made by ' + fullDefenceClaim.claim.defendants[0].name + ' and signed an agreement to settle your claim.',
-      'We’ve asked ' + fullDefenceClaim.claim.defendants[0].name + ' to sign the agreement.',
-      'Request County Court Judgment',
-      'request a County Court Judgment'
+      'We’ve asked ' + fullDefenceClaim.claim.defendants[0].name + ' to sign the agreement.'
     ],
     defendantAssertions: [
       'Your response to the claim',
@@ -285,9 +283,7 @@ const testData = [
       'Download their response',
       'Settle out of court',
       'You’ve agreed to the offer made by ' + fullDefenceClaim.claim.defendants[0].name + ' and signed an agreement to settle your claim.',
-      'We’ve asked ' + fullDefenceClaim.claim.defendants[0].name + ' to sign the agreement.',
-      'Request County Court Judgment',
-      'request a County Court Judgment'
+      'We’ve asked ' + fullDefenceClaim.claim.defendants[0].name + ' to sign the agreement.'
     ],
     defendantAssertions: [
       'Your response to the claim',


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-5873

### Change description
Remove option to start the CCJ journey from the claim status page when accepted defendant's offer and pending countersignature.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
