### PR TITLE
ROC-6885 Bump cmc-draft-store-middleware version to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@hmcts/class-validator": "^0.9.1-e",
-    "@hmcts/cmc-draft-store-middleware": "^2.0.0",
+    "@hmcts/cmc-draft-store-middleware": "^2.0.1",
     "@hmcts/cmc-validators": "^0.2.3",
     "@hmcts/ctsc-web-chat": "^0.3.9",
     "@hmcts/draft-store-client": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,10 +106,10 @@
     google-libphonenumber "^3.1.6"
     validator "10.4.0"
 
-"@hmcts/cmc-draft-store-middleware@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hmcts/cmc-draft-store-middleware/-/cmc-draft-store-middleware-2.0.0.tgz#6900c3ed23ac1173ef4b68b88623704fc92be377"
-  integrity sha512-/wlmRcXBGfXMUQDegptsEINwz5mtEw4Wa4MK1puc8p1F29GtNNP3+CAdbaoIkC/WtmnehaHbBLVHrIatc8w4Cw==
+"@hmcts/cmc-draft-store-middleware@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@hmcts/cmc-draft-store-middleware/-/cmc-draft-store-middleware-2.0.1.tgz#07414dbc33421a67e16b65e3e2c34b4c4f10717f"
+  integrity sha512-cMnfDytTicSGUq8GZCax6xMPy7aqXKxfOpWo20ds3sz3wju/vVxesIS3XFtQAhA8faXAgdcwV7VU5yqUZcAtPQ==
   dependencies:
     "@hmcts/draft-store-client" "^1.2.1"
     moment "^2.19.1"


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-6885

### Change description
Bump the draft-middleware dependency which now returns the latest draft if there are multiple, instead of throwing an exception

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
