### PR TITLE
Removed ECMAScript syntactic sugar not supported in IE11

### DIFF
--- a/src/main/public/js/date-picker.js
+++ b/src/main/public/js/date-picker.js
@@ -1,17 +1,17 @@
 const datePickerUtils = {
 
-  getIndexOfDate: (element) => $(element).data("index"),
+  getIndexOfDate: function(element) { return  $(element).data("index")},
 
-  getDisplayValueOfDate: (element) => new Date($(element).text()),
+  getDisplayValueOfDate: function(element) { return new Date($(element).text())},
 
-  buildDatesArray: (index, value) => {
+  buildDatesArray: function(index, value) {
     return {
-      index,
-      value
+      index: index,
+      value: value
     };
   },
 
-  formatDateForData: (d) => {
+  formatDateForData: function(d) {
     let mDate = moment(d);
     return {
       year: mDate.year(),
@@ -20,7 +20,7 @@ const datePickerUtils = {
     };
   },
 
-  displayFirstOfMonth: (date) => {
+  displayFirstOfMonth: function(date) {
     const mDate = moment(date);
     const day = mDate.format("D");
     let displayMonth = { content: "<span>" + day + "</span>" };
@@ -34,21 +34,21 @@ const datePickerUtils = {
 
 const datePicker = {
 
-  init: () => datePicker.getBankHolidays((bankHolidays) => datePicker.buildDatePicker(bankHolidays)),
+  init: function() { return datePicker.getBankHolidays(function(bankHolidays) { return datePicker.buildDatePicker(bankHolidays)})},
 
-  getBankHolidays: (callback) =>
+  getBankHolidays: function(callback) {
     $.ajax({
       type: "GET",
       url: "https://www.gov.uk/bank-holidays.json",
-      success: (res) => {
+      success: function(res) {
         const events = res["england-and-wales"].events;
-        const dates = events.map((event) => moment(event.date).format("MM-D-YYYY"));
+        const dates = events.map(function(event) { return moment(event.date).format("MM-D-YYYY")});
         callback(dates);
       },
-      error: () => callback([])
-    }),
+      error: function() { return callback([])}
+    })},
 
-  buildDatePicker: (datesDisabled) => {
+  buildDatePicker: function(datesDisabled) {
     datePicker.selector().datepicker({
       multidate: true,
       daysOfWeekDisabled: "06",
@@ -56,61 +56,61 @@ const datePicker = {
       startDate: "+1d",
       weekStart: 1,
       maxViewMode: 0,
-      datesDisabled,
+      datesDisabled: datesDisabled,
       templates: {
         leftArrow: datePicker.toggleArrows("prev"),
         rightArrow: datePicker.toggleArrows("next")
       },
-      beforeShowDay: (date) => datePickerUtils.displayFirstOfMonth(date)
-    }).on("changeDate", (event) => datePicker.changeDateHandler(event));
+      beforeShowDay: function(date) { return datePickerUtils.displayFirstOfMonth(date)}
+    }).on("changeDate", function(event) { return datePicker.changeDateHandler(event)});
 
     datePicker.setUpDOWHeading();
 
     // Update the date-picker with dates that have already been added.
-    const d = datePicker.getData().map((date) => date.value);
+    const d = datePicker.getData().map(function(date) { return date.value });
     datePicker.selector().datepicker("setDates", d);
   },
 
-  selector: () => $("#date-picker"),
+  selector: function() { return $("#date-picker")},
 
-  setUpDOWHeading: () => {
+  setUpDOWHeading: function() {
     const days = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"];
     const dow = $(".dow");
-    $.each(dow, (index, node) => node.textContent = days[index]);
+    $.each(dow, function(index, node) { return node.textContent = days[index]});
   },
 
-  toggleArrows: (nextOrPrevArrow) => "<img alt=\"" + nextOrPrevArrow + "\" src=\"/img/date-picker/" + nextOrPrevArrow + "_arrow.png\" />",
+  toggleArrows: function(nextOrPrevArrow) { return "<img alt=\"" + nextOrPrevArrow + "\" src=\"/img/date-picker/" + nextOrPrevArrow + "_arrow.png\" />" },
 
-  changeDateHandler: (event) => {
+  changeDateHandler: function(event) {
     const uuid = $("#externalId")[0].innerText;
     const csrf = $("input[name=\"_csrf\"]").val();
 
-    let dates = event.dates.map((eventDate) => datePickerUtils.formatDateForData(eventDate));
+    let dates = event.dates.map(function(eventDate) { return datePickerUtils.formatDateForData(eventDate)});
     $.post("/case/" + uuid + "/directions-questionnaire/hearing-dates/date-picker/replace", {
       _csrf: csrf,
       hasUnavailableDates: $("input[name=hasUnavailableDates]:checked").val(),
       unavailableDates: dates
-    }, (result) => {
+    }, function(result) {
       $("#date-selection-wrapper").empty().append(result);
       $("#date-selection-wrapper .add-another-delete-link").click(function (e) {
         e.preventDefault();
         let dateIndex = /\d+$/.exec(e.currentTarget.id)[0];
         const d = dates
-          .map((localDate) => moment({ year: localDate.year, month: localDate.month - 1, day: localDate.day }))
-          .map((mDate) => mDate.toDate())
-          .sort((date1, date2) => date1.getTime() - date2.getTime())
-          .filter((localDate, index) => index !== Number(dateIndex));
+          .map(function(localDate) { return moment({ year: localDate.year, month: localDate.month - 1, day: localDate.day })})
+          .map(function(mDate) { return mDate.toDate()})
+          .sort(function(date1, date2) { date1.getTime() - date2.getTime()})
+          .filter(function(localDate, index) { return index !== Number(dateIndex)});
         datePicker.selector().datepicker("setDates", d);
       });
     });
   },
 
-  getData: () => {
+  getData: function() {
     const list = $(".add-another-list .add-another-list-item > span").toArray();
-    return list.map((item) => datePickerUtils.buildDatesArray(
+    return list.map(function(item) { return datePickerUtils.buildDatesArray(
       datePickerUtils.getIndexOfDate(item),
       datePickerUtils.getDisplayValueOfDate(item)
-    ));
+    )});
   }
 };
 


### PR DESCRIPTION
Following ECMAScript 6 features have been converted to ES5 equivalent:

* Arrow Functions: http://es6-features.org/#ExpressionBodies
* Enhanced Object Properties: http://es6-features.org/#PropertyShorthand