### PR TITLE
Displaying the breakdown of Interest calculations when the claimant has opted to claim interest at the same rate for the whole period.

### DIFF
--- a/src/main/app/claims/models/claim.ts
+++ b/src/main/app/claims/models/claim.ts
@@ -68,6 +68,7 @@ export class Claim {
   settlementReachedAt: Moment
   claimantResponse: ClaimantResponse
   claimantRespondedAt: Moment
+  totalClaimAmount?: number
   totalAmountTillToday: number
   totalAmountTillDateOfIssue: number
   totalInterest: number
@@ -398,6 +399,7 @@ export class Claim {
         this.totalAmountTillDateOfIssue = input.totalAmountTillDateOfIssue
       }
       this.totalAmountTillToday = input.totalAmountTillToday
+      this.totalClaimAmount = input.totalClaimAmount
       this.totalInterest = input.totalInterest
       this.features = input.features
 

--- a/src/main/features/response/routes/claim-details.ts
+++ b/src/main/features/response/routes/claim-details.ts
@@ -5,6 +5,7 @@ import { Claim } from 'claims/models/claim'
 import { getInterestDetails } from 'shared/interestUtils'
 import { ErrorHandling } from 'shared/errorHandling'
 import { User } from 'idam/user'
+import * as moment from 'moment'
 
 function isCurrentUserLinkedToClaim (user: User, claim: Claim): boolean {
   return claim.defendantId === user.id
@@ -16,8 +17,16 @@ export default express.Router()
     ErrorHandling.apply(async (req: express.Request, res: express.Response, next: express.NextFunction) => {
       const claim: Claim = res.locals.claim
       const interestData = await getInterestDetails(claim)
+      const todaysDate = new Date()
+      const currentYear = todaysDate.getFullYear()
+      const isLeapYear = moment([currentYear]).isLeapYear()
+      let numOfDaysInYear = 365
+      if (isLeapYear) {
+        numOfDaysInYear = 366
+      }
       res.render(Paths.claimDetailsPage.associatedView, {
         interestData: interestData,
+        numOfDayInYear: numOfDaysInYear,
         pdfUrl: isCurrentUserLinkedToClaim(res.locals.user, res.locals.claim) ? ClaimPaths.sealedClaimPdfReceiver : ClaimPaths.receiptReceiver
       })
     })

--- a/src/main/features/response/views/claim-details.njk
+++ b/src/main/features/response/views/claim-details.njk
@@ -4,6 +4,7 @@
 
 {% from "form.njk" import csrfProtection %}
 {% from "amountBreakdown.njk" import amountBreakdownTable %}
+{% from "interestCalculation.njk" import interestCalculationBreakdownTable %}
 {% from "summaryTable.njk" import timelineSummary, evidenceSummary %}
 {% from "internalLink.njk" import internalLink %}
 
@@ -31,6 +32,11 @@
       <p><span class="bold-small">{{ t('Claim amount') }}:</span> {{ claim.totalAmountTillToday | numeral }}</p>
 
       {{ amountBreakdownTable('View amount breakdown', claim, interestData) }}
+
+      {% if claim.helpWithFeesNumber and interestData !== undefined and interestData.rate !== undefined and claim.claimData.interest.type !== 'breakdown' %}
+        {{ interestCalculationBreakdownTable('How interest to date is calculated', claim, interestData, numOfDayInYear) }}
+      {% endif %}
+
       <p><span class="bold-small">{{ t('Reason for claim') }}:</span></p>
       <p>{{ claim.claimData.reason }}</p>
 

--- a/src/main/views/macro/interestCalculation.njk
+++ b/src/main/views/macro/interestCalculation.njk
@@ -22,7 +22,7 @@
             <li>The rate of annual interest is {{ interestData.rate }}%.</li>
             <li>Annual interest on, for example, {{ claim.totalClaimAmount | numeral }} is {{ (claim.totalClaimAmount * (interestData.rate)/100) | numeral }} ({{ claim.totalClaimAmount }} x {{ interestData.rate / 100 }})</li>
             <li>Daily interest on {{ claim.totalClaimAmount | numeral }} is {{ ((claim.totalClaimAmount * (interestData.rate/100))/isLeapYear) | numeral }} ({{ claim.totalClaimAmount * interestData.rate / 100 }} / {{ isLeapYear }})</li>
-            <li>Interest on {{ claim.totalClaimAmount | numeral }} at {{ interestData.rate }}% for {{ interestData.numberOfDays }} days is {{ (((claim.totalClaimAmount * (interestData.rate/100))/isLeapYear)* interestData.numberOfDays) | numeral }} ({{ claim.totalClaimAmount * interestData.rate / 100 }} x {{ interestData.numberOfDays }} / {{  isLeapYear}})</li>
+            <li>Total amount of interest on {{ claim.totalClaimAmount | numeral }} for {{ interestData.numberOfDays }} days is {{ (((claim.totalClaimAmount * (interestData.rate/100))/isLeapYear)* interestData.numberOfDays) | numeral }} ({{ claim.totalClaimAmount * interestData.rate / 100 }} x {{ interestData.numberOfDays }} / {{  isLeapYear}})</li>
           </ul>
         </div>  
       </div>

--- a/src/main/views/macro/interestCalculation.njk
+++ b/src/main/views/macro/interestCalculation.njk
@@ -1,0 +1,31 @@
+{% from "interestSnippet.njk" import interestSnippet %}
+
+{% macro interestCalculationBreakdownTable(label, claim, interestData, isLeapYear) %}
+  <details>
+    <summary>{{ t(label) }}</summary>
+      <div class="panel panel-border-narrow">
+        <p>For most types of debt the rate is usually 8%.</p>
+        <p>To calculate this, we use the steps below.</p>
+        <ol class="list list-number">
+          <li>
+            <p>Work out the yearly interest: take the amount you’re claiming and multiply it by 0.08 (which is 8%).</p>
+          </li>
+          <li>
+            <p>Work out the daily interest: divide your yearly interest from step 1 by 365 (the number of days in a year).</p>
+          </li>
+          <li>
+            <p>Work out the total amount of interest: multiply the daily interest from step 2 by the number of days the debt has been overdue.</p>
+          </li>
+        </ol>
+        <div class="example">
+          <ul>
+            <li>The rate of annual interest is {{ interestData.rate }}%.</li>
+            <li>Annual interest on, for example, {{ claim.totalClaimAmount | numeral }} is {{ (claim.totalClaimAmount * (interestData.rate)/100) | numeral }} ({{ claim.totalClaimAmount }} x {{ interestData.rate / 100 }})</li>
+            <li>Daily interest on {{ claim.totalClaimAmount | numeral }} is {{ ((claim.totalClaimAmount * (interestData.rate/100))/isLeapYear) | numeral }} ({{ claim.totalClaimAmount * interestData.rate / 100 }} / {{ isLeapYear }})</li>
+            <li>Interest on {{ claim.totalClaimAmount | numeral }} at {{ interestData.rate }}% for {{ interestData.numberOfDays }} days is {{ (((claim.totalClaimAmount * (interestData.rate/100))/isLeapYear)* interestData.numberOfDays) | numeral }} ({{ claim.totalClaimAmount * interestData.rate / 100 }} x {{ interestData.numberOfDays }} / {{  isLeapYear}})</li>
+            <li><div class="font-xsmall">{{ t('({{ interestDate }} to {{ interestToDate }})', { interestDate: interestData.interestFromDate | date, interestToDate: interestData.interestToDate | date }) }}</div></li>
+          </ul>
+        </div>  
+      </div>
+  </details>
+{% endmacro %}

--- a/src/main/views/macro/interestCalculation.njk
+++ b/src/main/views/macro/interestCalculation.njk
@@ -23,7 +23,6 @@
             <li>Annual interest on, for example, {{ claim.totalClaimAmount | numeral }} is {{ (claim.totalClaimAmount * (interestData.rate)/100) | numeral }} ({{ claim.totalClaimAmount }} x {{ interestData.rate / 100 }})</li>
             <li>Daily interest on {{ claim.totalClaimAmount | numeral }} is {{ ((claim.totalClaimAmount * (interestData.rate/100))/isLeapYear) | numeral }} ({{ claim.totalClaimAmount * interestData.rate / 100 }} / {{ isLeapYear }})</li>
             <li>Interest on {{ claim.totalClaimAmount | numeral }} at {{ interestData.rate }}% for {{ interestData.numberOfDays }} days is {{ (((claim.totalClaimAmount * (interestData.rate/100))/isLeapYear)* interestData.numberOfDays) | numeral }} ({{ claim.totalClaimAmount * interestData.rate / 100 }} x {{ interestData.numberOfDays }} / {{  isLeapYear}})</li>
-            <li><div class="font-xsmall">{{ t('({{ interestDate }} to {{ interestToDate }})', { interestDate: interestData.interestFromDate | date, interestToDate: interestData.interestToDate | date }) }}</div></li>
           </ul>
         </div>  
       </div>


### PR DESCRIPTION
### JIRA link

> https://tools.hmcts.net/jira/browse/ROC-8638

### Change description

> Displaying the breakdown of Interest calculations when the claimant has opted to claim interest at the same rate for the whole period.

**Background:**
When the claimant is claiming interest at a same rate for the whole period, Interest calculator automatically calculates the interest in the back-end and display it to the claimant directly in the Claim amount page of the user journey while submitting the case . We don't display to the Claimant on how that Interest got calculated which at times is misleading for the claimant. 

**Problem Statement:** 
Claimant is unaware on how the Interest component of the claim amount got calculated when they have opted to claim interest at the same rate for the whole period.

**Solution implemented:**   

1. Must Have requirement to introduce an expandable sub-section in the Claim amount page, where static text around the detailed logic of how any interest gets calculated is displayed back to the Claimant.
2. Nice to have requirement is to show the actual calculations and the exact interest amount derived to be displayed back to the Claimant.   

**Solution screenshot:**

![image](https://user-images.githubusercontent.com/41957682/104012167-442b2a80-51a7-11eb-8c11-006b529eb626.png)


### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [x] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
