### PR TITLE
ROC-8101 Move injection of the warning_banner toggle state to Node.js, just consume in nunjucks

### DIFF
--- a/src/main/app/utils/featureToggles.ts
+++ b/src/main/app/utils/featureToggles.ts
@@ -1,16 +1,14 @@
 import * as config from 'config'
 import * as toBoolean from 'to-boolean'
 import { LaunchDarklyClient } from 'shared/clients/launchDarklyClient'
-import { ClaimStoreClient } from 'claims/claimStoreClient'
 
 export class FeatureToggles {
-  readonly claimStoreClient: ClaimStoreClient
   readonly launchDarklyClient: LaunchDarklyClient
 
-  constructor (claimStoreClient: ClaimStoreClient, launchDarklyClient: LaunchDarklyClient) {
-    this.claimStoreClient = claimStoreClient
+  constructor (launchDarklyClient: LaunchDarklyClient) {
     this.launchDarklyClient = launchDarklyClient
   }
+
   static isEnabled (featureName: string): boolean {
     return FeatureToggles.isAnyEnabled(featureName)
   }

--- a/src/main/modules/nunjucks/index.ts
+++ b/src/main/modules/nunjucks/index.ts
@@ -73,13 +73,6 @@ import { PaymentOption } from 'claims/models/paymentOption'
 import { ResponseType as DomainResponseType } from 'claims/models/response/responseType'
 import { FeaturesBuilder } from 'claim/helpers/featuresBuilder'
 import { ProceedOfflineReason } from 'claims/models/proceedOfflineReason'
-import { LaunchDarklyClient } from 'shared/clients/launchDarklyClient'
-import { ClaimStoreClient } from 'claims/claimStoreClient'
-import { FeatureToggles } from 'utils/featureToggles'
-
-const claimStoreClient: ClaimStoreClient = new ClaimStoreClient()
-const launchDarklyClient: LaunchDarklyClient = new LaunchDarklyClient()
-const featureToggles: FeatureToggles = new FeatureToggles(claimStoreClient, launchDarklyClient)
 
 const packageDotJson = require('../../../../package.json')
 
@@ -216,8 +209,6 @@ export class Nunjucks {
     nunjucksEnv.addGlobal('toDate', function (date) {
       return date ? new Date(date) : new Date()
     })
-    nunjucksEnv.addGlobal('warningBanner', (): boolean => toBoolean(featureToggles
-      .isWarningBannerEnabled()))
   }
 
   private convertPropertiesToBoolean (featureToggles: { [key: string]: any }): { [key: string]: boolean } {

--- a/src/test/app/utils/featureToggles.ts
+++ b/src/test/app/utils/featureToggles.ts
@@ -4,7 +4,6 @@ import * as toBoolean from 'to-boolean'
 
 import { FeatureToggles } from 'utils/featureToggles'
 import { LaunchDarklyClient } from 'shared/clients/launchDarklyClient'
-import { ClaimStoreClient } from 'claims/claimStoreClient'
 
 describe('FeatureToggles', () => {
   describe('isAnyEnabled', () => {
@@ -31,7 +30,7 @@ describe('FeatureToggles', () => {
   describe('isWarningBannerEnabled', () => {
     it('should return toggle if warningBanner toggle exists', async () => {
       const mockLaunchDarklyClient: LaunchDarklyClient = new LaunchDarklyClient()
-      const featureToggles = new FeatureToggles(new ClaimStoreClient(), mockLaunchDarklyClient)
+      const featureToggles = new FeatureToggles(mockLaunchDarklyClient)
       let actual = toBoolean(mockLaunchDarklyClient.default('warning_banner', false))
       let result = await featureToggles.isWarningBannerEnabled()
       expect(result).to.equal(actual)


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-8101

### Change description
Move responsibility for providing the warning_banner toggle state to Node.js; nunjucks will then just consume it

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
