### PR TITLE
[To merge 19 March] ROC-7619 Decide features from the saved claim, in IoC

### DIFF
--- a/src/main/features/claim/helpers/featuresBuilder.ts
+++ b/src/main/features/claim/helpers/featuresBuilder.ts
@@ -2,8 +2,6 @@ import { FeatureToggles } from 'utils/featureToggles'
 import { FeatureTogglesClient } from 'shared/clients/featureTogglesClient'
 import { ClaimStoreClient } from 'claims/claimStoreClient'
 import { User } from 'idam/user'
-import { Draft } from '@hmcts/draft-store-client'
-import { DraftClaim } from 'drafts/models/draftClaim'
 
 const claimStoreClient: ClaimStoreClient = new ClaimStoreClient()
 const featureTogglesClient: FeatureTogglesClient = new FeatureTogglesClient()
@@ -14,7 +12,7 @@ export class FeaturesBuilder {
   static readonly JUDGE_PILOT_THRESHOLD = 1000
   static readonly ONLINE_DQ_THRESHOLD = 1000
 
-  static async features (draft: Draft<DraftClaim>, user: User): Promise<string> {
+  static async features (amount: number, user: User): Promise<string> {
     const roles: string[] = await claimStoreClient.retrieveUserRoles(user)
 
     let features = ''
@@ -22,23 +20,23 @@ export class FeaturesBuilder {
       features = 'admissions'
     }
 
-    if (draft.document.amount.totalAmount() <= this.MEDIATION_PILOT_AMOUNT) {
+    if (amount <= this.MEDIATION_PILOT_AMOUNT) {
       if (await featureTogglesClient.isFeatureToggleEnabled(user, roles, 'cmc_mediation_pilot')) {
         features += features === '' ? 'mediationPilot' : ', mediationPilot'
       }
     }
 
-    if (draft.document.amount.totalAmount() <= this.LA_PILOT_THRESHOLD) {
+    if (amount <= this.LA_PILOT_THRESHOLD) {
       if (await featureTogglesClient.isFeatureToggleEnabled(user, roles, 'cmc_legal_advisor')) {
         features += features === '' ? 'LAPilotEligible' : ', LAPilotEligible'
       }
-    } else if (draft.document.amount.totalAmount() <= this.JUDGE_PILOT_THRESHOLD) {
+    } else if (amount <= this.JUDGE_PILOT_THRESHOLD) {
       if (await featureTogglesClient.isFeatureToggleEnabled(user, roles, 'cmc_judge_pilot')) {
         features += features === '' ? 'judgePilotEligible' : ', judgePilotEligible'
       }
     }
 
-    if (draft.document.amount.totalAmount() <= this.ONLINE_DQ_THRESHOLD) {
+    if (amount <= this.ONLINE_DQ_THRESHOLD) {
       if (FeatureToggles.isEnabled('directionsQuestionnaire') && await featureTogglesClient.isFeatureToggleEnabled(user, roles, 'cmc_directions_questionnaire')) {
         features += features === '' ? 'directionsQuestionnaire' : ', directionsQuestionnaire'
       }

--- a/src/main/features/claim/routes/finish-payment.ts
+++ b/src/main/features/claim/routes/finish-payment.ts
@@ -31,7 +31,7 @@ export default express.Router()
       const claim: Claim = await claimStoreClient.retrieveByExternalId(externalId, user)
       logger.info('CLAIM IN FINISH PAYMENT: ', JSON.stringify(claim))
       if (ClaimState[claim.state] === ClaimState.AWAITING_CITIZEN_PAYMENT) {
-        const features = await FeaturesBuilder.features(draft, user)
+        const features = await FeaturesBuilder.features(claim.claimData.amount.totalAmount(), user)
 
         const createdClaim = await claimStoreClient.createCitizenClaim(draft, user, features)
         if (ClaimState[createdClaim.state] === ClaimState.AWAITING_CITIZEN_PAYMENT) {

--- a/src/main/features/claim/routes/pay.ts
+++ b/src/main/features/claim/routes/pay.ts
@@ -61,7 +61,7 @@ async function successHandler (req, res, next) {
   let savedClaim: Claim
 
   try {
-    const features = await FeaturesBuilder.features(draft, user)
+    const features = await FeaturesBuilder.features(draft.document.amount.totalAmount(), user)
     savedClaim = await claimStoreClient.saveClaim(draft, user, features)
   } catch (err) {
     if (err.statusCode === HttpStatus.INTERNAL_SERVER_ERROR || err.statusCode === HttpStatus.SERVICE_UNAVAILABLE) {

--- a/src/test/features/claim/helpers/featuresBuilder.ts
+++ b/src/test/features/claim/helpers/featuresBuilder.ts
@@ -6,14 +6,9 @@ import * as claimStoreServiceMock from 'test/http-mocks/claim-store'
 import * as mock from 'nock'
 import * as HttpStatus from 'http-status-codes'
 import * as config from 'config'
-import { DraftClaim } from 'drafts/models/draftClaim'
 import { User } from 'idam/user'
-import { Draft } from '@hmcts/draft-store-client'
-import { claimDraft as claimDraftData } from 'test/data/draft/claimDraft'
-import * as moment from 'moment'
 import { attachDefaultHooks } from 'test/routes/hooks'
 import { app } from 'main/app'
-import { YesNoOption } from 'models/yesNoOption'
 
 function mockFeatureFlag (feature: string, enabled: boolean): mock.Scope {
   return mock(`${config.get<string>('feature-toggles-api.url')}/api/ff4j/check`)
@@ -22,108 +17,13 @@ function mockFeatureFlag (feature: string, enabled: boolean): mock.Scope {
 }
 
 const user = new User('1', 'user@example.com', 'John', 'Smith', [], 'citizen', '')
-const eligibleDraft = new Draft<DraftClaim>(123, 'claim', new DraftClaim().deserialize(claimDraftData), moment(), moment())
-const pilotLimit = 300
-const limitDraft = new Draft<DraftClaim>(123, 'claim', new DraftClaim().deserialize({
-  ...claimDraftData,
-  amount: {
-    rows: [
-      {
-        reason: 'Valid reason',
-        amount: pilotLimit
-      }
-    ]
-  },
-  interest: {
-    option: YesNoOption.NO
-  }
-}), moment(), moment())
 
-const judgePilotLimit = 1000
-
-const draftWithJudgePilotLimit = new Draft<DraftClaim>(123, 'claim', new DraftClaim().deserialize({
-  ...claimDraftData,
-  amount: {
-    rows: [
-      {
-        reason: 'Valid reason',
-        amount: judgePilotLimit
-      }
-    ]
-  },
-  interest: {
-    option: YesNoOption.NO
-  }
-}), moment(), moment())
-
-const draftWithJudgePilotLimitPlusInterest = new Draft<DraftClaim>(123, 'claim', new DraftClaim().deserialize({
-  ...claimDraftData,
-  amount: {
-    rows: [
-      {
-        reason: 'Valid reason',
-        amount: judgePilotLimit
-      }
-    ]
-  }
-}), moment(), moment())
-
-const draftWithJudgePilotOverLimit = new Draft<DraftClaim>(123, 'claim', new DraftClaim().deserialize({
-  ...claimDraftData,
-  amount: {
-    rows: [
-      {
-        reason: 'Valid reason',
-        amount: judgePilotLimit + 1
-      }
-    ]
-  },
-  interest: {
-    option: YesNoOption.NO
-  }
-}), moment(), moment())
-
-const legalAdvisorEligibleLimit = new Draft<DraftClaim>(123, 'claim', new DraftClaim().deserialize({
-  ...claimDraftData,
-  amount: {
-    rows: [
-      {
-        reason: 'Valid reason',
-        amount: pilotLimit
-      }
-    ]
-  },
-  interest: {
-    option: YesNoOption.NO
-  }
-}), moment(), moment())
-
-const overLimitDraft = new Draft<DraftClaim>(123, 'claim', new DraftClaim().deserialize({
-  ...claimDraftData,
-  amount: {
-    rows: [
-      {
-        reason: 'Valid reason',
-        amount: pilotLimit + 1
-      }
-    ]
-  },
-  interest: {
-    option: YesNoOption.NO
-  }
-}), moment(), moment())
-
-const limitPlusInterestDraft = new Draft<DraftClaim>(123, 'claim', new DraftClaim().deserialize({
-  ...claimDraftData,
-  amount: {
-    rows: [
-      {
-        reason: 'Valid reason',
-        amount: pilotLimit
-      }
-    ]
-  }
-}), moment(), moment())
+const MIN_THRESHOLD = Math.min(
+  FeaturesBuilder.JUDGE_PILOT_THRESHOLD,
+  FeaturesBuilder.LA_PILOT_THRESHOLD,
+  FeaturesBuilder.MEDIATION_PILOT_AMOUNT,
+  FeaturesBuilder.ONLINE_DQ_THRESHOLD
+)
 
 describe('FeaturesBuilder', () => {
   attachDefaultHooks(app)
@@ -135,93 +35,69 @@ describe('FeaturesBuilder', () => {
   describe('Admissions Feature', () => {
     it('should add admissions to features if flag is set', async () => {
       mockFeatureFlag('cmc_admissions', true)
-      const features = await FeaturesBuilder.features(eligibleDraft, user)
+      const features = await FeaturesBuilder.features(1, user)
       expect(features).to.equal('admissions')
     })
   })
 
   describe('Directions Questionnaire Feature', () => {
-    it('should add dq to features if flag is set and draft is <= 1000', async () => {
+    it(`should add dq to features if flag is set and amount <= ${FeaturesBuilder.ONLINE_DQ_THRESHOLD}`, async () => {
       mockFeatureFlag('cmc_directions_questionnaire', true)
-      const features = await FeaturesBuilder.features(draftWithJudgePilotLimit, user)
+      const features = await FeaturesBuilder.features(FeaturesBuilder.ONLINE_DQ_THRESHOLD, user)
       expect(features).to.equal('directionsQuestionnaire')
     })
 
-    it('should add dq to features if principal amount <= 1000 but with interest is > 1000 and flag is set', async () => {
-      mockFeatureFlag('cmc_directions_questionnaire', true)
-      const features = await FeaturesBuilder.features(draftWithJudgePilotLimitPlusInterest, user)
-      expect(features).to.equal('directionsQuestionnaire')
-    })
-
-    it('should not dd dq to features if principal amount is > 1000', async () => {
-      const features = await FeaturesBuilder.features(draftWithJudgePilotOverLimit, user)
+    it(`should not dd dq to features if amount > ${FeaturesBuilder.ONLINE_DQ_THRESHOLD}`, async () => {
+      const features = await FeaturesBuilder.features(FeaturesBuilder.ONLINE_DQ_THRESHOLD + 0.01, user)
       expect(features).to.be.undefined
     })
 
   })
 
   describe('Mediation Pilot Feature', () => {
-    it('should add mediation pilot to features if principal amount <= 300 and flag is set', async () => {
+    it(`should add mediation pilot to features if amount <= ${FeaturesBuilder.MEDIATION_PILOT_AMOUNT} and flag is set`, async () => {
       mockFeatureFlag('cmc_mediation_pilot', true)
-      const features = await FeaturesBuilder.features(limitDraft, user)
+      const features = await FeaturesBuilder.features(FeaturesBuilder.MEDIATION_PILOT_AMOUNT, user)
       expect(features).to.equal('mediationPilot')
     })
 
-    it('should add mediation pilot to features if principal amount <= 300 but with interest is > 300 and flag is set', async () => {
-      mockFeatureFlag('cmc_mediation_pilot', true)
-      const features = await FeaturesBuilder.features(limitPlusInterestDraft, user)
-      expect(features).to.equal('mediationPilot')
-    })
-
-    it('should not add mediation pilot to features if principal amount is > 300', async () => {
-      const features = await FeaturesBuilder.features(overLimitDraft, user)
+    it(`should not add mediation pilot to features if amount > ${FeaturesBuilder.MEDIATION_PILOT_AMOUNT}`, async () => {
+      const features = await FeaturesBuilder.features(FeaturesBuilder.MEDIATION_PILOT_AMOUNT + 0.01, user)
       expect(features).to.be.undefined
     })
   })
 
   describe('Legal advisor Pilot Feature', () => {
-    it('should add legal advisor eligible to features if principal amount <= 300 and flag is set', async () => {
+    it(`should add legal advisor eligible to features if amount <= ${FeaturesBuilder.LA_PILOT_THRESHOLD} and flag is set`, async () => {
       mockFeatureFlag('cmc_legal_advisor', true)
-      const features = await FeaturesBuilder.features(legalAdvisorEligibleLimit, user)
+      const features = await FeaturesBuilder.features(FeaturesBuilder.LA_PILOT_THRESHOLD, user)
       expect(features).to.equal('LAPilotEligible')
     })
 
-    it('should add legal advisor eligible to features if principal amount <= 300 but with interest is > 300 and flag is set', async () => {
-      mockFeatureFlag('cmc_legal_advisor', true)
-      const features = await FeaturesBuilder.features(limitPlusInterestDraft, user)
-      expect(features).to.equal('LAPilotEligible')
-    })
-
-    it('should not add legal advisor eligible to features if principal amount is > 300', async () => {
-      const features = await FeaturesBuilder.features(overLimitDraft, user)
+    it(`should not add legal advisor eligible to features if amount > ${FeaturesBuilder.LA_PILOT_THRESHOLD}`, async () => {
+      const features = await FeaturesBuilder.features(FeaturesBuilder.LA_PILOT_THRESHOLD, user)
       expect(features).to.be.undefined
     })
   })
 
   describe('Judge Pilot Feature', () => {
-    it('should add judge pilot eligible to features if principal amount <= 1000 and flag is set', async () => {
+    it(`should add judge pilot eligible to features if amount <= ${FeaturesBuilder.JUDGE_PILOT_THRESHOLD} and flag is set`, async () => {
       mockFeatureFlag('cmc_judge_pilot', true)
-      const features = await FeaturesBuilder.features(draftWithJudgePilotLimit, user)
+      const features = await FeaturesBuilder.features(FeaturesBuilder.JUDGE_PILOT_THRESHOLD, user)
       expect(features).to.equal('judgePilotEligible')
     })
 
-    it('should add judge pilot eligible to features if principal amount <= 1000 but with interest is > 1000 and flag is set', async () => {
-      mockFeatureFlag('cmc_judge_pilot', true)
-      const features = await FeaturesBuilder.features(draftWithJudgePilotLimitPlusInterest, user)
-      expect(features).to.equal('judgePilotEligible')
-    })
-
-    it('should not add judge pilot eligible to features if principal amount is > 1000', async () => {
-      const features = await FeaturesBuilder.features(draftWithJudgePilotOverLimit, user)
+    it(`should not add judge pilot eligible to features if amount > ${FeaturesBuilder.JUDGE_PILOT_THRESHOLD}`, async () => {
+      const features = await FeaturesBuilder.features(FeaturesBuilder.JUDGE_PILOT_THRESHOLD, user)
       expect(features).to.be.undefined
     })
   })
 
-  it('should add legal advisor, dqOnline and mediation pilot to features if principal amount <= 300 and flag is set', async () => {
+  it(`should add legal advisor, dqOnline and mediation pilot to features if principal amount <= ${MIN_THRESHOLD} and flags are set`, async () => {
     mockFeatureFlag('cmc_directions_questionnaire', true)
     mockFeatureFlag('cmc_legal_advisor', true)
     mockFeatureFlag('cmc_mediation_pilot', true)
-    const features = await FeaturesBuilder.features(limitDraft, user)
+    const features = await FeaturesBuilder.features(MIN_THRESHOLD, user)
     expect(features).to.equal('mediationPilot, LAPilotEligible, directionsQuestionnaire')
   })
 })


### PR DESCRIPTION
**NOTE:** To be merged in tandem with https://github.com/hmcts/cmc-claim-store/pull/1494

### JIRA link
https://tools.hmcts.net/jira/browse/ROC-7619

### Change description
Adjust features builder to accept an amount (which was all it needed anyway).
Adjust IoC submission journey to invoke the features builder with the retrieved claim from CCD instead of the draft.

### Work checklist

- [x] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
