### PR TITLE
ROC-8246: Claimant cannot view transferred cases online

### DIFF
--- a/src/main/features/dashboard/views/macro/claimStatus/claimTransferred.njk
+++ b/src/main/features/dashboard/views/macro/claimStatus/claimTransferred.njk
@@ -4,8 +4,12 @@
     <p>{{  t('Your online account won’t be updated - any further updates will be by post from {{ courtName }}.', {courtName :claim.transferContent.hearingCourtName }) }}</p>
     <p>{{  t('If you need to send any forms, letters or documents about the claim, send them to this address:') }}</p>
     <p>
-      {{ claim.transferContent.hearingCourtName  }}<br>
-      {{ claim.transferContent.hearingCourtAddress.line1 }} <br/>
+      {% if claim.transferContent.hearingCourtName is defined %}
+        {{ claim.transferContent.hearingCourtName  }}<br>
+      {% endif %}
+      {% if claim.transferContent.hearingCourtAddress.line1 is defined %}
+        {{ claim.transferContent.hearingCourtAddress.line1 }} <br/>
+      {% endif %}
       {% if claim.transferContent.hearingCourtAddress.line2 is defined %}
         {{ claim.transferContent.hearingCourtAddress.line2 }} <br/>
       {% endif %}


### PR DESCRIPTION
### JIRA link
https://tools.hmcts.net/jira/browse/ROC-8246

### Change description
A fix to the live incident  where the claimant is not able to navigate to claim page and download the claim documents when. the case status is transferred.

### Work checklist

- [X] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [X] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
