### PR TITLE
ROC-6413 date-picker compatibility with IE11 and Edge

### DIFF
--- a/src/main/public/js/date-picker.js
+++ b/src/main/public/js/date-picker.js
@@ -98,7 +98,7 @@ const datePicker = {
         e.preventDefault();
         let dateIndex = /\d+$/.exec(e.currentTarget.id)[0];
         const d = dates
-          .map((localDate) => moment({ ...localDate, month: localDate.month - 1 }))
+          .map((localDate) => moment({ year: localDate.year, month: localDate.month - 1, day: localDate.day }))
           .map((mDate) => mDate.toDate())
           .sort((date1, date2) => date1.getTime() - date2.getTime())
           .filter((localDate, index) => index !== Number(dateIndex));


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-6413

### Change description
Continuation of https://github.com/hmcts/cmc-citizen-frontend/pull/1849
Found comments that Edge also doesn't like the `...spread` notation.

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
