### PR TITLE
ROC-7926 No mediation and mediation failed dashboards to show updates will be by post

### DIFF
--- a/src/main/features/dashboard/views/macro/claimStatus/claimRejected.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/claimRejected.njk
@@ -313,6 +313,7 @@
         { deadline: claim.directionsQuestionnaireDeadline | date }) }}</p>
     <p>{{ t('You also need to send a copy of the form to {{ defendantName }}', { defendantName: claim.claimData.defendant.name }) }}</p>
     <p>{{ _downloadResponseLink(claim, 'Download their response') }}</p>
+    <p>{{ t('Your online account won’t be updated with the progress of this claim - any further updates will be by post.') }}</p>
   </div>
 {% endmacro %}
 
@@ -329,6 +330,7 @@
     <p>{{ t('Your defence will be cancelled if you don’t complete and return the form before 4pm on {{ deadline }}.',
         { deadline: claim.directionsQuestionnaireDeadline | date }) }}</p>
     <p>{{ t('You also need to send a copy of the form to {{ claimantName }}', { claimantName: claim.claimData.claimant.name } ) }}</p>
+    <p>{{ t('Your online account won’t be updated with the progress of this claim - any further updates will be by post.') }}</p>
   </div>
 {% endmacro %}
 
@@ -373,7 +375,7 @@
     <p>{{ t('You must make sure we receive the form before 4pm on {{ deadline }}, or we’ll cancel your claim.',
         { deadline: claim.directionsQuestionnaireDeadline | date }) }}</p>
     <p>{{ t('You also need to send a copy of the form to {{ defendantName }}', { defendantName: claim.claimData.defendant.name } ) }}</p>
-    <p>{{ t('Your online account won’t be updated with any more details about this claim.') }}</p>
+    <p>{{ t('Your online account won’t be updated with the progress of this claim - any further updates will be by post.') }}</p>
   </div>
 {% endmacro %}
 
@@ -402,7 +404,7 @@
     <p>{{ t('You must make sure we receive the form before 4pm on {{ deadline }}, or we’ll cancel your defence.',
         { deadline: claim.directionsQuestionnaireDeadline | date }) }}</p>
     <p>{{ t('You also need to send a copy of the form to {{ claimantName }}', { claimantName: claim.claimData.claimant.name } ) }}</p>
-    <p>{{ t('Your online account won’t be updated with any more details about this claim.') }}</p>
+    <p>{{ t('Your online account won’t be updated with the progress of this claim - any further updates will be by post.') }}</p>
   </div>
 {% endmacro %}
 

--- a/src/test/features/dashboard/routes/claimStatus/full-defence.ts
+++ b/src/test/features/dashboard/routes/claimStatus/full-defence.ts
@@ -33,7 +33,6 @@ import {
   settlementOfferAccept,
   settlementOfferReject
 } from 'test/data/entity/fullDefenceData'
-import { FeatureToggles } from 'utils/featureToggles'
 import { MediationOutcome } from 'claims/models/mediationOutcome'
 import { DefenceType } from 'claims/models/response/defenceType'
 import { YesNoOption } from 'models/yesNoOption'
@@ -56,25 +55,25 @@ function fullDefenceClaim () {
 function testData () {
   return [
     {
-      status: 'Full defence - defendant paid what he believe',
+      status: 'Full defence - defendant already paid',
       claim: fullDefenceClaim(),
       claimOverride: {
         response: { ...defenceWithAmountClaimedAlreadyPaidData }
       },
       claimantAssertions: [
         'The defendant’s response',
-        fullDefenceClaim().claim.defendants[0].name + ` says they paid you ${NumberFormatter.formatMoney(defenceWithAmountClaimedAlreadyPaidData.paymentDeclaration.paidAmount)} on `,
+        `${fullDefenceClaim().claim.defendants[0].name} says they paid you ${NumberFormatter.formatMoney(defenceWithAmountClaimedAlreadyPaidData.paymentDeclaration.paidAmount)} on `,
         'You can accept or reject this response.',
         'View and respond'
       ],
       defendantAssertions: [
         'Your response to the claim',
-        'We’ve emailed ' + fullDefenceClaim().claim.claimants[0].name + ' telling them when and how you said you paid the claim.',
+        `We’ve emailed ${fullDefenceClaim().claim.claimants[0].name} telling them when and how you said you paid the claim.`,
         'Download your response'
       ]
     },
     {
-      status: 'Full defence - defendant paid what he believe - claimant does not proceed in time',
+      status: 'Full defence - defendant already paid - claimant does not proceed in time',
       claim: fullDefenceClaim(),
       claimOverride: {
         response: { ...defenceWithAmountClaimedAlreadyPaidData },
@@ -93,7 +92,102 @@ function testData () {
       ]
     },
     {
-      status: 'Full defence - defendant paid what he believe - claimant rejected defendant response without mediation',
+      status: 'Full defence - defendant already paid - claimant rejects defendant response with mediation',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        response: {
+          ...defenceWithAmountClaimedAlreadyPaidData,
+          freeMediation: 'yes'
+        },
+        claimantResponse: {
+          freeMediation: 'yes',
+          settleForAmount: 'no',
+          type: 'REJECTION'
+        },
+        claimantRespondedAt: MomentFactory.currentDate(),
+        ...directionsQuestionnaireDeadline()
+      },
+      claimantAssertions: [
+        'You’ve rejected the defendant’s response.',
+        'We’ll contact you to try to arrange a mediation appointment',
+        'You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.',
+        'Find out how mediation works'
+      ],
+      defendantAssertions: [
+        'John Smith has rejected your defence.',
+        'We’ll contact you to try to arrange a mediation appointment',
+        'You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.',
+        'Find out how mediation works'
+      ]
+    },
+    {
+      status: 'Full defence - defendant already paid - claimant rejects defendant response with mediation - mediation failed',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        features: ['admissions', 'directionsQuestionnaire'],
+        response: {
+          ...defenceWithAmountClaimedAlreadyPaidData,
+          freeMediation: 'yes',
+          directionsQuestionnaire: {
+            hearingLoop: 'NO',
+            selfWitness: 'NO',
+            disabledAccess: 'NO',
+            hearingLocation: 'Central London County Court',
+            hearingLocationOption: 'SUGGESTED_COURT'
+          }
+        },
+        claimantResponse: {
+          freeMediation: 'yes',
+          settleForAmount: 'no',
+          type: 'REJECTION'
+        },
+        claimantRespondedAt: MomentFactory.currentDate(),
+        mediationOutcome: MediationOutcome.FAILED
+      },
+      claimantAssertions: [
+        'Mediation was unsuccessful',
+        'You weren’t able to resolve your claim against ' + fullDefenceClaim().claim.defendants[0].name + ' using mediation.'
+      ],
+      defendantAssertions: [
+        'Mediation was unsuccessful',
+        'You weren’t able to resolve ' + fullDefenceClaim().claim.claimants[0].name + '’s claim against you using mediation.',
+        'Download ' + fullDefenceClaim().claim.claimants[0].name + '’s hearing requirements'
+      ]
+    },
+    {
+      status: 'Full defence - defendant already paid - claimant rejects defendant response with mediation - mediation succeeded',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        response: {
+          ...defenceWithDisputeData,
+          freeMediation: 'yes'
+        },
+        claimantResponse: {
+          freeMediation: 'yes',
+          settleForAmount: 'no',
+          type: 'REJECTION'
+        },
+        claimantRespondedAt: MomentFactory.currentDate(),
+        ...directionsQuestionnaireDeadline(),
+        mediationOutcome: MediationOutcome.SUCCEEDED
+      },
+      claimantAssertions: [
+        'You settled the claim through mediation',
+        'You made an agreement which means the claim is now ended and sets out the terms of how ' + fullDefenceClaim().claim.defendants[0].name + ' must repay you.',
+        'Download the agreement',
+        '(PDF)'
+      ],
+      defendantAssertions: [
+        'You settled the claim through mediation',
+        'You made an agreement which means the claim is now ended and sets out the terms of how you must repay ' + fullDefenceClaim().claim.claimants[0].name + '.',
+        'Download the agreement',
+        '(PDF)',
+        'Contact ' + fullDefenceClaim().claim.claimants[0].name,
+        'if you need their payment details. Make sure you get receipts for any payments.'
+      ]
+    },
+    {
+      status: 'Full defence - defendant already paid - claimant rejects defendant response without mediation',
       claim: fullDefenceClaim(),
       claimOverride: {
         response: { ...defenceWithAmountClaimedAlreadyPaidData },
@@ -108,13 +202,14 @@ function testData () {
       ],
       defendantAssertions: [
         `John Smith has rejected your admission of ${NumberFormatter.formatMoney(defenceWithAmountClaimedAlreadyPaidData.paymentDeclaration.paidAmount)}`,
-        'They said you didn’t pay them £' + defenceWithAmountClaimedAlreadyPaidData.paymentDeclaration.paidAmount,
+        `They said you didn’t pay them £${defenceWithAmountClaimedAlreadyPaidData.paymentDeclaration.paidAmount}`,
         'You might have to go to a court hearing. We’ll contact you if we set a hearing date to tell you how to prepare.',
         'Download your response'
       ]
     },
+
     {
-      status: 'Full defence - defendant dispute all of the claim - defendant offers settlement to settle out of court - claim settled with agreement',
+      status: 'Full defence - defendant disputes all of the claim - defendant offers settlement to settle out of court - claim settled with agreement',
       claim: fullDefenceClaim(),
       claimOverride: {
         response: {
@@ -134,14 +229,9 @@ function testData () {
         'You’ve both signed a legal agreement. The claim is now settled.',
         'Download the settlement agreement'
       ]
-    }
-  ]
-}
-
-function legacyClaimDetails () {
-  return [
+    },
     {
-      status: 'Full defence - defendant dispute all of the claim and accepts mediation - defendant offers settlement to settle out of court - claimant rejected offer',
+      status: 'Full defence - defendant disputes all of the claim and accepts mediation',
       claim: fullDefenceClaim(),
       claimOverride: {
         response: {
@@ -149,16 +239,18 @@ function legacyClaimDetails () {
           ...baseDefenceData,
           freeMediation: FreeMediationOption.YES
         },
-        ...directionsQuestionnaireDeadline(),
-        ...settlementOfferReject()
+        ...directionsQuestionnaireDeadline()
       },
       claimantAssertions: [
-        'The defendant’s response',
-        fullDefenceClaim().claim.defendants[0].name + ' has rejected the claim. They’ve suggested mediation to help resolve this dispute.',
-        'Find out how mediation works',
-        'You need to email CONTACT_EMAIL before 4pm on',
-        'If you don’t send an email before the deadline, the claim will proceed without mediation.',
-        'Download their response',
+        'Decide whether to proceed',
+        `${fullDefenceClaim().claim.defendants[0].name} has rejected your claim.`,
+        'You need to decide whether to proceed with the claim.',
+        'You need to respond before 4pm on ',
+        'Your claim won’t continue if you don’t respond by then.',
+        'View and respond',
+        'Settle out of court',
+        `${fullDefenceClaim().claim.defendants[0].name} has made an offer to settle out of court.`,
+        'View and respond to the offer',
         'Tell us you’ve ended the claim',
         'If you’ve been paid or you’ve made another agreement with the defendant, you need to tell us.',
         'Tell us you’ve settled'
@@ -169,11 +261,44 @@ function legacyClaimDetails () {
         'We’ll ask ' + fullDefenceClaim().claim.claimants[0].name + ' if they agree to take part in mediation.',
         'Download your response',
         'Settle out of court',
-        'The claimant has rejected your offer to settle the claim. Complete the directions questionnaire.'
+        'settle the claim out of court'
       ]
     },
     {
-      status: 'Full defence - defendant dispute all of the claim and accepts mediation - defendant offers settlement to settle out of court - claimant accepted offer',
+      status: 'Full defence - defendant disputes all of the claim and accepts mediation - defendant offers settlement to settle out of court',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        response: {
+          ...baseResponseData,
+          ...baseDefenceData,
+          freeMediation: FreeMediationOption.YES
+        },
+        ...directionsQuestionnaireDeadline(),
+        ...settlementOffer()
+      },
+      claimantAssertions: [
+        'Decide whether to proceed',
+        `${fullDefenceClaim().claim.defendants[0].name} has rejected your claim`,
+        'You need to decide whether to proceed with the claim. You need to respond before 4pm on',
+        'Your claim won’t continue if you don’t respond by then.',
+        'Settle out of court',
+        `${fullDefenceClaim().claim.defendants[0].name} has made an offer to settle out of court.`,
+        'View and respond to the offer',
+        'Tell us you’ve ended the claim',
+        'If you’ve been paid or you’ve made another agreement with the defendant, you need to tell us.',
+        'Tell us you’ve settled'
+      ],
+      defendantAssertions: [
+        'Your response to the claim',
+        'You have rejected the claim. You’ve suggested mediation.',
+        `We’ll ask ${fullDefenceClaim().claim.claimants[0].name} if they agree to take part in mediation.`,
+        'Download your response',
+        'Settle out of court',
+        `You made an offer to settle the claim out of court. ${fullDefenceClaim().claim.claimants[0].name} can accept or reject your offer.`
+      ]
+    },
+    {
+      status: 'Full defence - defendant disputes all of the claim and accepts mediation - defendant offers settlement to settle out of court - claimant accepts offer',
       claim: fullDefenceClaim(),
       claimOverride: {
         response: {
@@ -185,15 +310,18 @@ function legacyClaimDetails () {
         ...settlementOfferAccept()
       },
       claimantAssertions: [
-        'The defendant’s response',
-        fullDefenceClaim().claim.defendants[0].name + ' has rejected the claim. They’ve suggested mediation to help resolve this dispute.',
-        'Find out how mediation works',
-        'You need to email CONTACT_EMAIL before 4pm on',
-        'If you don’t send an email before the deadline, the claim will proceed without mediation.',
-        'Download their response',
+        'Decide whether to proceed',
+        `${fullDefenceClaim().claim.defendants[0].name} has rejected your claim.`,
+        'You need to decide whether to proceed with the claim.',
+        'You need to respond before 4pm on ',
+        'Your claim won’t continue if you don’t respond by then.',
+        'View and respond',
         'Settle out of court',
-        'You’ve agreed to the offer made by ' + fullDefenceClaim().claim.defendants[0].name + ' and signed an agreement to settle your claim.',
-        'We’ve asked ' + fullDefenceClaim().claim.defendants[0].name + ' to sign the agreement.'
+        `You’ve agreed to the offer made by ${fullDefenceClaim().claim.defendants[0].name} and signed an agreement to settle your claim.`,
+        `We’ve asked ${fullDefenceClaim().claim.defendants[0].name} to sign the agreement.`,
+        'Tell us you’ve ended the claim',
+        'If you’ve been paid or you’ve made another agreement with the defendant, you need to tell us.',
+        'Tell us you’ve settled'
       ],
       defendantAssertions: [
         'Your response to the claim',
@@ -206,170 +334,24 @@ function legacyClaimDetails () {
       ]
     },
     {
-      status: 'Full defence - defendant dispute all of the claim and accepts mediation - defendant offers settlement to settle out of court',
+      status: 'Full defence - defendant disputes all of the claim and accepts mediation - defendant offers settlement to settle out of court - claimant rejects offer',
       claim: fullDefenceClaim(),
       claimOverride: {
         response: {
           ...baseResponseData,
           ...baseDefenceData,
           freeMediation: FreeMediationOption.YES
-        },
-        ...directionsQuestionnaireDeadline(),
-        ...settlementOffer()
-      },
-      claimantAssertions: [
-        'The defendant’s response',
-        fullDefenceClaim().claim.defendants[0].name + ' has rejected the claim. They’ve suggested mediation to help resolve this dispute.',
-        'Find out how mediation works',
-        'You need to email CONTACT_EMAIL before 4pm on',
-        'If you don’t send an email before the deadline, the claim will proceed without mediation.',
-        'Settle out of court',
-        fullDefenceClaim().claim.defendants[0].name + ' has made an offer to settle out of court.',
-        'View and respond to the offer',
-        'If you’ve been paid',
-        'Tell us you’ve settled'
-      ],
-      defendantAssertions: [
-        'Your response to the claim',
-        'You have rejected the claim. You’ve suggested mediation.',
-        'We’ll ask ' + fullDefenceClaim().claim.claimants[0].name + ' if they agree to take part in mediation.',
-        'Download your response',
-        'Settle out of court',
-        'You made an offer to settle the claim out of court. ' + fullDefenceClaim().claim.claimants[0].name + ' can accept or reject your offer.'
-      ]
-    },
-    {
-      status: 'Full defence - defendant dispute all of the claim and accepts mediation',
-      claim: fullDefenceClaim(),
-      claimOverride: {
-        response: {
-          ...baseResponseData,
-          ...baseDefenceData,
-          freeMediation: FreeMediationOption.YES
-        },
-        ...directionsQuestionnaireDeadline()
-      },
-      claimantAssertions: [
-        'The defendant’s response',
-        'John Doe has rejected the claim. They’ve suggested mediation to help resolve this dispute.',
-        'Find out how mediation works',
-        'You need to email CONTACT_EMAIL before 4pm on',
-        'If you don’t send an email before the deadline, the claim will proceed without mediation.'
-      ],
-      defendantAssertions: [
-        'Your response to the claim',
-        'You have rejected the claim. You’ve suggested mediation.',
-        'We’ll ask ' + fullDefenceClaim().claim.claimants[0].name + ' if they agree to take part in mediation.',
-        'Download your response',
-        'Settle out of court',
-        'settle the claim out of court'
-      ]
-    },
-    {
-      status: 'Full defence - defendant dispute all of the claim and reject mediation',
-      claim: fullDefenceClaim(),
-      claimOverride: {
-        response: {
-          ...baseResponseData,
-          ...baseDefenceData
-        },
-        ...directionsQuestionnaireDeadline()
-      },
-      claimantAssertions: [
-        'They said they dispute your claim.',
-        'complete a directions questionnaire',
-        'Download their response',
-        'Tell us you’ve ended the claim',
-        'If you’ve been paid or you’ve made another agreement with the defendant, you need to tell us.',
-        'Tell us you’ve settled'
-      ],
-      defendantAssertions: [
-        'Your response to the claim',
-        'You’ve rejected the claim and said you don’t want to use mediation to solve it. You’ll have to go to a hearing.',
-        'You need to',
-        'Your defence will be cancelled if you don’t complete and return the form before',
-        'Settle out of court',
-        'settle the claim out of court'
-      ]
-    },
-    {
-      status: 'Full defence - defendant dispute all of the claim and reject mediation - defendant offers settlement to settle out of court',
-      claim: fullDefenceClaim(),
-      claimOverride: {
-        response: {
-          ...baseResponseData,
-          ...baseDefenceData
-        },
-        ...directionsQuestionnaireDeadline(),
-        ...settlementOffer()
-      },
-      claimantAssertions: [
-        'The defendant has rejected your claim',
-        'They said they dispute your claim.',
-        'You need to',
-        'Your claim won’t proceed if you don’t complete and return the form before',
-        'Settle out of court',
-        fullDefenceClaim().claim.defendants[0].name + ' has made an offer to settle out of court.',
-        'View and respond to the offer',
-        'Tell us you’ve ended the claim',
-        'If you’ve been paid or you’ve made another agreement with the defendant, you need to tell us.',
-        'Tell us you’ve settled'
-      ],
-      defendantAssertions: [
-        'Your response to the claim',
-        'You’ve rejected the claim and said you don’t want to use mediation to solve it. You’ll have to go to a hearing.',
-        'You need to',
-        'Your defence will be cancelled if you don’t complete and return the form before',
-        'Settle out of court',
-        'You made an offer to settle the claim out of court. ' + fullDefenceClaim().claim.claimants[0].name + ' can accept or reject your offer.'
-      ]
-    },
-    {
-      status: 'Full defence - defendant dispute all of the claim and reject mediation - defendant offers settlement to settle out of court - claimant accepted offer',
-      claim: fullDefenceClaim(),
-      claimOverride: {
-        response: {
-          ...baseResponseData,
-          ...baseDefenceData
-        },
-        ...directionsQuestionnaireDeadline(),
-        ...settlementOfferAccept()
-      },
-      claimantAssertions: [
-        'The defendant has rejected your claim',
-        'They said they dispute your claim.',
-        'You need to',
-        'Your claim won’t proceed if you don’t complete and return the form before',
-        'Settle out of court',
-        'You’ve agreed to the offer made by ' + fullDefenceClaim().claim.defendants[0].name + ' and signed an agreement to settle your claim.',
-        'We’ve asked ' + fullDefenceClaim().claim.defendants[0].name + ' to sign the agreement.'
-      ],
-      defendantAssertions: [
-        'Your response to the claim',
-        'You’ve rejected the claim and said you don’t want to use mediation to solve it. You’ll have to go to a hearing.',
-        'You need to',
-        'Your defence will be cancelled if you don’t complete and return the form before',
-        'Settle out of court',
-        'The claimant has accepted your offer and signed a legal agreement. You need to sign the agreement to settle out of court.',
-        'Sign the settlement agreement'
-      ]
-    },
-    {
-      status: 'Full defence - defendant dispute all of the claim and reject mediation - defendant offers settlement to settle out of court - claimant rejected offer',
-      claim: fullDefenceClaim(),
-      claimOverride: {
-        response: {
-          ...baseResponseData,
-          ...baseDefenceData
         },
         ...directionsQuestionnaireDeadline(),
         ...settlementOfferReject()
       },
       claimantAssertions: [
-        'The defendant has rejected your claim',
-        'They said they dispute your claim.',
-        'You need to',
-        'Your claim won’t proceed if you don’t complete and return the form before ',
+        'Decide whether to proceed',
+        `${fullDefenceClaim().claim.defendants[0].name} has rejected your claim.`,
+        'You need to decide whether to proceed with the claim.',
+        'You need to respond before 4pm on',
+        'Your claim won’t continue if you don’t respond by then.',
+        'View and respond',
         'Settle out of court',
         'You’ve rejected the defendant’s offer to settle out of court. You won’t receive any more offers from the defendant.',
         'Tell us you’ve ended the claim',
@@ -378,565 +360,348 @@ function legacyClaimDetails () {
       ],
       defendantAssertions: [
         'Your response to the claim',
-        'You’ve rejected the claim and said you don’t want to use mediation to solve it. You’ll have to go to a hearing.',
-        'Your defence will be cancelled if you don’t complete and return the form before',
+        'You have rejected the claim. You’ve suggested mediation.',
+        'We’ll ask ' + fullDefenceClaim().claim.claimants[0].name + ' if they agree to take part in mediation.',
+        'Download your response',
         'Settle out of court',
         'The claimant has rejected your offer to settle the claim. Complete the directions questionnaire.'
+      ]
+    },
+    {
+      status: 'Full defence - defendant disputes all of the claim and accepts mediation with directions questionnaire enabled',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        features: ['admissions', 'directionsQuestionnaire'],
+        response: {
+          ...baseResponseData,
+          ...baseDefenceData,
+          freeMediation: FreeMediationOption.YES
+        }
+      },
+      claimantAssertions: [
+        'Decide whether to proceed',
+        fullDefenceClaim().claim.defendants[0].name + ' has rejected your claim.',
+        'View and respond'
+      ],
+      defendantAssertions: [
+        'Your response to the claim',
+        'You have rejected the claim. You’ve suggested mediation.',
+        'We’ll ask ' + fullDefenceClaim().claim.claimants[0].name + ' if they agree to take part in mediation.',
+        'Download your response',
+        'Settle out of court',
+        'settle the claim out of court'
+      ]
+    },
+
+    {
+      status: 'Full defence - defendant disputes all of the claim and rejects mediation',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        response: {
+          ...baseResponseData,
+          ...baseDefenceData
+        },
+        ...directionsQuestionnaireDeadline()
+      },
+      claimantAssertions: [
+        'Decide whether to proceed',
+        `${fullDefenceClaim().claim.defendants[0].name} has rejected your claim.`,
+        'You need to decide whether to proceed with the claim.',
+        'You need to respond before 4pm on ',
+        'Your claim won’t continue if you don’t respond by then.',
+        'View and respond',
+        'Settle out of court',
+        `${fullDefenceClaim().claim.defendants[0].name} has made an offer to settle out of court.`,
+        'View and respond to the offer',
+        'Tell us you’ve ended the claim',
+        'If you’ve been paid or you’ve made another agreement with the defendant, you need to tell us.',
+        'Tell us you’ve settled'
+      ],
+      defendantAssertions: [
+        'Wait for the claimant to respond',
+        'You’ve rejected the claim.',
+        'You said you don’t want to use mediation to solve it. You might have to go to a hearing.',
+        'We’ll contact you when the claimant responds.',
+        'Settle out of court',
+        `You made an offer to settle the claim out of court. ${fullDefenceClaim().claim.claimants[0].name} can accept or reject your offer.`,
+        'We’ll email you when they respond.'
+      ]
+    },
+    {
+      status: 'Full defence - defendant disputes all of the claim and rejects mediation - claimant accepts full defence',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        response: {
+          ...defenceWithDisputeData,
+          freeMediation: 'no'
+        },
+        claimantResponse: {
+          type: 'ACCEPTATION'
+        },
+        claimantRespondedAt: MomentFactory.currentDate(),
+        ...directionsQuestionnaireDeadline()
+      },
+      claimantAssertions: [
+        'You stopped this claim',
+        'You ended the claim on'
+      ],
+      defendantAssertions: [
+        'This claim has ended',
+        fullDefenceClaim().claim.claimants[0].name
+        + ' ended their claim against you on'
+      ]
+    },
+    {
+      status: 'Full defence - defendant disputes all of the claim and rejects mediation - claimant does not do intention to proceed',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        response: {
+          ...defenceWithDisputeData
+        },
+        ...directionsQuestionnaireDeadline(),
+        ...intentionToProceedDeadline()
+      },
+      claimantAssertions: [
+        'The court ended the claim',
+        'This is because you didn’t proceed before the deadline of 4pm on',
+        'You can contact us to apply for the claim to be restarted.',
+        'Download the defendant’s full response'
+      ],
+      defendantAssertions: [
+        'The court ended the claim',
+        'This is because John Smith didn’t proceed with it before the deadline of 4pm on',
+        'If they want to restart the claim, they need to ask for permission from the court. We’ll contact you by post if they do this.'
+      ]
+    },
+    {
+      status: 'Full defence - defendant disputes all of the claim and rejects mediation - defendant offers settlement to settle out of court',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        response: {
+          ...baseResponseData,
+          ...baseDefenceData
+        },
+        ...directionsQuestionnaireDeadline(),
+        ...settlementOffer()
+      },
+      claimantAssertions: [
+        'Decide whether to proceed',
+        `${fullDefenceClaim().claim.defendants[0].name} has rejected your claim.`,
+        'You need to decide whether to proceed with the claim.',
+        'You need to respond before 4pm on ',
+        'Your claim won’t continue if you don’t respond by then.',
+        'View and respond',
+        'Settle out of court',
+        `${fullDefenceClaim().claim.defendants[0].name} has made an offer to settle out of court.`,
+        'View and respond to the offer',
+        'Tell us you’ve ended the claim',
+        'If you’ve been paid or you’ve made another agreement with the defendant, you need to tell us.',
+        'Tell us you’ve settled'
+      ],
+      defendantAssertions: [
+        'Wait for the claimant to respond',
+        'You’ve rejected the claim.',
+        'You said you don’t want to use mediation to solve it. You might have to go to a hearing.',
+        'We’ll contact you when the claimant responds.',
+        'Settle out of court',
+        `You made an offer to settle the claim out of court. ${fullDefenceClaim().claim.claimants[0].name} can accept or reject your offer.`,
+        'We’ll email you when they respond.'
+      ]
+    },
+    {
+      status: 'Full defence - defendant disputes all of the claim and rejects mediation - defendant offers settlement to settle out of court - claimant accepts offer',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        response: {
+          ...baseResponseData,
+          ...baseDefenceData
+        },
+        ...directionsQuestionnaireDeadline(),
+        ...settlementOfferAccept()
+      },
+      claimantAssertions: [
+        'Decide whether to proceed',
+        `${fullDefenceClaim().claim.defendants[0].name} has rejected your claim.`,
+        'You need to decide whether to proceed with the claim.',
+        'You need to respond before 4pm on ',
+        'Your claim won’t continue if you don’t respond by then.',
+        'View and respond',
+        'Settle out of court',
+        `You’ve agreed to the offer made by ${fullDefenceClaim().claim.defendants[0].name} and signed an agreement to settle your claim.`,
+        `We’ve asked ${fullDefenceClaim().claim.defendants[0].name} to sign the agreement.`,
+        'Tell us you’ve ended the claim',
+        'If you’ve been paid or you’ve made another agreement with the defendant, you need to tell us.',
+        'Tell us you’ve settled'
+      ],
+      defendantAssertions: [
+        'Wait for the claimant to respond',
+        'You’ve rejected the claim.',
+        'You said you don’t want to use mediation to solve it. You might have to go to a hearing.',
+        'We’ll contact you when the claimant responds.',
+        'Settle out of court',
+        'The claimant has accepted your offer and signed a legal agreement. You need to sign the agreement to settle out of court.',
+        'When you’ve both signed the agreement, the claim won’t proceed.',
+        'Sign the settlement agreement'
+      ]
+    },
+    {
+      status: 'Full defence - defendant disputes all of the claim and rejects mediation - defendant offers settlement to settle out of court - claimant rejects offer',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        response: {
+          ...baseResponseData,
+          ...baseDefenceData
+        },
+        ...directionsQuestionnaireDeadline(),
+        ...settlementOfferReject()
+      },
+      claimantAssertions: [
+        'Decide whether to proceed',
+        `${fullDefenceClaim().claim.defendants[0].name} has rejected your claim.`,
+        'You need to decide whether to proceed with the claim.',
+        'You need to respond before 4pm on ',
+        'Your claim won’t continue if you don’t respond by then.',
+        'View and respond',
+        'Settle out of court',
+        'You’ve rejected the defendant’s offer to settle out of court. You won’t receive any more offers from the defendant.',
+        'Tell us you’ve ended the claim',
+        'If you’ve been paid or you’ve made another agreement with the defendant, you need to tell us.',
+        'Tell us you’ve settled'
+      ],
+      defendantAssertions: [
+        'Wait for the claimant to respond',
+        'You’ve rejected the claim.',
+        'You said you don’t want to use mediation to solve it. You might have to go to a hearing.',
+        'We’ll contact you when the claimant responds.',
+        'Settle out of court',
+        'The claimant has rejected your offer to settle the claim. Complete the directions questionnaire.'
+      ]
+    },
+    {
+      status: 'Full defence - defendant disputes all of the claim and rejects mediation with directions questionnaire enabled',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        ...directionsQuestionnaireDeadline(),
+        features: ['admissions', 'directionsQuestionnaire'],
+        response: {
+          ...baseResponseData,
+          ...baseDefenceData,
+          freeMediation: FreeMediationOption.NO
+        }
+      },
+      claimantAssertions: [
+        'Decide whether to proceed',
+        fullDefenceClaim().claim.defendants[0].name + ' has rejected your claim.',
+        'View and respond'
+      ],
+      defendantAssertions: [
+        'Wait for the claimant to respond',
+        'You’ve rejected the claim.',
+        'You said you don’t want to use mediation to solve it. You might have to go to a hearing.',
+        'We’ll contact you when the claimant responds.',
+        'Settle out of court',
+        'settle the claim out of court'
+      ]
+    },
+    {
+      status: 'Full defence - defendant disputes the claim - claimant rejects defendant response with mediation - online DQ',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        features: ['admission', 'directionsQuestionnaire'],
+        response: {
+          ...baseResponseData,
+          ...baseDefenceData,
+          freeMediation: FreeMediationOption.YES,
+          defenceType: DefenceType.DISPUTE,
+          directionsQuestionnaire: {
+            hearingLoop: 'NO',
+            selfWitness: 'NO',
+            disabledAccess: 'NO',
+            hearingLocation: 'Central London County Court',
+            hearingLocationOption: 'SUGGESTED_COURT'
+          }
+        },
+        claimantResponse: {
+          freeMediation: 'yes',
+          settleForAmount: 'no',
+          type: 'REJECTION'
+        },
+        claimantRespondedAt: MomentFactory.currentDate()
+      },
+      claimantAssertions: [
+        'You’ve both agreed to try mediation.',
+        'We’ll contact you to try to arrange a call with the mediator.'
+      ],
+      defendantAssertions: [
+        `${fullDefenceClaim().claim.claimants[0].name} has rejected your defence.`,
+        'You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.',
+        'Find out how mediation works',
+        'They’ve also sent us their hearing requirements.',
+        'Download their hearing requirements'
+      ]
+    },
+    {
+      status: 'Full defence - defendant disputes the claim - claimant rejects defendant response without mediation - online DQ',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        features: ['admission', 'directionsQuestionnaire'],
+        response: {
+          ...baseResponseData,
+          ...baseDefenceData,
+          freeMediation: FreeMediationOption.NO,
+          defenceType: DefenceType.DISPUTE,
+          directionsQuestionnaire: {
+            hearingLoop: 'NO',
+            selfWitness: 'NO',
+            disabledAccess: 'NO',
+            hearingLocation: 'Central London County Court',
+            hearingLocationOption: 'SUGGESTED_COURT'
+          }
+        },
+        claimantResponse: {
+          type: 'REJECTION',
+          freeMediation: 'no',
+          settleForAmount: 'no'
+        },
+        claimantRespondedAt: MomentFactory.currentDate()
+      },
+      claimantAssertions: [
+        'You’ve rejected defendant’s response and said you want to take the case to court.',
+        'The court will review the case. We’ll email you if we set a hearing date to tell you how to prepare.'
+      ],
+      defendantAssertions: [
+        `${fullDefenceClaim().claim.claimants[0].name} has rejected your defence.`,
+        'The court will review the case. We’ll email you if we set a hearing date to tell you how to prepare.',
+        'They’ve also sent us their hearing requirements.',
+        'Download their hearing requirements']
+    },
+
+    {
+      status: 'Full defence - defendant sent a paper response',
+      claim: fullDefenceClaim(),
+      claimOverride: {
+        response: {
+          ...baseResponseData,
+          ...baseDefenceData,
+          freeMediation: FreeMediationOption.YES
+        },
+        paperResponse: YesNoOption.YES.option
+      },
+      claimantAssertions: [
+        'The claim will continue by post',
+        'The defendant responded to your claim by post. This means you can no longer use this service to continue the claim - you’ll need to use paper forms instead.',
+        'Your online account won’t be updated with the progress of this claim.',
+        'We’ll post you a copy of the defendant’s response. This will explain what you need to do next.'
+      ],
+      defendantAssertions: [
+        'The claim will continue by post',
+        'Because you responded to the claim using a paper form, all further action in this claim will be by post.',
+        'Your online account won’t be updated with the progress of this claim.',
+        'If ' + fullDefenceClaim().claim.claimants[0].name + ' chooses to continue the claim we’ll post you a copy of their response. This will explain what you need to do next.'
       ]
     }
   ]
 }
-
-const mediationDQEnabledClaimDetails = [
-  {
-    status: 'Full defence - defendant sent a paper response',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData,
-        freeMediation: FreeMediationOption.YES
-      },
-      paperResponse: YesNoOption.YES.option
-    },
-    claimantAssertions: [
-      'The claim will continue by post',
-      'The defendant responded to your claim by post. This means you can no longer use this service to continue the claim - you’ll need to use paper forms instead.',
-      'Your online account won’t be updated with the progress of this claim.',
-      'We’ll post you a copy of the defendant’s response. This will explain what you need to do next.'
-    ],
-    defendantAssertions: [
-      'The claim will continue by post',
-      'Because you responded to the claim using a paper form, all further action in this claim will be by post.',
-      'Your online account won’t be updated with the progress of this claim.',
-      'If ' + fullDefenceClaim().claim.claimants[0].name + ' chooses to continue the claim we’ll post you a copy of their response. This will explain what you need to do next.'
-    ]
-  },
-  {
-    status: 'Full defence - defendant paid what he believe - claimant rejected defendant response with mediation',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      response: {
-        ...defenceWithAmountClaimedAlreadyPaidData,
-        freeMediation: 'yes'
-      },
-      claimantResponse: {
-        freeMediation: 'yes',
-        settleForAmount: 'no',
-        type: 'REJECTION'
-      },
-      claimantRespondedAt: MomentFactory.currentDate(),
-      ...directionsQuestionnaireDeadline()
-    },
-    claimantAssertions: [
-      'You’ve rejected the defendant’s response.',
-      'We’ll contact you to try to arrange a mediation appointment',
-      'You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.',
-      'Find out how mediation works'
-    ],
-    defendantAssertions: [
-      'John Smith has rejected your defence.',
-      'We’ll contact you to try to arrange a mediation appointment',
-      'You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.',
-      'Find out how mediation works'
-    ]
-  },
-  {
-    status: 'Full defence - defendant paid what he believe - claimant rejected defendant response with mediation - mediation failed',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      features: ['admissions', 'directionsQuestionnaire'],
-      response: {
-        ...defenceWithAmountClaimedAlreadyPaidData,
-        freeMediation: 'yes',
-        directionsQuestionnaire: {
-          hearingLoop: 'NO',
-          selfWitness: 'NO',
-          disabledAccess: 'NO',
-          hearingLocation: 'Central London County Court',
-          hearingLocationOption: 'SUGGESTED_COURT'
-        }
-      },
-      claimantResponse: {
-        freeMediation: 'yes',
-        settleForAmount: 'no',
-        type: 'REJECTION'
-      },
-      claimantRespondedAt: MomentFactory.currentDate(),
-      mediationOutcome: MediationOutcome.FAILED
-    },
-    claimantAssertions: [
-      'Mediation was unsuccessful',
-      'You weren’t able to resolve your claim against ' + fullDefenceClaim().claim.defendants[0].name + ' using mediation.'
-    ],
-    defendantAssertions: [
-      'Mediation was unsuccessful',
-      'You weren’t able to resolve ' + fullDefenceClaim().claim.claimants[0].name + '’s claim against you using mediation.',
-      'Download ' + fullDefenceClaim().claim.claimants[0].name + '’s hearing requirements'
-    ]
-  },
-  {
-    status: 'Full defence - defendant paid what he believe - claimant rejected defendant§ response with mediation - mediation success',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      response: {
-        ...defenceWithDisputeData,
-        freeMediation: 'yes'
-      },
-      claimantResponse: {
-        freeMediation: 'yes',
-        settleForAmount: 'no',
-        type: 'REJECTION'
-      },
-      claimantRespondedAt: MomentFactory.currentDate(),
-      ...directionsQuestionnaireDeadline(),
-      mediationOutcome: MediationOutcome.SUCCEEDED
-    },
-    claimantAssertions: [
-      'You settled the claim through mediation',
-      'You made an agreement which means the claim is now ended and sets out the terms of how ' + fullDefenceClaim().claim.defendants[0].name + ' must repay you.',
-      'Download the agreement',
-      '(PDF)'
-    ],
-    defendantAssertions: [
-      'You settled the claim through mediation',
-      'You made an agreement which means the claim is now ended and sets out the terms of how you must repay ' + fullDefenceClaim().claim.claimants[0].name + '.',
-      'Download the agreement',
-      '(PDF)',
-      'Contact ' + fullDefenceClaim().claim.claimants[0].name,
-      'if you need their payment details. Make sure you get receipts for any payments.'
-    ]
-  },
-  {
-    status: 'Full defence - defendant dispute all of the claim and reject mediation - defendant offers settlement to settle out of court - claimant rejected offer',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData
-      },
-      ...directionsQuestionnaireDeadline(),
-      ...settlementOfferReject()
-    },
-    claimantAssertions: [
-      'Decide whether to proceed',
-      fullDefenceClaim().claim.defendants[0].name + ' has rejected your claim',
-      'You need to decide whether to proceed with the claim. You need to respond before 4pm on',
-      'Your claim won’t continue if you don’t respond by then.',
-      'Settle out of court',
-      'You’ve rejected the defendant’s offer to settle out of court. You won’t receive any more offers from the defendant.',
-      'If you’ve been paid',
-      'Tell us you’ve ended the claim'
-    ],
-    defendantAssertions: [
-      'Wait for the claimant to respond',
-      'You’ve rejected the claim.',
-      'You said you don’t want to use mediation to solve it. You might have to go to a hearing.',
-      'We’ll contact you when the claimant responds.',
-      'Settle out of court',
-      'The claimant has rejected your offer to settle the claim. Complete the directions questionnaire.'
-    ]
-  },
-  {
-    status: 'Full defence - defendant dispute all of the claim and reject mediation - defendant offers settlement to settle out of court - claimant rejected offer',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      createdAt: '2019-08-25',
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData
-      },
-      ...directionsQuestionnaireDeadline(),
-      ...settlementOfferReject()
-    },
-    claimantAssertions: [
-      'The defendant has rejected your claim',
-      'They said they dispute your claim.',
-      'Your claim won’t proceed if you don’t complete and return the form before 4pm on',
-      'Download their response',
-      'Settle out of court',
-      'You’ve rejected the defendant’s offer to settle out of court. You won’t receive any more offers from the defendant.',
-      'If you’ve been paid',
-      'Tell us you’ve ended the claim'
-    ],
-    defendantAssertions: [
-      'Your response to the claim',
-      'You’ve rejected the claim and said you don’t want to use mediation to solve it. You’ll have to go to a hearing.',
-      'Your defence will be cancelled if you don’t complete and return the form before 4pm on',
-      'Settle out of court',
-      'The claimant has rejected your offer to settle the claim. Complete the directions questionnaire.'
-    ]
-  },
-  {
-    status: 'Full defence - defendant dispute all of the claim and reject mediation - defendant offers settlement to settle out of court - claimant accepted offer',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData
-      },
-      ...directionsQuestionnaireDeadline(),
-      ...settlementOfferAccept()
-    },
-    claimantAssertions: [
-      'Decide whether to proceed',
-      fullDefenceClaim().claim.defendants[0].name + ' has rejected your claim',
-      'You need to decide whether to proceed with the claim. You need to respond before 4pm on',
-      'Your claim won’t continue if you don’t respond by then.',
-      'Settle out of court',
-      'You’ve agreed to the offer made by ' + fullDefenceClaim().claim.defendants[0].name + ' and signed an agreement to settle your claim.',
-      'We’ve asked ' + fullDefenceClaim().claim.defendants[0].name + ' to sign the agreement.'
-    ],
-    defendantAssertions: [
-      'Wait for the claimant to respond',
-      'You’ve rejected the claim.',
-      'You said you don’t want to use mediation to solve it. You might have to go to a hearing.',
-      'We’ll contact you when the claimant responds.',
-      'Settle out of court',
-      'The claimant has accepted your offer and signed a legal agreement. You need to sign the agreement to settle out of court.',
-      'Sign the settlement agreement'
-    ]
-  },
-  {
-    status: 'Full defence - defendant dispute all of the claim and reject mediation - defendant offers settlement to settle out of court',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData
-      },
-      ...directionsQuestionnaireDeadline(),
-      ...settlementOffer()
-    },
-    claimantAssertions: [
-      'Decide whether to proceed',
-      fullDefenceClaim().claim.defendants[0].name + ' has rejected your claim',
-      'You need to decide whether to proceed with the claim. You need to respond before 4pm on',
-      'Your claim won’t continue if you don’t respond by then.',
-      'Settle out of court',
-      fullDefenceClaim().claim.defendants[0].name + ' has made an offer to settle out of court.',
-      'If you’ve been paid',
-      'Tell us you’ve ended the claim'
-    ],
-    defendantAssertions: [
-      'Wait for the claimant to respond',
-      'You’ve rejected the claim.',
-      'You said you don’t want to use mediation to solve it. You might have to go to a hearing.',
-      'We’ll contact you when the claimant responds.',
-      'Settle out of court',
-      'You made an offer to settle the claim out of court. ' + fullDefenceClaim().claim.claimants[0].name + ' can accept or reject your offer.'
-    ]
-  },
-  {
-    status: 'Full defence - defendant dispute all of the claim and reject mediation',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData
-      },
-      ...directionsQuestionnaireDeadline()
-    },
-    claimantAssertions: [
-      'Decide whether to proceed',
-      'John Doe has rejected your claim.',
-      'You need to decide whether to proceed with the claim. You need to respond before 4pm on',
-      'Your claim won’t continue if you don’t respond by then.'
-    ],
-    defendantAssertions: [
-      'Wait for the claimant to respond',
-      'You’ve rejected the claim.',
-      'You said you don’t want to use mediation to solve it. You might have to go to a hearing.',
-      'We’ll contact you when the claimant responds.',
-      'Settle out of court',
-      'settle the claim out of court'
-    ]
-  },
-  {
-    status: 'Full defence - defendant dispute all of the claim and rejects mediation - claimant does not do intention to proceed',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      response: {
-        ...defenceWithDisputeData
-      },
-      ...directionsQuestionnaireDeadline(),
-      ...intentionToProceedDeadline()
-    },
-    claimantAssertions: [
-      'The court ended the claim',
-      'This is because you didn’t proceed before the deadline of 4pm on',
-      'You can contact us to apply for the claim to be restarted.',
-      'Download the defendant’s full response'
-    ],
-    defendantAssertions: [
-      'The court ended the claim',
-      'This is because John Smith didn’t proceed with it before the deadline of 4pm on',
-      'If they want to restart the claim, they need to ask for permission from the court. We’ll contact you by post if they do this.'
-    ]
-  },
-  {
-    status: 'Full defence - defendant dispute all of the claim and rejects mediation - claimant accepts full defense.',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      response: {
-        ...defenceWithDisputeData,
-        freeMediation: 'no'
-      },
-      claimantResponse: {
-        type: 'ACCEPTATION'
-      },
-      claimantRespondedAt: MomentFactory.currentDate(),
-      ...directionsQuestionnaireDeadline()
-    },
-    claimantAssertions: [
-      'You stopped this claim',
-      'You ended the claim on'
-    ],
-    defendantAssertions: [
-      'This claim has ended',
-      fullDefenceClaim().claim.claimants[0].name
-      + ' ended their claim against you on'
-    ]
-  },
-  {
-    status: 'Full defence - defendant dispute all of the claim and rejects mediation with directions questionnaire enabled',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      ...directionsQuestionnaireDeadline(),
-      features: ['admissions', 'directionsQuestionnaire'],
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData,
-        freeMediation: FreeMediationOption.NO
-      }
-    },
-    claimantAssertions: [
-      'Decide whether to proceed',
-      fullDefenceClaim().claim.defendants[0].name + ' has rejected your claim.',
-      'View and respond'
-    ],
-    defendantAssertions: [
-      'Wait for the claimant to respond',
-      'You’ve rejected the claim.',
-      'You said you don’t want to use mediation to solve it. You might have to go to a hearing.',
-      'We’ll contact you when the claimant responds.',
-      'Settle out of court',
-      'settle the claim out of court'
-    ]
-  },
-  {
-    status: 'Full defence - defendant dispute all of the claim and accepts mediation',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      ...directionsQuestionnaireDeadline(),
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData,
-        freeMediation: FreeMediationOption.YES
-      }
-    },
-    claimantAssertions: [
-      fullDefenceClaim().claim.defendants[0].name + ' has rejected your claim.',
-      'You need to decide whether to proceed with the claim',
-      'If you’ve been paid',
-      'Tell us you’ve ended the claim'
-    ],
-    defendantAssertions: [
-      'Your response to the claim',
-      'You have rejected the claim. You’ve suggested mediation.',
-      'We’ll ask ' + fullDefenceClaim().claim.claimants[0].name + ' if they agree to take part in mediation.',
-      'Download your response',
-      'Settle out of court',
-      'settle the claim out of court'
-    ]
-  },
-  {
-    status: 'Full defence - defendant dispute all of the claim and accepts mediation with directions questionnaire enabled',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      features: ['admissions', 'directionsQuestionnaire'],
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData,
-        freeMediation: FreeMediationOption.YES
-      }
-    },
-    claimantAssertions: [
-      'Decide whether to proceed',
-      fullDefenceClaim().claim.defendants[0].name + ' has rejected your claim.',
-      'View and respond'
-    ],
-    defendantAssertions: [
-      'Your response to the claim',
-      'You have rejected the claim. You’ve suggested mediation.',
-      'We’ll ask ' + fullDefenceClaim().claim.claimants[0].name + ' if they agree to take part in mediation.',
-      'Download your response',
-      'Settle out of court',
-      'settle the claim out of court'
-    ]
-  },
-  {
-    status: 'Full defence - defendant disputes the claim - claimant rejected defendant response without mediation - online DQ',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      features: ['admission', 'directionsQuestionnaire'],
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData,
-        freeMediation: FreeMediationOption.NO,
-        defenceType: DefenceType.DISPUTE,
-        directionsQuestionnaire: {
-          hearingLoop: 'NO',
-          selfWitness: 'NO',
-          disabledAccess: 'NO',
-          hearingLocation: 'Central London County Court',
-          hearingLocationOption: 'SUGGESTED_COURT'
-        }
-      },
-      claimantResponse: {
-        type: 'REJECTION',
-        freeMediation: 'no',
-        settleForAmount: 'no'
-      },
-      claimantRespondedAt: MomentFactory.currentDate()
-    },
-    claimantAssertions: ['You’ve rejected defendant’s response and said you want to take the case to court.',
-      'The court will review the case. We’ll email you if we set a hearing date to tell you how to prepare.'],
-    defendantAssertions: [fullDefenceClaim().claim.claimants[0].name + ' has rejected your defence.',
-      'The court will review the case. We’ll email you if we set a hearing date to tell you how to prepare.',
-      'They’ve also sent us their hearing requirements.',
-      'Download their hearing requirements']
-  },
-  {
-    status: 'Full defence - defendant disputes the claim - claimant rejected defendant response with mediation - online DQ',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      features: ['admission', 'directionsQuestionnaire'],
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData,
-        freeMediation: FreeMediationOption.YES,
-        defenceType: DefenceType.DISPUTE,
-        directionsQuestionnaire: {
-          hearingLoop: 'NO',
-          selfWitness: 'NO',
-          disabledAccess: 'NO',
-          hearingLocation: 'Central London County Court',
-          hearingLocationOption: 'SUGGESTED_COURT'
-        }
-      },
-      claimantResponse: {
-        freeMediation: 'yes',
-        settleForAmount: 'no',
-        type: 'REJECTION'
-      },
-      claimantRespondedAt: MomentFactory.currentDate()
-    },
-    claimantAssertions: ['You’ve both agreed to try mediation.',
-      'We’ll contact you to try to arrange a call with the mediator.'],
-    defendantAssertions: [fullDefenceClaim().claim.claimants[0].name + ' has rejected your defence.',
-      'You’ve both agreed to try mediation. We’ll contact you to try to arrange a call with the mediator.',
-      'Find out how mediation works',
-      'They’ve also sent us their hearing requirements.',
-      'Download their hearing requirements']
-  },
-  {
-    status: 'Full defence - defendant dispute all of the claim and accepts mediation - defendant offers settlement to settle out of court',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData,
-        freeMediation: FreeMediationOption.YES
-      },
-      ...directionsQuestionnaireDeadline(),
-      ...settlementOffer()
-    },
-    claimantAssertions: [
-      'Decide whether to proceed',
-      fullDefenceClaim().claim.defendants[0].name + ' has rejected your claim',
-      'You need to decide whether to proceed with the claim. You need to respond before 4pm on',
-      'Your claim won’t continue if you don’t respond by then.',
-      'Settle out of court',
-      fullDefenceClaim().claim.defendants[0].name + ' has made an offer to settle out of court.',
-      'View and respond to the offer',
-      'Tell us you’ve ended the claim',
-      'If you’ve been paid or you’ve made another agreement with the defendant, you need to tell us.',
-      'Tell us you’ve settled'
-    ],
-    defendantAssertions: [
-      'Your response to the claim',
-      'You have rejected the claim. You’ve suggested mediation.',
-      'We’ll ask ' + fullDefenceClaim().claim.claimants[0].name + ' if they agree to take part in mediation.',
-      'Download your response',
-      'Settle out of court',
-      'You made an offer to settle the claim out of court. ' + fullDefenceClaim().claim.claimants[0].name + ' can accept or reject your offer.'
-    ]
-  },
-  {
-    status: 'Full defence - defendant dispute all of the claim and accepts mediation - defendant offers settlement to settle out of court - claimant accepted offer',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData,
-        freeMediation: FreeMediationOption.YES
-      },
-      ...directionsQuestionnaireDeadline(),
-      ...settlementOfferAccept()
-    },
-    claimantAssertions: [
-      'Decide whether to proceed',
-      fullDefenceClaim().claim.defendants[0].name + ' has rejected your claim',
-      'You need to decide whether to proceed with the claim. You need to respond before 4pm on',
-      'Your claim won’t continue if you don’t respond by then.',
-      'Settle out of court',
-      'Tell us you’ve ended the claim',
-      'If you’ve been paid or you’ve made another agreement with the defendant, you need to tell us.',
-      'Tell us you’ve settled'
-    ],
-    defendantAssertions: [
-      'Your response to the claim',
-      'You have rejected the claim. You’ve suggested mediation.',
-      'We’ll ask ' + fullDefenceClaim().claim.claimants[0].name + ' if they agree to take part in mediation.',
-      'Download your response',
-      'Settle out of court',
-      'The claimant has accepted your offer and signed a legal agreement. You need to sign the agreement to settle out of court.',
-      'Sign the settlement agreement'
-    ]
-  },
-  {
-    status: 'Full defence - defendant dispute all of the claim and accepts mediation - defendant offers settlement to settle out of court - claimant rejected offer',
-    claim: fullDefenceClaim(),
-    claimOverride: {
-      response: {
-        ...baseResponseData,
-        ...baseDefenceData,
-        freeMediation: FreeMediationOption.YES
-      },
-      ...directionsQuestionnaireDeadline(),
-      ...settlementOfferReject()
-    },
-    claimantAssertions: [
-      'Decide whether to proceed',
-      fullDefenceClaim().claim.defendants[0].name + ' has rejected your claim',
-      'You need to decide whether to proceed with the claim. You need to respond before 4pm on',
-      'Your claim won’t continue if you don’t respond by then.',
-      'Settle out of court',
-      'You’ve rejected the defendant’s offer to settle out of court. You won’t receive any more offers from the defendant.',
-      'If you’ve been paid',
-      'Tell us you’ve ended the claim'
-    ],
-    defendantAssertions: [
-      'Your response to the claim',
-      'You have rejected the claim. You’ve suggested mediation.',
-      'We’ll ask ' + fullDefenceClaim().claim.claimants[0].name + ' if they agree to take part in mediation.',
-      'Download your response',
-      'Settle out of court',
-      'The claimant has rejected your offer to settle the claim. Complete the directions questionnaire.'
-    ]
-  }
-]
 
 const claimPagePath = Paths.claimantPage.evaluateUri({ externalId: fullDefenceClaim().externalId })
 const defendantPagePath = Paths.defendantPage.evaluateUri({ externalId: fullDefenceClaim().externalId })
@@ -955,30 +720,6 @@ describe('Dashboard page', () => {
             idamServiceMock.resolveRetrieveUserFor('1', 'citizen')
             claimStoreServiceMock.mockNextWorkingDay(MomentFactory.parse('2019-08-16'))
           })
-
-          if (FeatureToggles.isEnabled('mediation')) {
-            mediationDQEnabledClaimDetails.forEach(data => {
-              it(`should render mediation or DQ status: ${data.status}`, async () => {
-                claimStoreServiceMock.resolveRetrieveByExternalId(data.claim, data.claimOverride)
-
-                await request(app)
-                  .get(claimPagePath)
-                  .set('Cookie', `${cookieName}=ABC`)
-                  .expect(res => expect(res).to.be.successful.withText(...data.claimantAssertions))
-              })
-            })
-          } else {
-            legacyClaimDetails().forEach(data => {
-              it(`should render legacy claim status: ${data.status}`, async () => {
-                claimStoreServiceMock.resolveRetrieveByExternalId(data.claim, data.claimOverride)
-
-                await request(app)
-                  .get(claimPagePath)
-                  .set('Cookie', `${cookieName}=ABC`)
-                  .expect(res => expect(res).to.be.successful.withText(...data.claimantAssertions))
-              })
-            })
-          }
 
           testData().forEach(data => {
             it(`should render claim status: ${data.status}`, async () => {
@@ -1007,30 +748,6 @@ describe('Dashboard page', () => {
                 .expect(res => expect(res).to.be.successful.withText(...data.defendantAssertions))
             })
           })
-
-          if (FeatureToggles.isEnabled('mediation')) {
-            mediationDQEnabledClaimDetails.forEach(data => {
-              it(`should render mediation or DQ dashboard: ${data.status}`, async () => {
-                claimStoreServiceMock.resolveRetrieveByExternalId(data.claim, data.claimOverride)
-
-                await request(app)
-                  .get(defendantPagePath)
-                  .set('Cookie', `${cookieName}=ABC`)
-                  .expect(res => expect(res).to.be.successful.withText(...data.defendantAssertions))
-              })
-            })
-          } else {
-            legacyClaimDetails().forEach(data => {
-              it(`should render non mediation or DQ dashboard: ${data.status}`, async () => {
-                claimStoreServiceMock.resolveRetrieveByExternalId(data.claim, data.claimOverride)
-
-                await request(app)
-                  .get(defendantPagePath)
-                  .set('Cookie', `${cookieName}=ABC`)
-                  .expect(res => expect(res).to.be.successful.withText(...data.defendantAssertions))
-              })
-            })
-          }
         })
       })
     })


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-7926

### Change description
Add line to claimant and defendant dashboards when the claimant continues with the claim after defendant disputes all without mediation, and when mediation failed, to say that the claim will continue offline by post and the online service won't be updated.

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
