### PR TITLE
feature: add a11y 'warning' checks to a11y tests

### DIFF
--- a/src/test/a11y/a11y.ts
+++ b/src/test/a11y/a11y.ts
@@ -50,6 +50,10 @@ async function runPa11y (url: string): Promise<Issue[]> {
     includeWarnings: true,
     // Ignore GovUK template elements that are outside the team's control from a11y tests
     hideElements: '#logo, .logo, .copyright, link[rel=mask-icon]',
+    ignore: [
+      'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Abs',  // Visual warning on invisible elements, so not relevant
+      'WCAG2AA.Principle1.Guideline1_3.1_3_1_A.G141'  // DAC have rated Semantically Incorrect Headings as AAA, not AA
+    ],
     headers: {
       Cookie: `${cookieName}=ABC`
     },

--- a/src/test/a11y/a11y.ts
+++ b/src/test/a11y/a11y.ts
@@ -48,6 +48,8 @@ interface TestsOnSpecificPages {
 async function runPa11y (url: string): Promise<Issue[]> {
   const result = await pa11y(url, {
     includeWarnings: true,
+    // Ignore GovUK template elements that are outside the team's control from a11y tests
+    hideElements: '#logo, .logo, .copyright, link[rel=mask-icon]',
     headers: {
       Cookie: `${cookieName}=ABC`
     },

--- a/src/test/a11y/a11y.ts
+++ b/src/test/a11y/a11y.ts
@@ -47,6 +47,7 @@ interface TestsOnSpecificPages {
 
 async function runPa11y (url: string): Promise<Issue[]> {
   const result = await pa11y(url, {
+    includeWarnings: true,
     headers: {
       Cookie: `${cookieName}=ABC`
     },
@@ -70,9 +71,17 @@ function check (uri: string, customTests: CustomChecks = [], requestDetails: Req
     })
 
     describe(`Pa11y tests for ${uri}`, () => {
-      it('should have no accessibility errors', async () => {
-        const issues: Issue[] = await runPa11y(agent.get(uri).url)
-        ensureNoAccessibilityErrors(issues)
+      let issues: Issue[]
+      before(async () => {
+        issues = await runPa11y(agent.get(uri).url)
+      })
+
+      it('should have no accessibility errors', () => {
+        ensureNoAccessibilityAlerts('error', issues)
+      })
+
+      it('should have no accessibility warnings', () => {
+        ensureNoAccessibilityAlerts('warning', issues)
       })
     })
   })
@@ -100,9 +109,9 @@ async function extractPageContent (url: string, requestDetails: RequestDetails =
   return res.text
 }
 
-function ensureNoAccessibilityErrors (issues: Issue[]): void {
-  const errors: Issue[] = issues.filter((issue: Issue) => issue.type === 'error')
-  expect(errors, `\n${JSON.stringify(errors, null, 2)}\n`).to.be.empty
+function ensureNoAccessibilityAlerts (issueType: string, issues: Issue[]): void {
+  const alerts: Issue[] = issues.filter((issue: Issue) => issue.type === issueType)
+  expect(alerts, `\n${JSON.stringify(alerts, null, 2)}\n`).to.be.empty
 }
 
 const excludedPaths: Paths[] = [


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/ROC-8194

### Change description

This change adds an extra check for every `a11y` test to make sure there are no warnings as well as no errors. This is a departmental requirement to be accessibility compliant.

The 'warning' and 'error' checks are in separate tests to allow for clearer reporting, clearer prioritisation, and for the benefit of showing these reports to anyone in/outside the team unfamiliar with the technical setup of the test.

Confluence Spike for further details: https://tools.hmcts.net/confluence/display/ROC/Pa11y+Warnings+Spike

### Work checklist

- [x] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have ~~clicked through the running application~~ forced accessibility warnings to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [x] Yes
- [ ] No
