### PR TITLE
ROC 6200 check and send court name must not be null

### DIFF
--- a/src/main/features/directions-questionnaire/routes/hearing-exceptional-circumstances.ts
+++ b/src/main/features/directions-questionnaire/routes/hearing-exceptional-circumstances.ts
@@ -53,6 +53,7 @@ export default express.Router()
 
           if (form.model.exceptionalCircumstances.option === YesNoOption.YES.option) {
             draft.document.hearingLocation.courtName = defendantDirectionsQuestionnaire.hearingLocation.courtName
+            draft.document.hearingLocation.courtAccepted = YesNoOption.YES
             form.model.reason = undefined
           }
         } else {

--- a/src/test/features/claimant-response/helpers/taskListBuilder.ts
+++ b/src/test/features/claimant-response/helpers/taskListBuilder.ts
@@ -742,11 +742,8 @@ describe('Claimant response task list builder', () => {
         draft, claim, new MediationDraft()
       )
 
-      if (FeatureToggles.isEnabled('mediation')) {
-        expect(taskList.tasks.find(task => task.name === 'Free telephone mediation')).not.to.be.undefined
-      } else {
-        expect(taskList).to.be.eq(undefined)
-      }
+      expect(taskList.tasks.find(task => task.name === 'Free telephone mediation')).not.to.be.undefined
+
     })
 
   })

--- a/src/test/features/directions-questionnaire/routes/hearing-exceptional-circumstances.ts
+++ b/src/test/features/directions-questionnaire/routes/hearing-exceptional-circumstances.ts
@@ -49,6 +49,7 @@ function setupMocks (claimant: PartyType, defendant: PartyType, currentParty: Ma
       },
       hearingLocation: {
         courtName: 'Little Whinging, Surrey',
+        courtAccepted: YesNoOption.YES,
         locationOption: CourtLocationType.SUGGESTED_COURT,
         exceptionalCircumstancesReason: 'Poorly pet owl',
         hearingLocationSlug: undefined,


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-6200


### Change description

Clicking submit on claimant response was causing a court name null pointer exception

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
