### PR TITLE
bump version to fetch feature-toggle api from hmctspublic

### DIFF
--- a/charts/cmc-citizen-frontend/Chart.yaml
+++ b/charts/cmc-citizen-frontend/Chart.yaml
@@ -1,7 +1,7 @@
 description: Helm chart for the HMCTS CMC Citizen Frontend service
 name: cmc-citizen-frontend
 home: https://github.com/hmcts/cmc-citizen-frontend
-version: 1.0.7
+version: 1.0.8
 # be aware when bumping version that it is used elsewhere, e.g.:
 # chart-cmc - demo: https://github.com/hmcts/chart-cmc/tree/master/cmc
 # flux - AAT AKS: https://github.com/hmcts/cnp-flux-config/blob/365e8ee13e20d4f66c925f5a0648db26dcad8872/k8s/aat/money-claims/citizen-frontend/citizen-frontend.yaml#L15

--- a/charts/cmc-citizen-frontend/requirements.yaml
+++ b/charts/cmc-citizen-frontend/requirements.yaml
@@ -8,7 +8,7 @@ dependencies:
     tags:
       - idam-pr
   - name: rpe-feature-toggle-api
-    version: ~3.0.0
+    version: ~3.0.2
     repository: '@hmctspublic'
     tags:
       - rpe-feature-toggle-api-pod


### PR DESCRIPTION
### Change description

Bump feature toggles api version which uses "hmctspublic"

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No
