### PR TITLE
ROC 6387 claim status page h2 incorrect size

### DIFF
--- a/src/main/features/dashboard/views/macro/caseStatus.njk
+++ b/src/main/features/dashboard/views/macro/caseStatus.njk
@@ -28,7 +28,9 @@
   claimRejectedFreeMediationNOWithoutDQsForClaimantDashboard,
   claimRejectedFreeMediationNOWithoutDQsForDefendantDashboard,
   claimRejectedWithDQsForDefendantDashboard,
-  claimRejectedWithDQsForClaimantDashboard %}
+  claimRejectedWithDQsForClaimantDashboard,
+  claimRejectedFreeMediationYesWithoutDQsForDefendantDashboard,
+  claimRejectedFreeMediationYesWithoutDQsForClaimantDashboard %}
 
 {% from "./claimStatus/claimPartAdmittedDefendant.njk" import
   claimPartAdmittedAlreadyPaidForDefendantDashboard,
@@ -175,7 +177,11 @@
   {% elif status === ClaimStatus.PART_ADMIT_PAY_IMMEDIATELY %}
     {{ partAdmittedClaimantAcceptsClaimantDashboard(claim) }}
   {% elif status === ClaimStatus.CLAIMANT_REJECTED_DEFENDANT_DEFENCE_NO_DQ %}
-    {{ claimRejectedFreeMediationNOWithoutDQsForClaimantDashboard() }}
+    {% if claim.claimantResponse.freeMediation === FreeMediationOption.NO %}
+      {{ claimRejectedFreeMediationNOWithoutDQsForClaimantDashboard(claim) }}
+    {% else %}
+      {{ claimRejectedFreeMediationYesWithoutDQsForClaimantDashboard(claim) }}
+    {% endif %}
   {% elif status === ClaimStatus.DEFENDANT_REJECTS_WITH_DQS %}
     {{ claimRejectedWithDQsForClaimantDashboard(claim) }}
   {% elif status === ClaimStatus.ORDER_DRAWN %}
@@ -271,7 +277,11 @@
   {% elif status === ClaimStatus.SETTLEMENT_AGREEMENT_REJECTED %}
     {{ settlementAgreementRejectedForDefendantDashboard() }}
   {% elif status === ClaimStatus.CLAIMANT_REJECTED_DEFENDANT_DEFENCE_NO_DQ %}
-    {{ claimRejectedFreeMediationNOWithoutDQsForDefendantDashboard() }}
+    {% if claim.claimantResponse.freeMediation === FreeMediationOption.NO %}
+      {{ claimRejectedFreeMediationNOWithoutDQsForDefendantDashboard(claim) }}
+    {% else %}
+      {{ claimRejectedFreeMediationYesWithoutDQsForDefendantDashboard(claim) }}
+    {% endif %}
   {% elif status === ClaimStatus.DEFENDANT_REJECTS_WITH_DQS %}
     {{ claimRejectedWithDQsForDefendantDashboard(claim) }}
   {% elif status === ClaimStatus.ORDER_DRAWN %}

--- a/src/main/features/dashboard/views/macro/claimStatus/admissionByCCJClaimant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/admissionByCCJClaimant.njk
@@ -8,7 +8,7 @@
 
 {% macro admissionByCCJClaimantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('You requested a County Court Judgment against {{ defendantName }}',
+    <h2 class="heading-medium">{{ t('You requested a County Court Judgment against {{ defendantName }}',
         { defendantName: claim.claimData.defendant.name }) }}</h2>
     <p>{{ t('When we’ve processed your request, we’ll post a copy of the judgment to you and to {{ defendantName }}',
         { defendantName: claim.claimData.defendant.name }) }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/admissionByCCJDefendant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/admissionByCCJDefendant.njk
@@ -44,7 +44,7 @@
 
 {% macro CCJAfterDefendantDidNotSignSettlementAgreementClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('A County Court Judgment (CCJ) has been issued against you') }}</h2>
+    <h2 class="heading-medium">{{ t('A County Court Judgment (CCJ) has been issued against you') }}</h2>
     {% if claim.response.responseType === domain.ResponseType.FULL_ADMISSION %}
       {% if claim.claimantResponse.courtDetermination %}
         <p>{{ t('They rejected your repayment plan.') }}</p>
@@ -75,7 +75,7 @@
 
 {% macro CCJByDeterminationDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('{{ claimantName }} requested a County Court Judgment (CCJ) against you', { claimantName: claim.claimData.claimant.name }) }}</h2>
+    <h2 class="heading-medium">{{ t('{{ claimantName }} requested a County Court Judgment (CCJ) against you', { claimantName: claim.claimData.claimant.name }) }}</h2>
     {% if claim.response.responseType === domain.ResponseType.FULL_ADMISSION %}
       <p>{{ t('They rejected your repayment plan.') }}</p>
     {% elif claim.response.responseType === domain.ResponseType.PART_ADMISSION %}

--- a/src/main/features/dashboard/views/macro/claimStatus/breachOfPaymentDefendant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/breachOfPaymentDefendant.njk
@@ -7,7 +7,7 @@
 
 {% macro CCJAfterBreakingSettlementAgreementClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('{{ claimantName }} requested a County Court Judgment (CCJ) against you', { claimantName: claim.claimData.claimant.name }) }}</h2>
+    <h2 class="heading-medium">{{ t('{{ claimantName }} requested a County Court Judgment (CCJ) against you', { claimantName: claim.claimData.claimant.name }) }}</h2>
     <p>{{ t('They requested the judgment because you didn’t pay on time or didn’t pay the correct amount.') }}</p>
     <p>{{ internalLink('View the repayment plan', CCJPaths.repaymentPlanSummaryPage.evaluateUri({ externalId: claim.externalId, madeBy: MadeBy.DEFENDANT.value })) }}</p>
 
@@ -17,7 +17,7 @@
 
 {% macro pastPaymentDeadlineDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('{{ claimantName }} requested a County Court Judgment (CCJ) against you', { claimantName: claim.claimData.claimant.name }) }}</h2>
+    <h2 class="heading-medium">{{ t('{{ claimantName }} requested a County Court Judgment (CCJ) against you', { claimantName: claim.claimData.claimant.name }) }}</h2>
     {% if claim.response.responseType === domain.ResponseType.PART_ADMISSION and claim.claimantResponse.courtDetermination %}
       <p>{{ t('They accepted your offer to pay {{ partAdmitAmount }}. They rejected your repayment plan.',
           { partAdmitAmount: claim.response.amount | numeral }) }}</p>
@@ -37,7 +37,7 @@
 
 {% macro admissionByCCJAfterPayImmediatelyDeadlineClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('A County Court Judgment (CCJ) has been issued against you') }}</h2>
+    <h2 class="heading-medium">{{ t('A County Court Judgment (CCJ) has been issued against you') }}</h2>
     {% if claim.response.responseType === domain.ResponseType.FULL_ADMISSION %}
       <p>{{ t('You agreed to pay the full {{ amount }} immediately.', { amount: claim.response.amount | numeral }) }}</p>
     {% elif claim.response.responseType === domain.ResponseType.PART_ADMISSION %}
@@ -52,7 +52,7 @@
 
 {% macro CCJAfterDefendantDidNotSignSettlementAgreementClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('A County Court Judgment (CCJ) has been issued against you') }}</h2>
+    <h2 class="heading-medium">{{ t('A County Court Judgment (CCJ) has been issued against you') }}</h2>
 
     <p>{{ t('{{ claimantName }} accepted your repayment plan.', { claimantName: claim.claimData.claimant.name }) }}</p>
     <p>{{ t('They asked you to sign a settlement agreement. Because you didn’t sign it, they requested a CCJ against you.') }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/ccjEligible.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/ccjEligible.njk
@@ -8,7 +8,7 @@
 {% macro ccjEligibleForClaimantClaimDetails(claim, csrf) %}
   <div class="status-block">
     {% set defendantName = claim.claimData.defendant.name %}
-    <h2 class="heading-small">{{ t('You can request a County Court Judgment') }}</h2>
+    <h2 class="heading-medium">{{ t('You can request a County Court Judgment') }}</h2>
     <p>{{ t('{{ defendantName }} has not responded to your claim by the deadline. '
         + 'You can request a County Court Judgment (CCJ) against them.',
         { defendantName : defendantName }) }}</p>
@@ -31,7 +31,7 @@
 
 {% macro ccjEligibleForDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('You haven’t responded to this claim') }}</h2>
+    <h2 class="heading-medium">{{ t('You haven’t responded to this claim') }}</h2>
     <p>{{ t('You haven’t responded to the claim. {{ claimantName }} can now ask for a County Court Judgment against you.',
         { claimantName: claim.claimData.claimant.name }) }}</p>
     <p>{{ t('A County Court Judgment can mean you find it difficult to get credit, like a mortgage or mobile phone contract. Bailiffs could also be sent to your home.') }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/ccjRequested.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/ccjRequested.njk
@@ -7,7 +7,7 @@
 
 {% macro ccjRequestedForClaimantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('You’ve requested a County Court Judgment (CCJ)') }}</h2>
+    <h2 class="heading-medium">{{ t('You’ve requested a County Court Judgment (CCJ)') }}</h2>
     <p>{{ t('We’ll contact you within 14 days to tell you whether the judgment has been entered.') }}</p>
     <p>{{ t('{{ defendantName }} can no longer respond to your claim using this service - they may have responded by post.',
         { defendantName: claim.claimData.defendant.name }) }}</p>
@@ -21,7 +21,7 @@
 
 {% macro ccjRequestedForDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('We’ll contact you') }}</h2>
+    <h2 class="heading-medium">{{ t('We’ll contact you') }}</h2>
     <p>{{ t('{{ claimantName }} has requested a County Court Judgment (CCJ) against you because the deadline for your response has passed.',
         { claimantName : claim.claimData.claimant.name }) }}</p>
     <p>{{ t('If you’ve responded by post before the deadline, we may still be processing your response. If we receive your postal response, we’ll reject the request for a CCJ.') }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/claimFullAdmissionForClaimant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/claimFullAdmissionForClaimant.njk
@@ -17,7 +17,7 @@
 {% macro claimFullAdmissionForClaimantClaimDetails(claim) %}
   <div class="status-block">
     {% if claim.response.paymentIntention.paymentOption === domain.PaymentOption.IMMEDIATELY %}
-    <h2 class="heading-small">{{ t('The defendant said they’ll pay you immediately') }}</h2>
+    <h2 class="heading-medium">{{ t('The defendant said they’ll pay you immediately') }}</h2>
     <p>{{ t('They must make sure you have the money by {{ paymentDate }}. Any cheques or transfers should be clear in your
       account.',
       { paymentDate: claim.response.paymentIntention.paymentDate | date }) }}</p>
@@ -52,7 +52,7 @@
 
 {% macro claimFullAdmissionPayImmediatelyPastDeadlineForClaimantClaimDetails(claim) %}
 <div class="status-block">
-  <h2 class="heading-small">{{ t('The defendant said they’ll pay you immediately') }}</h2>
+  <h2 class="heading-medium">{{ t('The defendant said they’ll pay you immediately') }}</h2>
   <p>{{ t('They must make sure you have the money by {{ paymentDate }}. Any cheques or transfers should be clear in your
     account.',
     { paymentDate: claim.response.paymentIntention.paymentDate | date }) }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/claimFullAdmissionForDefendant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/claimFullAdmissionForDefendant.njk
@@ -16,7 +16,7 @@
 
 {% macro claimFullAdmissionForDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Your response to the claim') }}</h2>
+    <h2 class="heading-medium">{{ t('Your response to the claim') }}</h2>
     {% set claimant = claim.claimData.claimant %}
     {% set amount = claim.totalAmountTillToday | numeral %}
     {% set paymentIntention = claim.response.paymentIntention %}

--- a/src/main/features/dashboard/views/macro/claimStatus/claimPartAdmissionClaimant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/claimPartAdmissionClaimant.njk
@@ -13,7 +13,7 @@
 
 {% macro claimPartAdmittedAlreadyPaidForClaimantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Respond to the defendant') }}</h2>
+    <h2 class="heading-medium">{{ t('Respond to the defendant') }}</h2>
     <p>{{ t('{{ defendantName }} says they paid you {{ amount }} on {{ paymentDate }}.',
         { defendantName: claim.claimData.defendant.name, amount: claim.response.amount | numeral, paymentDate: claim.response.paymentDeclaration.paidDate | date }) }}</p>
     <p>{{ t('You can accept or reject this response.') }}</p>
@@ -28,7 +28,7 @@
 
 {% macro claimPartAdmittedToOweForClaimantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('The defendant has admitted they owe {{ amount }} ', { amount: claim.response.amount | numeral }) }}</h2>
+    <h2 class="heading-medium">{{ t('The defendant has admitted they owe {{ amount }} ', { amount: claim.response.amount | numeral }) }}</h2>
 
     {% if claim.response.paymentIntention.paymentOption === domain.PaymentOption.IMMEDIATELY %}
       <p>{{ t('They said they don’t owe the full amount you claimed.') }}</p>
@@ -55,7 +55,7 @@
 
 {% macro partAdmittedPayImmediatelyClaimantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('The defendant has admitted they owe {{ amount }} ', { amount: claim.response.amount | numeral }) }}</h2>
+    <h2 class="heading-medium">{{ t('The defendant has admitted they owe {{ amount }} ', { amount: claim.response.amount | numeral }) }}</h2>
     <p>{{ t('They said they’ll pay you immediately.') }}</p>
     <p>{{ t('They must make sure you have the money by {{ paymentDate }}. Any cheques or transfers should be clear in your account.',
         { paymentDate: claim.response.paymentIntention.paymentDate | date }) }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/claimPartAdmittedDefendant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/claimPartAdmittedDefendant.njk
@@ -14,7 +14,7 @@
 
 {% macro claimPartAdmittedAlreadyPaidForDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Your response to the claim') }}</h2>
+    <h2 class="heading-medium">{{ t('Your response to the claim') }}</h2>
     <p>{{ t('We’ve emailed {{ claimantName }} telling them when and how you said you paid the claim.',
         { claimantName: claim.claimData.claimant.name }) }}</p>
     <p>{{ t('We’ll contact you to let you know how they respond. They can confirm you’ve paid and the claim is ' +
@@ -33,7 +33,7 @@
   {% set claimantDetailsPageURI = DashboardPaths.contactThemPage.evaluateUri({ externalId: claim.externalId }) %}
 
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Your response to the claim') }}</h2>
+    <h2 class="heading-medium">{{ t('Your response to the claim') }}</h2>
     <p>{% if paymentIntention.paymentOption === domain.PaymentOption.IMMEDIATELY %}
         {{ t('You’ve said you owe {{ amount }} and offered to pay {{ claimantName }} immediately.',
           { amount: claim.response.amount | numeral, claimantName: claimant.name }) }}
@@ -65,7 +65,7 @@
 
 {% macro partAdmittedAcceptedPayImmediatelyDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('{{ claimantName }} accepted your admission of {{ amount }}',
+    <h2 class="heading-medium">{{ t('{{ claimantName }} accepted your admission of {{ amount }}',
         { amount: claim.response.amount | numeral, claimantName: claim.claimData.claimant.name }) }}</h2>
     <p>{{ t('You must pay them by {{ paymentDate }}. Any cheques or transfers must be clear in their account by then.',
         { paymentDate: claim.response.paymentIntention.paymentDate | date }) }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/claimRejected.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/claimRejected.njk
@@ -159,7 +159,7 @@
 
     {% if claim.claimantResponse.freeMediation === FreeMediationOption.YES %}
       <p>{{ t('You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.') }}</p>
-      {{ externalLink(t('Find out how mediation works'), 'https://www.gov.uk/government/publications/small-claims-mediation-service-ex730') }}
+      <p>{{ externalLink(t('Find out how mediation works'), 'https://www.gov.uk/government/publications/small-claims-mediation-service-ex730') }}</p>
     {% endif %}
   </div>
 {% endmacro %}
@@ -310,6 +310,14 @@
   {{ t('Tell us your hearing requirements') }}
 {% endmacro %}
 
+{% macro claimRejectedFreeMediationYesWithoutDQsForClaimantDashboard() %}
+  {{ t('We will contact you with a meditation appointment') }}
+{% endmacro %}
+
 {% macro claimRejectedFreeMediationNOWithoutDQsForDefendantDashboard() %}
   {{ t('Tell us your hearing requirements') }}
+{% endmacro %}
+
+{% macro claimRejectedFreeMediationYesWithoutDQsForDefendantDashboard() %}
+  {{ t('We will contact you with a meditation appointment') }}
 {% endmacro %}

--- a/src/main/features/dashboard/views/macro/claimStatus/claimRejected.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/claimRejected.njk
@@ -7,7 +7,7 @@
 
 {% macro claimRejectedAlreadyPaidForClaimantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('The defendant’s response') }}</h2>
+    <h2 class="heading-medium">{{ t('The defendant’s response') }}</h2>
     <p>{{ t('{{ defendantName }} says they paid you {{ amount }} on {{ paymentDate }}.',
         { defendantName: claim.claimData.defendant.name, amount: claim.response.paymentDeclaration.paidAmount | numeral, paymentDate: claim.response.paymentDeclaration.paidDate | date }) }}</p>
     <p>{{ t('You can accept or reject this response.') }}</p>
@@ -22,7 +22,7 @@
 
 {% macro claimRejectedAlreadyPaidForDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Your response to the claim') }}</h2>
+    <h2 class="heading-medium">{{ t('Your response to the claim') }}</h2>
     <p>{{ t('We’ve emailed {{ claimantName }} telling them when and how you said you paid the claim.',
         { claimantName: claim.claimData.claimant.name }) }}</p>
     <p>{{ t('We’ll contact you to let you know how they respond. They can confirm you’ve paid and the claim is ' +
@@ -66,7 +66,7 @@
 
 {% macro claimRejectedDefendantDefenceFreeMediationNOForDefendantDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Wait for the court to review the case') }}</h2>
+    <h2 class="heading-medium">{{ t('Wait for the court to review the case') }}</h2>
     <p>{{ t('{{ claimantName }} has rejected your defence.',
         { claimantName: claim.claimData.claimant.name }) }}</p>
     <p>{{ t('The court will review the case. We’ll email you if we set a hearing date to tell you how to prepare.') }}</p>
@@ -75,7 +75,7 @@
 
 {% macro claimRejectedDefendantDefenceFreeMediationYESForDefendantDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
+    <h2 class="heading-medium">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
     <p>{{ t('{{ claimantName }} has rejected your defence.',
         { claimantName: claim.claimData.claimant.name }) }}</p>
     <p>{{ t('You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.') }}</p>
@@ -85,7 +85,7 @@
 
 {% macro claimRejectedDefendantDefenceFreeMediationNOForClaimantDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Wait for the court to review the case') }}</h2>
+    <h2 class="heading-medium">{{ t('Wait for the court to review the case') }}</h2>
     <p>{{ t('You’ve rejected defendant’s response and said you want to take the case to court.') }}</p>
     <p>{{ t('The court will review the case. We’ll email you if we set a hearing date to tell you how to prepare.') }}</p>
   </div>
@@ -98,14 +98,14 @@
 {% macro claimRejectedFreeMediationNOForDefendantClaimDetails(claim) %}
   {% if featureToggles.directionsQuestionnaire and claim.isIntentionToProceedEligible() %}
     <div class="status-block">
-      <h2 class="heading-small">{{ t('Wait for the claimant to respond') }}</h2>
+      <h2 class="heading-medium">{{ t('Wait for the claimant to respond') }}</h2>
       <p>{{ t('You’ve rejected the claim.') }}</p>
       <p>{{ t('You said you don’t want to use mediation to solve it. You might have to go to a hearing.') }}</p>
       <p>{{ t('We’ll contact you when the claimant responds.') }}</p>
     </div>
   {% else %}
     <div class="status-block">
-      <h2 class="heading-small">{{ t('Your response to the claim') }}</h2>
+      <h2 class="heading-medium">{{ t('Your response to the claim') }}</h2>
       <p>{{ t('You’ve rejected the claim and said you don’t want to use mediation to solve it. You’ll have to go to a hearing.') }}</p>
       {{ _linkToDirectionsQuestionnairePage(claim.externalId) }}
       <p>{{ t('Your defence will be cancelled if you don’t complete and return the form before 4pm on {{ deadline }}.',
@@ -122,14 +122,14 @@
 {% macro claimRejectedFreeMediationYESForDefendantClaimDetails(claim) %}
   {% if featureToggles.mediation %}
     <div class="status-block">
-      <h2 class="heading-small">{{ t('Wait for the claimant to respond') }}</h2>
+      <h2 class="heading-medium">{{ t('Wait for the claimant to respond') }}</h2>
       <p>{{ t('You’ve rejected the claim.') }}</p>
       <p>{{ t('You said you don’t want to use mediation to solve it. You might have to go to a hearing.') }}</p>
       <p>{{ t('We’ll contact you when the claimant responds.') }}</p>
     </div>
   {% else %}
     <div class="status-block">
-      <h2 class="heading-small">{{ t('Your response to the claim') }}</h2>
+      <h2 class="heading-medium">{{ t('Your response to the claim') }}</h2>
       <p>{{ t('You have rejected the claim. You’ve suggested mediation.') }}</p>
       <p>{{ t('We’ll ask {{ claimantName }} if they agree to take part in mediation.',
           { claimantName: claim.claimData.claimant.name }) }}</p>
@@ -155,7 +155,7 @@
 
 {% macro claimRejectedDefendantDefenceFreeMediationYESForClaimantDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('You’ve rejected {{ defendantName }} response.', { defendantName: claim.claimData.defendant.name }) }}</h2>
+    <h2 class="heading-medium">{{ t('You’ve rejected {{ defendantName }} response.', { defendantName: claim.claimData.defendant.name }) }}</h2>
 
     {% if claim.claimantResponse.freeMediation === FreeMediationOption.YES %}
       <p>{{ t('You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.') }}</p>
@@ -166,7 +166,7 @@
 
 {% macro claimRejectedWithDQsForClaimantClaimDetails(claim, mediationDeadline) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Decide whether to proceed') }}</h2>
+    <h2 class="heading-medium">{{ t('Decide whether to proceed') }}</h2>
     <p>{{ t('{{ defendantName }} has rejected your claim.', { defendantName: claim.claimData.defendant.name }) }}</p>
     <p>{{ t('You need to decide whether to proceed with the claim. You need to respond before 4pm on {{ respondToMediationDeadline }}. Your claim won’t continue if you don’t respond by then.',
         { respondToMediationDeadline: mediationDeadline | date }) }}</p>
@@ -176,7 +176,7 @@
 
 {% macro claimRejectedWithDQsForDefendantClaimDetails(claim, mediationDeadline) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Wait for the claimant to respond') }}</h2>
+    <h2 class="heading-medium">{{ t('Wait for the claimant to respond') }}</h2>
     {% if claim.response.freeMediation === YesNoOption.Yes %}
       <p>{{ t('You have rejected the claim. You’ve suggested mediation.') }}</p>
       <p>{{ t('We’ll ask {{ claimantName }} if they agree to take part in mediation.', { claimantName: claim.claimData.claimant.name }) }}</p>
@@ -200,7 +200,7 @@
 
 {% macro claimRejectedFreeMediationYESForDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Your response to the claim') }}</h2>
+    <h2 class="heading-medium">{{ t('Your response to the claim') }}</h2>
     <p>{{ t('You have rejected the claim. You’ve suggested mediation.') }}</p>
     <p>{{ t('We’ll ask {{ claimantName }} if they agree to take part in mediation.',
         { claimantName: claim.claimData.claimant.name }) }}</p>
@@ -231,7 +231,7 @@
 {% macro claimRejectedForClaimantClaimDetails(claim, mediationDeadline) %}
   {% if featureToggles.mediation and claim.isIntentionToProceedEligible() %}
     <div class="status-block">
-      <h2 class="heading-small">{{ t('Decide whether to proceed') }}</h2>
+      <h2 class="heading-medium">{{ t('Decide whether to proceed') }}</h2>
       <p>{{ t('{{ defendantName }} has rejected your claim.', { defendantName: claim.claimData.defendant.name }) }}</p>
       <p>{{ t('You need to decide whether to proceed with the claim. You need to respond before 4pm on {{ respondToMediationDeadline }}. Your claim won’t continue if you don’t respond by then.',
           { respondToMediationDeadline: mediationDeadline | date }) }}</p>
@@ -239,7 +239,7 @@
     </div>
   {% elif claim.response.freeMediation === YesNoOption.YES.option %}
     <div class="status-block">
-      <h2 class="heading-small">{{ t('The defendant’s response') }}</h2>
+      <h2 class="heading-medium">{{ t('The defendant’s response') }}</h2>
       <p>{{ t('{{ defendantName }} has rejected the claim. They’ve suggested mediation to help resolve this dispute.',
           { defendantName: claim.claimData.defendant.name }) }}</p>
       <p>{{ t(externalLink('Find out how mediation works', 'https://formfinder.hmctsformfinder.justice.gov.uk/ex730-eng.pdf') + ' (PDF, 399KB)') | safe }}</p>
@@ -257,7 +257,7 @@
     </div>
   {% else %}
     <div class="status-block">
-      <h2 class="heading-small">{{ t('The defendant has rejected your claim') }}</h2>
+      <h2 class="heading-medium">{{ t('The defendant has rejected your claim') }}</h2>
       <p>{{ t('They said they dispute your claim.') }}</p>
       {{ _linkToDirectionsQuestionnairePage(claim.externalId) }}
       <p>{{ t('Your claim won’t proceed if you don’t complete and return the form before 4pm on {{ deadline }}.',
@@ -273,7 +273,7 @@
 
 {% macro claimRejectedFreeMediationNOWithoutDQsForClaimantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('You rejected {{ defendantName }}’s response',
+    <h2 class="heading-medium">{{ t('You rejected {{ defendantName }}’s response',
           { defendantName: claim.claimData.defendant.name }) }}</h2>
     <p>{{ t('You need to {{ completeDQ }} form to tell us your requirements in case there’s a hearing.',
         { completeDQ: internalLink(
@@ -291,7 +291,7 @@
 
 {% macro claimRejectedFreeMediationNOWithoutDQsForDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('The claimant rejected your response') }}</h2>
+    <h2 class="heading-medium">{{ t('The claimant rejected your response') }}</h2>
     <p>{{ t('You’ll have to go to a hearing.') }}</p>
     <p>{{ t('You need to {{ completeDQ }} form to give us more information before the hearing.',
         { completeDQ: internalLink(

--- a/src/main/features/dashboard/views/macro/claimStatus/claimantResponse.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/claimantResponse.njk
@@ -12,7 +12,7 @@
 
   {% if featureToggles.mediation and claim.claimantResponse.freeMediation === FreeMediationOption.YES %}
       <div class="status-block">
-      <h2 class="heading-small">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
+      <h2 class="heading-medium">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
       <p>{{ t('You’ve rejected the defendant’s response.')}}</p>
       <p>{{ t('You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.') }}</p>
       <p>{{ internalLink(t('Find out how mediation works'), DashboardPaths.howFreeMediationWorksPage.uri) }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/moreTimeRequested.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/moreTimeRequested.njk
@@ -8,7 +8,7 @@
 
 {% macro moreTimeRequestedForClaimantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('The defendant has requested more time to respond') }}</h2>
+    <h2 class="heading-medium">{{ t('The defendant has requested more time to respond') }}</h2>
     <p>{{ t('{{ defendantName }} has requested an extra 14 days to respond. They need to respond by {{ responseDeadline }}.',
         { defendantName: claim.claimData.defendant.name, responseDeadline: claim.responseDeadline | date }) | safe }}</p>
   </div>
@@ -21,7 +21,7 @@
 
 {% macro moreTimeRequestedForDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('More time requested') }}</h2>
+    <h2 class="heading-medium">{{ t('More time requested') }}</h2>
     <p>{{ t('You need to respond before 4pm on {{ responseDeadline }} {{ remainingTime }}.',
         { responseDeadline: claim.responseDeadline | date, remainingTime: timeRemaining(claim.remainingDays, isAfter4pm()) }) | safe }}</p>
     <p>{{ _respondToClaimLink(claim) }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/noReponse.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/noReponse.njk
@@ -7,7 +7,7 @@
 
 {% macro noResponseForClaimantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Your claim has been sent') }}</h2>
+    <h2 class="heading-medium">{{ t('Your claim has been sent') }}</h2>
     <p>{{ t('{{ defendantName }} has until {{ responseDeadline }} to respond. They can request an extra 14 days if they need it.',
         { defendantName: claim.claimData.defendant.name, responseDeadline: claim.responseDeadline | date }) }}</p>
   </div>
@@ -22,7 +22,7 @@
 
 {% macro noResponseForDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('You haven’t responded to this claim') }}</h2>
+    <h2 class="heading-medium">{{ t('You haven’t responded to this claim') }}</h2>
     <p>{{ t('You need to respond before 4pm on {{ responseDeadline }} {{ remainingTime }}.',
         { responseDeadline: claim.responseDeadline | date, remainingTime: timeRemaining(claim.remainingDays, isAfter4pm()) | trim }) | safe }}</p>
     <p>{{ _respondToClaimLink(claim) }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/offerAccepted.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/offerAccepted.njk
@@ -28,12 +28,12 @@
 {% macro offerAcceptedForDefendantClaimDetails(claim) %}
   <div class="status-block">
     {% if claim.settlement.isThroughAdmissions() %}
-      <h2 class="heading-small">{{ t('The claimant has accepted your repayment plan') }}</h2>
+      <h2 class="heading-medium">{{ t('The claimant has accepted your repayment plan') }}</h2>
       <p>{{ t('{{ claimantName }} has accepted your plan and asked you to sign a legal agreement that formalises it. The agreement is called a ‘settlement agreement’.',
         { claimantName: claim.claimData.claimant.name }) }}</p>
       <p>{{ t('If you sign the settlement agreement, they can’t request a CCJ against you unless you break the terms.') }}</p>
     {% else %}
-      <h2 class="heading-small">{{ t('Settle out of court') }}</h2>
+      <h2 class="heading-medium">{{ t('Settle out of court') }}</h2>
       <p>{{ t('The claimant has accepted your offer and signed a legal agreement. You need to sign the agreement to settle out of court.') }}</p>
       <p>{{ t('When you’ve both signed the agreement, the claim won’t proceed.') }}</p>
     {% endif %}

--- a/src/main/features/dashboard/views/macro/claimStatus/offerRejected.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/offerRejected.njk
@@ -9,7 +9,7 @@
 {% macro offerRejectedForClaimantClaimDetails(claim) %}
   <div class="status-block">
     {% set defendantName = claim.claimData.defendant.name %}
-    <h2 class="heading-small">{{ t('Settle out of court') }}</h2>
+    <h2 class="heading-medium">{{ t('Settle out of court') }}</h2>
     <p>{{ t('You’ve rejected the defendant’s offer to settle out of court. '
         + 'You won’t receive any more offers from the defendant.') }}</p>
   </div>
@@ -24,7 +24,7 @@
 
 {% macro offerRejectedForDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Settle out of court') }}</h2>
+    <h2 class="heading-medium">{{ t('Settle out of court') }}</h2>
     <p>{{ t('The claimant has rejected your offer to settle the claim. Complete the directions questionnaire.') }}</p>
   </div>
 {% endmacro %}

--- a/src/main/features/dashboard/views/macro/claimStatus/offerSettlement.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/offerSettlement.njk
@@ -8,7 +8,7 @@
 
 {% macro offerSettlementReachedClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Agreement signed') }}</h2>
+    <h2 class="heading-medium">{{ t('Agreement signed') }}</h2>
     <p>{{ t('You’ve both signed a legal agreement. The claim is now settled.') }}</p>
     <p>{{ downloadAgreementLink(claim) }}</p>
   </div>
@@ -22,7 +22,7 @@
       {% set claimantDetailsPageURI = DashboardPaths.contactThemPage.evaluateUri({ externalId: claim.externalId }) %}
       {% set ccjRequest = CCJPaths.paidAmountPage.evaluateUri({externalId:claim.externalId}) %}
 
-      <h2 class="heading-small">{{ t('You’ve both signed a settlement agreement') }}</h2>
+      <h2 class="heading-medium">{{ t('You’ve both signed a settlement agreement') }}</h2>
 
       {% set amountToPay = 'the full amount' %}
       {% if claim.response.responseType === ResponseType.PART_ADMISSION.value %}
@@ -71,7 +71,7 @@
       {% set claimantDetailsPageURI = DashboardPaths.contactThemPage.evaluateUri({ externalId: claim.externalId }) %}
       {% set ccjRequest = CCJPaths.paidAmountPage.evaluateUri({ externalId:claim.externalId }) %}
 
-      <h2 class="heading-small">{{ t('You’ve both signed a settlement agreement') }}</h2>
+      <h2 class="heading-medium">{{ t('You’ve both signed a settlement agreement') }}</h2>
 
       {% set amountToPay = 'the full amount' %}
       {% if claim.response.responseType === ResponseType.PART_ADMISSION.value %}
@@ -108,7 +108,7 @@
         {{ paidInFullClaimantButtonClaimDetails(claim) }}
       {% endif %}
     {% else %}
-      <h2 class="heading-small">{{ t('Agreement signed') }}</h2>
+      <h2 class="heading-medium">{{ t('Agreement signed') }}</h2>
       <p>{{ t('You’ve both signed a legal agreement. The claim is now settled.') }}</p>
       <p>{{ downloadAgreementLink(claim) }}</p>
     {% endif %}

--- a/src/main/features/dashboard/views/macro/claimStatus/offerSubmitted.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/offerSubmitted.njk
@@ -10,7 +10,7 @@
 
 {% macro offerSubmittedForClaimantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Settle out of court') }}</h2>
+    <h2 class="heading-medium">{{ t('Settle out of court') }}</h2>
     <p>{{ t('{{ defendantName }} has made an offer to settle out of court.',
         { defendantName: claim.claimData.defendant.name }) }}</p>
     <p>{{ _viewAndRespondToOfferLink(claim) }}</p>
@@ -25,7 +25,7 @@
 
 {% macro offerSubmittedForDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Settle out of court') }}</h2>
+    <h2 class="heading-medium">{{ t('Settle out of court') }}</h2>
     <p>{{ t('You made an offer to settle the claim out of court. {{ claimantName }} can accept or reject your offer.',
         { claimantName: claim.claimData.claimant.name }) }}</p>
     <p>{{ t('We’ll email you when they respond.') }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/orders.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/orders.njk
@@ -19,10 +19,10 @@
 {% macro reviewReceiver(claim, respondToReviewOrderDeadline) %}
   <div class="status-block">
     {% if claim.reviewOrder.requestedBy === MadeBy.CLAIMANT.value %}
-      <h2 class="heading-small">{{ t('Read {{ claimantName }}’s request', { claimantName: claim.claimData.claimant.name }) }}</h2>
+      <h2 class="heading-medium">{{ t('Read {{ claimantName }}’s request', { claimantName: claim.claimData.claimant.name }) }}</h2>
       <p>{{ t('{{ claimantName }} has asked the court to change the order.', { claimantName: claim.claimData.claimant.name }) }}</p>
     {% else %}
-      <h2 class="heading-small">{{ t('Read {{ defendantName }}’s request', { defendantName: claim.claimData.defendant.name }) }}</h2>
+      <h2 class="heading-medium">{{ t('Read {{ defendantName }}’s request', { defendantName: claim.claimData.defendant.name }) }}</h2>
       <p>{{ t('{{ defendantName }} has asked the court to change the order.', { defendantName: claim.claimData.defendant.name }) }}</p>
     {% endif %}
 

--- a/src/main/features/dashboard/views/macro/claimStatus/orders.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/orders.njk
@@ -77,7 +77,7 @@
 
 {% macro directionsOrderIssued(claim, party, reconsiderationDeadline, isReviewOrderEligible) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Send us more details before the hearing') }}</h2>
+    <h2 class="heading-medium">{{ t('Send us more details before the hearing') }}</h2>
     <p>{{ t('The court has ordered you to send us more details.') }}</p>
     <p>{{ internalLink(t('Download the court’s order '), OrdersPaths.directionsOrderDocument.evaluateUri({ externalId: claim.externalId })) }}
       {{ t('(PDF) to find out the details you need to send.') }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/paidInFullClaimant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/paidInFullClaimant.njk
@@ -24,7 +24,7 @@
   {% set defendantName = claim.claimData.defendant.name %}
   {% set moneyReceivedOn = claim.moneyReceivedOn | date %}
 
-  <h2 class="heading-small">{{ t('This claim is settled') }}</h2>
+  <h2 class="heading-medium">{{ t('This claim is settled') }}</h2>
   <p>{{ t('{{ defendantName }} paid you on {{ moneyReceivedOn }}.', { defendantName: defendantName, moneyReceivedOn: moneyReceivedOn }) }}</p>
 {% endmacro %}
 

--- a/src/main/features/dashboard/views/macro/claimStatus/paidInFullClaimant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/paidInFullClaimant.njk
@@ -2,7 +2,7 @@
 
 {% macro paidInFullClaimantClaimDetails(externalId) %}
     <div class="status-block">
-      <h2 class="heading-small">{{ t('Tell us you’ve ended the claim') }}</h2>
+      <h2 class="heading-medium">{{ t('Tell us you’ve ended the claim') }}</h2>
       <p>{{ t('If you’ve been paid or you’ve made another agreement with the defendant, you need to tell us.') }}</p>
       <p>{{ internalLink(t('Tell us you’ve settled'),
                          DashboardPaths.datePaidPage.evaluateUri({ externalId: externalId }),

--- a/src/main/features/dashboard/views/macro/claimStatus/partAdmitRejectionClaimant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/partAdmitRejectionClaimant.njk
@@ -14,14 +14,14 @@
 {% macro partAdmitRejectedByClaimantClaimDetails(claim) %}
   {% if claim.claimantResponse.freeMediation === FreeMediationOption.YES %}
     <div class="status-block">
-      <h2 class="heading-small">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
+      <h2 class="heading-medium">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
       <p>{{ t('You’ve rejected the defendant’s response.')}}</p>
       <p>{{ t('You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.') }}</p>
       <p>{{ internalLink(t('Find out how mediation works'), DashboardPaths.howFreeMediationWorksPage.uri) }}</p>
     </div>
   {% else %}
     <div class="status-block">
-      <h2 class="heading-small">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
+      <h2 class="heading-medium">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
       <p>{{ t('You rejected the defendant’s admission of {{ amount }}', { amount: claim.response.amount | numeral }) }}</p>
       <h2 class="heading-small">{{ t('Tell us your hearing requirements') }}</h2>
 
@@ -37,13 +37,13 @@
 {% macro partAdmitRejectedByClaimantDQClaimDetails(claim) %}
   <div class="status-block">
     {% if claim.claimantResponse.freeMediation === FreeMediationOption.YES %}
-      <h2 class="heading-small">{{ t('We’ll contact you with a mediation appointment') }}</h2>
+      <h2 class="heading-medium">{{ t('We’ll contact you with a mediation appointment') }}</h2>
 
       <p>{{ t('You rejected the defendant’s admission of {{ amount }}', { amount: claim.response.amount | numeral }) }}</p>
       <p>{{ t('You’ve both agreed to try mediation. We’ll contact you to arrange a call with the mediator.') }}</p>
       <p>{{ internalLink(t('Find out how mediation works'), DashboardPaths.howFreeMediationWorksPage.uri) }}</p>
     {% else %}
-      <h2 class="heading-small">{{ t('Wait for the court to review the case') }}</h2>
+      <h2 class="heading-medium">{{ t('Wait for the court to review the case') }}</h2>
 
       <p>{{ t('You’ve rejected {{ defendantName }}’s response and said you want to take the case to court.',
           { defendantName: claim.claimData.defendant.name }) }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/partAdmitRejectionDefendant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/partAdmitRejectionDefendant.njk
@@ -15,7 +15,7 @@
 {% macro partAdmitRejectedByClaimantDefendantClaimDetails(claim) %}
   {% if claim.claimantResponse.freeMediation === FreeMediationOption.YES %}
     <div class="status-block">
-      <h2 class="heading-small">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
+      <h2 class="heading-medium">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
       <p>{{ t('{{ claimantName }} has rejected your defence.',
           { claimantName: claim.claimData.claimant.name }) }}</p>
       <p>{{ t('You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.') }}</p>
@@ -23,7 +23,7 @@
     </div>
   {% else %}
     <div class="status-block">
-      <h2 class="heading-small">{{ t('{{ claimantName }} has rejected your admission of {{ amount }}',
+      <h2 class="heading-medium">{{ t('{{ claimantName }} has rejected your admission of {{ amount }}',
           { amount: claim.response.amount | numeral, claimantName: claim.claimData.claimant.name }) }}</h2>
       <p>{{ t('They believe you owe them the full {{ amount }} claimed.', { amount: claim.totalAmountTillToday | numeral }) }}</p>
       <p>{{ t('You might have to go to a hearing. We’ll contact you if we set a hearing date to tell you how to prepare.') }}</p>
@@ -40,7 +40,7 @@
 
 {% macro partAdmitRejectedByClaimantDefendantDQClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('{{ claimantName }} has rejected your admission of {{ amount }}',
+    <h2 class="heading-medium">{{ t('{{ claimantName }} has rejected your admission of {{ amount }}',
         { amount: claim.response.amount | numeral, claimantName: claim.claimData.claimant.name }) }}</h2>
     <p>{{ t('They believe you owe them the full {{ amount }} claimed.', { amount: claim.totalAmountTillToday | numeral }) }}</p>
 

--- a/src/main/features/dashboard/views/macro/claimStatus/redeterminationRequestedClaimant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/redeterminationRequestedClaimant.njk
@@ -6,14 +6,14 @@
   <div class="status-block">
     {% if claim.reDetermination.partyType === MadeBy.CLAIMANT
     or claim.isInterlocutoryJudgmentRequestedOnAdmissions() %}
-      <h2 class="heading-small">{{ t('Awaiting judge’s review') }}</h2>
+      <h2 class="heading-medium">{{ t('Awaiting judge’s review') }}</h2>
       <p>{{ t('You’ve rejected the defendant’s repayment plan and an alternative plan suggested by the court.') }}</p>
       <p>{{ t('A County Court Judgment has been issued against the defendant.') }}</p>
       <p>{{ t('We’ll post a copy of the judgment to you and to {{ defendantName }}', { defendantName: claim.claimData.defendant.name }) }}</p>
       <p>{{ t('A judge will decide what {{ defendantName }} can afford to pay, based on their financial details.', { defendantName: claim.claimData.defendant.name }) }}</p>
       <p>{{ t('We’ll contact you to tell you what to do next.') }}</p>
     {% elif claim.reDetermination.partyType === MadeBy.DEFENDANT %}
-      <h2 class="heading-small">{{ t('The defendant rejected the repayment plan') }}</h2>
+      <h2 class="heading-medium">{{ t('The defendant rejected the repayment plan') }}</h2>
       <p>{{ t('They said they can’t afford to pay based on the terms of the County Court Judgment.') }}</p>
       <p>{{ t('A judge will review the case. We’ll contact you to tell you what to do next.') }}</p>
     {% endif %}

--- a/src/main/features/dashboard/views/macro/claimStatus/redeterminationRequestedDefendant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/redeterminationRequestedDefendant.njk
@@ -8,7 +8,7 @@
   <div class="status-block">
     {% if claim.reDetermination.partyType === MadeBy.CLAIMANT
       or claim.isInterlocutoryJudgmentRequestedOnAdmissions() %}
-      <h2 class="heading-small">{{ t('{{ claimantName }} requested a County Court Judgment (CCJ) against you',
+      <h2 class="heading-medium">{{ t('{{ claimantName }} requested a County Court Judgment (CCJ) against you',
           { claimantName: claim.claimData.claimant.name }) }}</h2>
       {% if claim.response.responseType === domain.ResponseType.FULL_ADMISSION %}
         <p>{{ t('They rejected your repayment plan.') }}</p>
@@ -20,7 +20,7 @@
           { claimantName: claim.claimData.claimant.name }) }}</p>
       <p>{{ t('A judge will make a repayment plan. We’ll contact you to tell you what to do next.') }}</p>
     {% elif claim.reDetermination.partyType === MadeBy.DEFENDANT %}
-      <h2 class="heading-small">{{ t('You’ve rejected the claimant’s repayment plan') }}</h2>
+      <h2 class="heading-medium">{{ t('You’ve rejected the claimant’s repayment plan') }}</h2>
       <p>{{ t('A judge will review the case. We’ll contact you to tell you what to do next.') }}</p>
     {% endif %}
     <p>{{ downloadResponseLink(claim) }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/settlementAgreementClaimant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/settlementAgreementClaimant.njk
@@ -23,7 +23,7 @@
 {% macro settlementAgreementSignedByClaimantClaimDetails(claim) %}
   {% set defendantName = claim.claimData.defendant.name %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('You’ve signed a settlement agreement') }}</h2>
+    <h2 class="heading-medium">{{ t('You’ve signed a settlement agreement') }}</h2>
     <p>{{ t('We’ve emailed {{ defendantName }} the repayment plan and the settlement agreement for them to sign.',
       { defendantName: defendantName }) }}</p>
     <p>{{ t('They must respond by {{ respondDate }}. We’ll email you when they respond.',
@@ -35,7 +35,7 @@
 {% macro settlementAgreementSignedByClaimantDeadlinePassedClaimDetails(claim, csrf) %}
   {% set defendantName = claim.claimData.defendant.name %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('The defendant has not signed your settlement agreement') }}</h2>
+    <h2 class="heading-medium">{{ t('The defendant has not signed your settlement agreement') }}</h2>
     <p>{{ t('You can request a County Court Judgment (CCJ) against them based on the repayment plan shown in the
       agreement.') }}</p>
     <p>{{ t('The court will make an order requiring them to pay the money. It does not guarantee that they pay it.')
@@ -51,7 +51,7 @@
 
 {% macro settlementAgreementSignedByBothClaimantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('You’ve both signed a settlement agreement') }}</h2>
+    <h2 class="heading-medium">{{ t('You’ve both signed a settlement agreement') }}</h2>
     {% if claim.settlement.getLastOffer().paymentIntention.paymentOption === domain.PaymentOption.BY_SPECIFIED_DATE %}
     <p>{{ t('The agreement says the defendant will pay you in full by {{ paymentDate }}.',
       { paymentDate: claim.settlement.getLastOffer().paymentIntention.paymentDate | date }) }}</p>
@@ -74,7 +74,7 @@
 
 {% macro settlementAgreementRejectedClaimantClaimDetails(claim, csrf) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('The defendant has rejected your settlement agreement') }}</h2>
+    <h2 class="heading-medium">{{ t('The defendant has rejected your settlement agreement') }}</h2>
     <p>{{ t('You can request a County Court Judgment (CCJ) against them based on the repayment plan they offered.') }}</p>
     <p>{{ t('The court will order them to pay the money. It doesn’t guarantee that they’ll pay you.') }}</p>
     <form class="form-group" novalidate method="post">
@@ -87,7 +87,7 @@
 
 {% macro requestCCJ(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('Request County Court Judgment') }}</h2>
+    <h2 class="heading-medium">{{ t('Request County Court Judgment') }}</h2>
     <p>{{ t('If the defendant doesn’t pay or breaks the terms of the settlement agreement, you can '
       + internalLink('request a County Court Judgment. ', CCJPaths.paidAmountPage.evaluateUri({
       externalId:claim.externalId }) )) | safe }}

--- a/src/main/features/dashboard/views/macro/claimStatus/settlementAgreementDefendant.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/settlementAgreementDefendant.njk
@@ -15,7 +15,7 @@
 
 {% macro settlementAgreementSignedByClaimantDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('{{ claimantName }} asked you to sign a settlement agreement', { claimantName: claim.claimData.claimant.name }) }}</h2>
+    <h2 class="heading-medium">{{ t('{{ claimantName }} asked you to sign a settlement agreement', { claimantName: claim.claimData.claimant.name }) }}</h2>
     <p>{{ t('They accepted your repayment plan and asked you to sign a settlement agreement to formalise it.') }}</p>
     <p>{{ t('If you sign the agreement, they can’t request a County Court Judgment against you unless you break the terms.') }}</p>
     <p>{{ t('If you don’t sign or respond by {{ deadline }} they can request a County Court Judgment against you.', deadline = claim.claimantRespondedAt | addDays(7) | date) }}</p>
@@ -26,7 +26,7 @@
 
 {% macro settlementAgreementSignedByBothDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('You’ve both signed a settlement agreement') }}</h2>
+    <h2 class="heading-medium">{{ t('You’ve both signed a settlement agreement') }}</h2>
     {% if claim.settlement.getLastOffer().paymentIntention.paymentOption === domain.PaymentOption.BY_SPECIFIED_DATE %}
       <p>{{ t('The agreement says you’ll repay {{ amount }} by {{ paymentDate }}.',
           { amount: amountToPay,
@@ -50,7 +50,7 @@
 
 {% macro settlementAgreementSignedByClaimantNewPaymentPlanDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('{{ claimantName }} rejected your repayment plan.', { claimantName: claim.claimData.claimant.name }) }}</h2>
+    <h2 class="heading-medium">{{ t('{{ claimantName }} rejected your repayment plan.', { claimantName: claim.claimData.claimant.name }) }}</h2>
     {% if claim.response.responseType === domain.ResponseType.PART_ADMISSION %}
       <p>{{ t('{{ claimantName }} accepted your offer to pay {{ partAdmitAmount }} but rejected your repayment plan.',
           { claimantName: claim.claimData.claimant.name, partAdmitAmount: claim.response.amount | numeral }) }}</p>
@@ -71,7 +71,7 @@
 
 {% macro settlementAgreementRejectedDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('You rejected the settlement agreement') }}</h2>
+    <h2 class="heading-medium">{{ t('You rejected the settlement agreement') }}</h2>
     <p>{{ t('{{ claimantName }} can request a County Court Judgment (CCJ) against you.', { claimantName: claim.claimData.claimant.name }) }}</p>
     <p>{{ t('A CCJ would order you to repay the money in line with the terms of the agreement.') }}</p>
     <p>{{ t('The court has reviewed the repayment plan and believes you can afford it.') }}</p>

--- a/src/main/features/dashboard/views/macro/claimStatus/statesPaidRejected.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/statesPaidRejected.njk
@@ -26,7 +26,7 @@
 
   {% if featureToggles.mediation and claim.claimantResponse.freeMediation === FreeMediationOption.YES %}
     <div class="status-block">
-      <h2 class="heading-small">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
+      <h2 class="heading-medium">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
 
       <p>{{ t('You’ve rejected the defendant’s response.')}}</p>
       <p>{{ t('You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.') }}</p>
@@ -117,7 +117,7 @@
 
 {% macro statesPaidRejectionMediationYESDefendantClaimDetails(claim) %}
   <div class="status-block">
-    <h2 class="heading-small">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
+    <h2 class="heading-medium">{{ t('We’ll contact you to try to arrange a mediation appointment') }}</h2>
     <p>{{ t('{{ claimantName }} has rejected your defence.',
         { claimantName: claim.claimData.claimant.name }) }}</p>
     <p>{{ t('You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.') }}</p>

--- a/src/test/features/dashboard/routes/dashboard/full-defence.ts
+++ b/src/test/features/dashboard/routes/dashboard/full-defence.ts
@@ -31,6 +31,7 @@ import {
   settlementOfferReject,
   settledWithAgreement
 } from 'test/data/entity/fullDefenceData'
+import { DefenceType } from 'claims/models/response/defenceType'
 
 const cookieName: string = config.get<string>('session.cookieName')
 
@@ -192,6 +193,27 @@ const testData = [
     },
     claimantAssertions: ['You’ve both signed a legal agreement. The claim is now settled.'],
     defendantAssertions: ['You’ve both signed a legal agreement. The claim is now settled.']
+  },
+  {
+    status: 'Full defence - defendant disputes the claim - claimant rejected defendant response with mediation - no online DQ',
+    claim: fullDefenceClaim,
+    claimOverride: {
+      response: {
+        ...baseResponseData,
+        ...baseDefenceData,
+        freeMediation: FreeMediationOption.YES,
+        defenceType: DefenceType.DISPUTE
+      },
+      claimantResponse: {
+        freeMediation: 'yes',
+        settleForAmount: 'no',
+        type: 'REJECTION'
+      },
+      claimantRespondedAt: MomentFactory.currentDate(),
+      ...directionsQuestionnaireDeadline
+    },
+    claimantAssertions: ['We will contact you with a meditation appointment'],
+    defendantAssertions: ['We will contact you with a meditation appointment']
   }
 ]
 


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-6387


### Change description
Update all H2 classes on claim status pages, that are directly after <div>, to the heading-medium class.


### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
