### PR TITLE
ROC-6701 Only delete the draft claim when claim is submitted successfully

### DIFF
--- a/src/main/app/logging/customEventTracker.ts
+++ b/src/main/app/logging/customEventTracker.ts
@@ -12,6 +12,6 @@ export function trackCustomEvent (eventName: string, trackingProperties: {}) {
       })
     }
   } catch (err) {
-    logger.logError(err.stack)
+    logger.error(err.stack)
   }
 }

--- a/src/main/features/claim/routes/pay.ts
+++ b/src/main/features/claim/routes/pay.ts
@@ -112,14 +112,15 @@ async function successHandler (req, res, next) {
       savedClaim = await claimStoreClient.retrieveByExternalId(externalId, user)
     }
   }
-  const payClient: PayClient = await getPayClient(req)
-  const paymentReference = draft.document.claimant.payment.reference
 
-  if (savedClaim) {
-    const ccdCaseNumber = savedClaim.ccdCaseId === undefined ? 'UNKNOWN' : String(savedClaim.ccdCaseId)
-    await payClient.update(user, paymentReference, savedClaim.externalId, ccdCaseNumber)
+  if (!savedClaim) {
+    throw new Error(`Error saving claim: ${externalId}`)
   }
 
+  const payClient: PayClient = await getPayClient(req)
+  const paymentReference = draft.document.claimant.payment.reference
+  const ccdCaseNumber = savedClaim.ccdCaseId === undefined ? 'UNKNOWN' : String(savedClaim.ccdCaseId)
+  await payClient.update(user, paymentReference, savedClaim.externalId, ccdCaseNumber)
   await new DraftService().delete(draft.id, user.bearerToken)
   res.redirect(Paths.confirmationPage.evaluateUri({ externalId: externalId }))
 }

--- a/src/test/features/claim/routes/pay.ts
+++ b/src/test/features/claim/routes/pay.ts
@@ -420,6 +420,11 @@ describe('Claim issue: post payment callback receiver', () => {
             idamServiceMock.resolveRetrieveServiceToken()
             payServiceMock.resolveRetrieve('Success')
             draftStoreServiceMock.resolveUpdate()
+            claimStoreServiceMock.resolveRetrieveUserRoles('cmc-new-features-consent-given')
+            featureToggleApiMock.resolveIsAdmissionsAllowed()
+            claimStoreServiceMock.rejectSaveClaimForUser('reason', 409)
+            claimStoreServiceMock.resolveRetrieveByExternalId()
+            payServiceMock.resolveUpdate()
             draftStoreServiceMock.resolveDelete()
 
             await request(app)
@@ -472,7 +477,7 @@ describe('Claim issue: post payment callback receiver', () => {
               .expect(res => expect(res).to.be.serverError.withText('Error'))
           })
 
-          it('should return 404 and render error page when feature toggle api fails', async () => {
+          it('should return 500 and render error page when feature toggle api fails', async () => {
             draftStoreServiceMock.resolveFind(draftType, payServiceMock.paymentInitiateResponse)
             idamServiceMock.resolveRetrieveServiceToken()
             payServiceMock.resolveRetrieve('Success')
@@ -483,7 +488,7 @@ describe('Claim issue: post payment callback receiver', () => {
             await request(app)
               .get(Paths.finishPaymentReceiver.uri)
               .set('Cookie', `${cookieName}=ABC`)
-              .expect(res => expect(res).to.be.notFound)
+              .expect(res => expect(res).to.be.serverError)
           })
 
           it('should return 500 and render error page when retrieve user roles fails', async () => {

--- a/src/test/http-mocks/claim-store.ts
+++ b/src/test/http-mocks/claim-store.ts
@@ -806,10 +806,10 @@ export function resolveSaveClaimForUser () {
     .reply(HttpStatus.OK, { ...sampleClaimObj })
 }
 
-export function rejectSaveClaimForUser (reason: string = 'HTTP error') {
+export function rejectSaveClaimForUser (reason: string = 'HTTP error', status: number = HttpStatus.INTERNAL_SERVER_ERROR) {
   mock(`${serviceBaseURL}/claims`)
     .post(new RegExp('/[0-9]+'))
-    .reply(HttpStatus.INTERNAL_SERVER_ERROR, reason)
+    .reply(status, reason)
 }
 
 export function resolveSaveCcjForExternalId () {


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-6701

### Change description
Only delete the draft claim when claim is submitted successfully. This will allow any successful payment followed by unsuccessful claim submission to be resubmitted by the citizen user without additional payment.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
