### PR TITLE
fix Zap-cli complaining about python2 and python3 compatibility

### DIFF
--- a/security.sh
+++ b/security.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 #echo "${SECURITYCONTEXT}" > /zap/security.context
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
 zap-x.sh -d -host 0.0.0.0 -port 1001 -config api.disablekey=true -config scanner.attackOnStart=true -config view.mode=attack -config connection.dnsTtlSuccessfulQueries=-1 -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true /dev/null 2>&1 &
 i=0
 while !(curl -s http://0.0.0.0:1001) > /dev/null


### PR DESCRIPTION

### Change description

Zap-cli scanning complaining about python2 and python3 compatibility.
This change will fix the issue.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No
