### PR TITLE
TA-371 & TA-373: Run crossbrowser tests on Edge and Safari

### DIFF
--- a/bin/run-crossbrowser-tests.sh
+++ b/bin/run-crossbrowser-tests.sh
@@ -6,7 +6,6 @@ then
     EXIT_STATUS=0
     BROWSER_GROUP=chrome yarn test:crossbrowser-verbose || EXIT_STATUS=$?
     BROWSER_GROUP=firefox yarn test:crossbrowser-verbose || EXIT_STATUS=$?
-    BROWSER_GROUP=microsoft yarn test:crossbrowser-verbose || EXIT_STATUS=$?
     echo EXIT_STATUS: $EXIT_STATUS
     exit $EXIT_STATUS
 else

--- a/bin/run-crossbrowser-tests.sh
+++ b/bin/run-crossbrowser-tests.sh
@@ -6,6 +6,7 @@ then
     EXIT_STATUS=0
     BROWSER_GROUP=chrome yarn test:crossbrowser-verbose || EXIT_STATUS=$?
     BROWSER_GROUP=firefox yarn test:crossbrowser-verbose || EXIT_STATUS=$?
+    BROWSER_GROUP=microsoft yarn test:crossbrowser-verbose || EXIT_STATUS=$?
     echo EXIT_STATUS: $EXIT_STATUS
     exit $EXIT_STATUS
 else

--- a/bin/run-crossbrowser-tests.sh
+++ b/bin/run-crossbrowser-tests.sh
@@ -7,6 +7,7 @@ then
     BROWSER_GROUP=chrome yarn test:crossbrowser-verbose || EXIT_STATUS=$?
     BROWSER_GROUP=firefox yarn test:crossbrowser-verbose || EXIT_STATUS=$?
     BROWSER_GROUP=microsoft yarn test:crossbrowser-verbose || EXIT_STATUS=$?
+    BROWSER_GROUP=safari yarn test:crossbrowser-verbose || EXIT_STATUS=$?
     echo EXIT_STATUS: $EXIT_STATUS
     exit $EXIT_STATUS
 else

--- a/charts/cmc-citizen-frontend/values.preview.template.yaml
+++ b/charts/cmc-citizen-frontend/values.preview.template.yaml
@@ -178,7 +178,7 @@ ccd:
       - civilmoneyclaims+la@gmail.com|CMC|MoneyClaimCase|readyForDirections
 
   ccd-definition-importer:
-    image: hmctspublic.azurecr.io/cmc/ccd-definition-importer:1.9.5
+    image: hmctspublic.azurecr.io/cmc/ccd-definition-importer:1.9.4
     environment:
       CCD_DEF_CLAIM_STORE_BASE_URL: http://${SERVICE_NAME}-claim-store
     definitionFilename: cmc-ccd.xlsx

--- a/charts/cmc-citizen-frontend/values.preview.template.yaml
+++ b/charts/cmc-citizen-frontend/values.preview.template.yaml
@@ -178,7 +178,7 @@ ccd:
       - civilmoneyclaims+la@gmail.com|CMC|MoneyClaimCase|readyForDirections
 
   ccd-definition-importer:
-    image: hmctspublic.azurecr.io/cmc/ccd-definition-importer:1.9.4
+    image: hmctspublic.azurecr.io/cmc/ccd-definition-importer:1.9.5
     environment:
       CCD_DEF_CLAIM_STORE_BASE_URL: http://${SERVICE_NAME}-claim-store
     definitionFilename: cmc-ccd.xlsx

--- a/saucelabs.conf.js
+++ b/saucelabs.conf.js
@@ -76,6 +76,9 @@ const setupConfig = {
     SaucelabsReporter: {
       require: './src/integration-test/helpers/saucelabsReporter'
     },
+    SauceLabsBrowserHelper: {
+      require: './src/integration-test/helpers/SauceLabsBrowserHelper.js'
+    },
     Mochawesome: {
       uniqueScreenshotNames: 'true'
     }

--- a/src/integration-test/crossbrowser/supportedBrowsers.js
+++ b/src/integration-test/crossbrowser/supportedBrowsers.js
@@ -3,15 +3,18 @@ const LATEST_WINDOWS = 'Windows 10';
 
 const supportedBrowsers = {
     microsoft: {
-        ie11_win: {
-            browserName: 'internet explorer',
-            platformName: LATEST_WINDOWS,
-            browserVersion: 'latest',
-            'sauce:options': {
-                name: 'OCMC Citizen: IE11',
-                screenResolution: '1400x1050'
-            }
-        },
+      // BUG: Date Picker not displaying in IE11 for citizen-frontend (25/2/21),
+      // https://tools.hmcts.net/jira/browse/ROC-8904
+      // uncomment IE11 config once bug is fixed.
+      // ie11_win: {
+        //     browserName: 'internet explorer',
+        //     platformName: LATEST_WINDOWS,
+        //     browserVersion: 'latest',
+        //     'sauce:options': {
+        //         name: 'OCMC Citizen: IE11',
+        //         screenResolution: '1400x1050'
+        //     }
+        // },
         edge_win_latest: {
             browserName: 'MicrosoftEdge',
             platformName: LATEST_WINDOWS,

--- a/src/integration-test/helpers/SauceLabsBrowserHelper.js
+++ b/src/integration-test/helpers/SauceLabsBrowserHelper.js
@@ -1,0 +1,16 @@
+const Helper = codecept_helper;
+
+class SauceLabsBrowserHelper extends Helper {
+
+    async _before() {
+    const webdriver = this.helpers['WebDriver'];
+    if (webdriver) {
+      if (webdriver.config.browser === 'internet explorer') {
+        console.log('Maximising IE11 browser window size');
+        await webdriver.browser.maximizeWindow();
+      }
+    }
+  }
+}
+
+module.exports = SauceLabsBrowserHelper;

--- a/src/integration-test/helpers/pageHelper.js
+++ b/src/integration-test/helpers/pageHelper.js
@@ -21,6 +21,12 @@ class PageHelper extends Helper {
     return this.helpers['WebDriver'].amOnPage(`${citizenAppBaseURL}${path}`)
   }
 
+  waitIfOnSafari() {
+    const helper = this.helpers['WebDriver']
+    if (helper.config.browser === 'safari') {
+      return this.helpers['WebDriver'].wait(5)
+    }
+  }
 }
 
 module.exports = PageHelper

--- a/src/integration-test/tests/citizen/defence/pages/defendant-check-and-send.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-check-and-send.ts
@@ -4,14 +4,14 @@ import { DefenceType } from 'integration-test/data/defence-type'
 const I: I = actor()
 
 const fields = {
-  checkboxFactsTrue: 'input#signedtrue',
-  checkboxHearingRequirementsTrue: 'input#directionsQuestionnaireSignedtrue',
-  signerName: 'input[id=signerName]',
-  signerRole: 'input[id=signerRole]'
+  checkboxFactsTrue: { css: 'input#signedtrue' },
+  checkboxHearingRequirementsTrue: { css: 'input#directionsQuestionnaireSignedtrue' },
+  signerName: { css: 'input[id=signerName]' },
+  signerRole: { css: 'input[id=signerRole]' }
 }
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class DefendantCheckAndSendPage {
@@ -31,7 +31,7 @@ export class DefendantCheckAndSendPage {
   }
 
   verifyFactsPartialResponseClaimAmountTooMuch (): void {
-    I.see('I reject part of the claim')
+    I.waitForText('I reject part of the claim')
     I.see('The claim amount is too much')
     I.see('How much money do you believe you owe?')
     I.see('Why this is what you owe?')
@@ -41,7 +41,7 @@ export class DefendantCheckAndSendPage {
   }
 
   verifyFactsPartialResponseIBelieveIPaidWhatIOwe (): void {
-    I.see('I reject part of the claim')
+    I.waitForText('I reject part of the claim')
     I.see('I’ve paid what I believe I owe')
     I.see('How much have you paid the claimant?')
     I.see('When did you pay this amount?')

--- a/src/integration-test/tests/citizen/defence/pages/defendant-defence-type.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-defence-type.ts
@@ -3,24 +3,26 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class DefendantDefenceTypePage {
 
   admitAllOfMoneyClaim (): void {
-    I.checkOption('I admit all of the claim')
-    I.click(buttons.submit)
+    this.answerClaim('I admit all of the claim')
   }
 
   admitPartOfMoneyClaim (): void {
-    I.checkOption('I admit part of the claim')
-    I.click(buttons.submit)
+    this.answerClaim('I admit part of the claim')
   }
 
   rejectAllOfMoneyClaim (): void {
-    I.checkOption('I reject all of the claim')
-    I.click(buttons.submit)
+    this.answerClaim('I reject all of the claim')
   }
 
+  private answerClaim (text: string): void {
+    I.waitForText(text)
+    I.checkOption(text)
+    I.click(buttons.submit)
+  }
 }

--- a/src/integration-test/tests/citizen/defence/pages/defendant-dob.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-dob.ts
@@ -4,13 +4,13 @@ import { DateParser } from 'integration-test/utils/date-parser'
 const I: I = actor()
 
 const fields = {
-  day: 'input[id="date[day]"]',
-  month: 'input[id="date[month]"]',
-  year: 'input[id="date[year]"]'
+  day: { css: 'input[id="date[day]"]' },
+  month: { css: 'input[id="date[month]"]' },
+  year: { css: 'input[id="date[year]"]' }
 }
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class DefendantDobPage {

--- a/src/integration-test/tests/citizen/defence/pages/defendant-enter-claim-reference.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-enter-claim-reference.ts
@@ -3,11 +3,11 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const fields = {
-  claimReference: 'input#reference'
+  claimReference: { css: 'input#reference' }
 }
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class DefendantEnterClaimReferencePage {

--- a/src/integration-test/tests/citizen/defence/pages/defendant-evidence.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-evidence.ts
@@ -15,6 +15,8 @@ const buttons = {
 export class DefendantEvidencePage {
 
   enterEvidenceRow (type: string, description: string, comment: string): void {
+    I.waitForElement(fields.type)
+    I.waitIfOnSafari()
     I.selectOption(fields.type, type)
     I.waitForVisible(fields.description)
     I.fillField(fields.description, description)

--- a/src/integration-test/tests/citizen/defence/pages/defendant-evidence.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-evidence.ts
@@ -3,9 +3,9 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const fields = {
-  type: 'rows[0][type]',
-  description: 'rows[0][description]',
-  comment: 'comment'
+  type: { css: 'select[name="rows[0][type]"]' },
+  description: { css: 'textarea[name="rows[0][description]"]' },
+  comment: '#comment'
 }
 
 const buttons = {
@@ -16,6 +16,7 @@ export class DefendantEvidencePage {
 
   enterEvidenceRow (type: string, description: string, comment: string): void {
     I.selectOption(fields.type, type)
+    I.waitForVisible(fields.description)
     I.fillField(fields.description, description)
     I.fillField(fields.comment, comment)
 

--- a/src/integration-test/tests/citizen/defence/pages/defendant-more-time-confirmation.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-more-time-confirmation.ts
@@ -3,7 +3,7 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class DefendantMoreTimeConfirmationPage {

--- a/src/integration-test/tests/citizen/defence/pages/defendant-more-time-request.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-more-time-request.ts
@@ -4,13 +4,13 @@ const I: I = actor()
 
 const fields = {
   requestMoreTime: {
-    yes: 'input[id=optionyes]',
-    no: 'input[id=optionno]'
+    yes: { css: 'input[id=optionyes]' },
+    no: { css: 'input[id=optionno]' }
   }
 }
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class DefendantMoreTimeRequestPage {

--- a/src/integration-test/tests/citizen/defence/pages/defendant-name-and-address.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-name-and-address.ts
@@ -3,15 +3,15 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const fields = {
-  name: 'input[id=name]',
-  addressLine1: 'input[id="address[line1]"]',
-  addressLine2: 'input[id="address[line2]"]',
-  addressCity: 'input[id="address[city]"]',
-  postcode: 'input[id="address[postcode]"]'
+  name: { css: 'input[id=name]' },
+  addressLine1: { css: 'input[id="address[line1]"]' },
+  addressLine2: { css: 'input[id="address[line2]"]' },
+  addressCity: { css: 'input[id="address[city]"]' },
+  postcode: { css: 'input[id="address[postcode]"]' }
 }
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class DefendantNameAndAddressPage {

--- a/src/integration-test/tests/citizen/defence/pages/defendant-phone.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-phone.ts
@@ -3,11 +3,11 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const fields = {
-  phoneNumber: 'input[id=number]'
+  phoneNumber: { css: 'input[id=number]' }
 }
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class DefendantPhonePage {

--- a/src/integration-test/tests/citizen/defence/pages/defendant-reject-all-of-claim.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-reject-all-of-claim.ts
@@ -3,13 +3,13 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const fields = {
-  dispute: 'input[id=optiondispute]',
-  alreadyPaid: 'input[id=optionalreadyPaid]',
-  counterClaim: 'input[id=optioncounterClaim]'
+  dispute: { css: 'input[id=optiondispute]' },
+  alreadyPaid: { css: 'input[id=optionalreadyPaid]' },
+  counterClaim: { css: 'input[id=optioncounterClaim]' }
 }
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class DefendantRejectAllOfClaimPage {

--- a/src/integration-test/tests/citizen/defence/pages/defendant-start.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-start.ts
@@ -3,7 +3,7 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const buttons = {
-  submit: 'input.button.button-start'
+  submit: { css: 'input.button.button-start' }
 }
 
 export class DefendantStartPage {

--- a/src/integration-test/tests/citizen/defence/pages/defendant-task-list.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-task-list.ts
@@ -5,71 +5,75 @@ const I: I = actor()
 export class DefendantTaskListPage {
 
   selectTaskConfirmYourDetails (): void {
-    I.click('Confirm your details')
+    this.clickText('Confirm your details')
   }
 
   selectTaskMoreTimeNeededToRespond (): void {
-    I.click('Decide if you need more time to respond')
+    this.clickText('Decide if you need more time to respond')
   }
 
   selectChooseAResponse (): void {
-    I.click('Choose a response')
+    this.clickText('Choose a response')
   }
 
   selectTaskHowMuchPaidToClaiment (): void {
-    I.click('How much have you paid the claimant?')
+    this.clickText('How much have you paid the claimant?')
   }
 
   selectTaskHowMuchHaveYouPaid (): void {
-    I.click('How much have you paid?')
+    this.clickText('How much have you paid?')
   }
 
   selectTaskTellUsHowMuchYouHavePaid (): void {
-    I.click('Tell us how much you’ve paid')
+    this.clickText('Tell us how much you’ve paid')
   }
 
   selectTaskHowMuchMoneyBelieveYouOwe (): void {
-    I.click('How much money do you admit you owe?')
+    this.clickText('How much money do you admit you owe?')
   }
 
   selectTaskDecideHowWillYouPay (): void {
-    I.click('Decide how you’ll pay')
+    this.clickText('Decide how you’ll pay')
   }
 
   selectTaskWhenDidYouPay (): void {
-    I.click('When did you pay?')
+    this.clickText('When did you pay?')
   }
 
   selectTaskWhyDoYouDisagreeWithTheClaim (): void {
-    I.click('Tell us why you disagree with the claim')
+    this.clickText('Tell us why you disagree with the claim')
   }
 
   selectTaskWhyDoYouDisagreeWithTheAmountClaimed (): void {
-    I.click('Why do you disagree with the amount claimed?')
+    this.clickText('Why do you disagree with the amount claimed?')
   }
 
   selectTaskWhenWillYouPay (): void {
-    I.click('When will you pay')
+    this.clickText('When will you pay')
   }
 
   selectYourRepaymentPlanTask (): void {
-    I.click('Your repayment plan')
+    this.clickText('Your repayment plan')
   }
 
   selectShareYourFinancialDetailsTask (): void {
-    I.click('Share your financial details')
+    this.clickText('Share your financial details')
   }
 
   selectTaskCheckAndSendYourResponse (): void {
-    I.click('Check and submit your response')
+    this.clickText('Check and submit your response')
   }
 
   selectTaskFreeMediation (): void {
-    I.click('Free telephone mediation')
+    this.clickText('Free telephone mediation')
   }
 
   selectTaskHearingRequirements (): void {
-    I.click('Give us details in case there’s a hearing')
+    this.clickText('Give us details in case there’s a hearing')
   }
 
+  private clickText (text: string) {
+    I.waitForText(text)
+    I.click(text)
+  }
 }

--- a/src/integration-test/tests/citizen/defence/pages/defendant-timeline-events.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-timeline-events.ts
@@ -12,8 +12,8 @@ export class DefendantTimelineEventsPage {
   enterTimelineEvent (eventNum: number, date: string, description: string): void {
     const fieldDate: string = fields.date.replace('x', eventNum.toString())
     const fieldDescription: string = fields.description.replace('y', eventNum.toString())
-    I.fillField(fieldDate, date)
-    I.fillField(fieldDescription, description)
+    I.fillField({ css: fieldDate }, date)
+    I.fillField({ css: fieldDescription }, description)
   }
 
   submitForm (): void {

--- a/src/integration-test/tests/citizen/defence/pages/defendant-your-defence.ts
+++ b/src/integration-test/tests/citizen/defence/pages/defendant-your-defence.ts
@@ -3,11 +3,11 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const fields = {
-  reason: 'textarea[id=text]'
+  reason: { css: 'textarea[id=text]' }
 }
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class DefendantYourDefencePage {

--- a/src/integration-test/tests/citizen/defence/steps/defence.ts
+++ b/src/integration-test/tests/citizen/defence/steps/defence.ts
@@ -146,14 +146,14 @@ export class DefenceSteps {
   }
 
   addTimeLineOfEvents (timeline: Timeline): void {
-    I.see('Add your timeline of events')
+    I.waitForText('Add your timeline of events')
     defendantTimelineOfEventsPage.enterTimelineEvent(0, timeline.events[0].date, timeline.events[0].description)
     defendantTimelineOfEventsPage.enterTimelineEvent(1, timeline.events[1].date, timeline.events[1].description)
     defendantTimelineOfEventsPage.submitForm()
   }
 
   enterEvidence (description: string, comment: string): void {
-    I.see('List your evidence')
+    I.waitForText('List your evidence')
     defendantEvidencePage.enterEvidenceRow('CONTRACTS_AND_AGREEMENTS', description, comment)
   }
 
@@ -296,11 +296,11 @@ export class DefenceSteps {
     isClaimAlreadyPaid: boolean = true,
     expectPhonePage: boolean = false
 ): void {
-    I.see('Confirm your details')
+    I.waitForText('Confirm your details')
     I.see('Decide if you need more time to respond')
     I.see('Choose a response')
     this.confirmYourDetails(defendantParty, expectPhonePage)
-    I.see('COMPLETE')
+    I.waitForText('COMPLETE')
 
     if (isRequestMoreTimeToRespond) {
       this.requestMoreTimeToRespond()
@@ -311,7 +311,7 @@ export class DefenceSteps {
     switch (defenceType) {
       case DefenceType.FULL_REJECTION_WITH_DISPUTE:
         this.rejectAllOfClaimAsDisputeClaim()
-        I.see('Tell us why you disagree with the claim')
+        I.waitForText('Tell us why you disagree with the claim')
         this.submitDefenceText('I fully dispute this claim')
         this.addTimeLineOfEvents({
           events: [{ date: 'may', description: 'ok' } as TimelineEvent, {
@@ -363,7 +363,7 @@ export class DefenceSteps {
         throw new Error('Unknown DefenceType')
     }
     this.checkAndSendAndSubmit(defendantType, defenceType)
-    I.see('You’ve submitted your response')
+    I.waitForText('You’ve submitted your response')
   }
 
   makeFullAdmission (

--- a/src/integration-test/tests/citizen/directionsQuestionnaire/pages/expert-reports.ts
+++ b/src/integration-test/tests/citizen/directionsQuestionnaire/pages/expert-reports.ts
@@ -3,15 +3,17 @@ import { DateParser } from 'integration-test/utils/date-parser'
 
 const I: I = actor()
 
-const fields = {
-  expertName: 'input[id="rows[0][expertName]"]',
-  day: 'input[id="rows[0][reportDate][day]"]',
-  month: 'input[id="rows[0][reportDate][month]"]',
-  year: 'input[id="rows[0][reportDate][year]"]'
+const heading = {
+  text: 'Have you already got a report written by an expert?'
 }
-
+const fields = {
+  expertName: { css: 'input[id="rows[0][expertName]"]' },
+  day: { css: 'input[id="rows[0][reportDate][day]"]' },
+  month: { css: 'input[id="rows[0][reportDate][month]"]' },
+  year: { css: 'input[id="rows[0][reportDate][year]"]' }
+}
 const buttons = {
-  submit: 'input[id="saveAndContinue"]'
+  submit: { css: 'input[id="saveAndContinue"]' }
 }
 
 export class ExpertReportsPage {
@@ -19,7 +21,9 @@ export class ExpertReportsPage {
   chooseYes (expertName: string, reportDate: string): void {
     const [ year, month, day ] = DateParser.parse(reportDate)
 
+    I.waitForText(heading.text)
     I.checkOption('Yes')
+    I.waitForVisible(fields.expertName)
     I.fillField(fields.expertName, expertName)
     I.fillField(fields.day, day)
     I.fillField(fields.month, month)
@@ -28,6 +32,7 @@ export class ExpertReportsPage {
   }
 
   chooseNo (): void {
+    I.waitForText(heading.text)
     I.checkOption('No')
     I.click(buttons.submit)
   }

--- a/src/integration-test/tests/citizen/directionsQuestionnaire/pages/hearing-dates.ts
+++ b/src/integration-test/tests/citizen/directionsQuestionnaire/pages/hearing-dates.ts
@@ -2,18 +2,22 @@ import I = CodeceptJS.I
 
 const I: I = actor()
 
+const heading = {
+  partialText: 'Are there dates in the next 9 months'
+}
 const fields = {
-  next: '.next',
-  prev: '.prev',
-  day: '.day:not(.disabled)'
+  next: { css: '.next' },
+  prev: { css: '.prev' },
+  day: { css: '.day:not(.disabled)' }
 }
 const buttons = {
-  submit: 'input[id="saveAndContinue"]'
+  submit: { css: 'input[id="saveAndContinue"]' }
 }
 
 export class HearingDatesPage {
 
   chooseYes (): void {
+    I.waitForText(heading.partialText)
     I.checkOption('Yes')
     I.waitForElement(fields.next)
     I.click(fields.next)
@@ -24,6 +28,7 @@ export class HearingDatesPage {
   }
 
   chooseNo (): void {
+    I.waitForText(heading.partialText)
     I.checkOption('No')
     I.click(buttons.submit)
   }

--- a/src/integration-test/tests/citizen/directionsQuestionnaire/pages/hearing-exceptional-circumstances.ts
+++ b/src/integration-test/tests/citizen/directionsQuestionnaire/pages/hearing-exceptional-circumstances.ts
@@ -3,21 +3,23 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const fields = {
-  reason: 'textarea[id="reason"]'
+  reason: { css: 'textarea[id="reason"]' }
 }
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class HearingExceptionalCircumstancesPage {
   chooseYes (): void {
+    I.waitForText('Yes')
     I.checkOption('Yes')
     I.fillField(fields.reason, 'Some Reason')
     I.click(buttons.submit)
   }
 
   chooseNo (): void {
+    I.waitForText('No')
     I.checkOption('No')
     I.fillField(fields.reason, 'Some Reason')
     I.click(buttons.submit)

--- a/src/integration-test/tests/citizen/directionsQuestionnaire/pages/hearing-location.ts
+++ b/src/integration-test/tests/citizen/directionsQuestionnaire/pages/hearing-location.ts
@@ -3,7 +3,7 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const heading = {
-  text: 'Choose a hearing location'
+  partialText: 'location'
 }
 const fields = {
   alternativeCourtName: { css: 'input[id="alternativeCourtName"]' },
@@ -15,13 +15,13 @@ const buttons = {
 
 export class HearingLocationPage {
   chooseYes (): void {
-    I.waitForText(heading.text)
+    I.waitForText(heading.partialText)
     I.checkOption('Yes')
     I.click(buttons.submit)
   }
 
   chooseNo (): void {
-    I.waitForText(heading.text)
+    I.waitForText(heading.partialText)
     I.checkOption('No')
     I.waitForElement('#alternativeOptionname')
     I.checkOption(fields.enterACourtName)
@@ -30,7 +30,7 @@ export class HearingLocationPage {
   }
 
   chooseNoAsClaimant (): void {
-    I.waitForText(heading.text)
+    I.waitForText(heading.partialText)
     I.checkOption('No')
     I.click(buttons.submit)
   }

--- a/src/integration-test/tests/citizen/directionsQuestionnaire/pages/hearing-location.ts
+++ b/src/integration-test/tests/citizen/directionsQuestionnaire/pages/hearing-location.ts
@@ -2,22 +2,26 @@ import I = CodeceptJS.I
 
 const I: I = actor()
 
-const fields = {
-  alternativeCourtName: 'input[id="alternativeCourtName"]',
-  enterACourtName: 'input[id="alternativeOptionname"]'
+const heading = {
+  text: 'Choose a hearing location'
 }
-
+const fields = {
+  alternativeCourtName: { css: 'input[id="alternativeCourtName"]' },
+  enterACourtName: { css: 'input[id="alternativeOptionname"]' }
+}
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class HearingLocationPage {
   chooseYes (): void {
+    I.waitForText(heading.text)
     I.checkOption('Yes')
     I.click(buttons.submit)
   }
 
   chooseNo (): void {
+    I.waitForText(heading.text)
     I.checkOption('No')
     I.waitForElement('#alternativeOptionname')
     I.checkOption(fields.enterACourtName)
@@ -26,6 +30,7 @@ export class HearingLocationPage {
   }
 
   chooseNoAsClaimant (): void {
+    I.waitForText(heading.text)
     I.checkOption('No')
     I.click(buttons.submit)
   }

--- a/src/integration-test/tests/citizen/directionsQuestionnaire/pages/other-wtiness.ts
+++ b/src/integration-test/tests/citizen/directionsQuestionnaire/pages/other-wtiness.ts
@@ -2,22 +2,27 @@ import I = CodeceptJS.I
 
 const I: I = actor()
 
+const heading = {
+  text: 'Do you want other people to give evidence?'
+}
 const fields = {
-  howMany: 'input[id="howMany"]'
+  howMany: { css: 'input[id="howMany"]' }
 }
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class OtherWitnessPage {
 
   chooseYes (): void {
+    I.waitForText(heading.text)
     I.checkOption('Yes')
     I.fillField(fields.howMany, '1')
     I.click(buttons.submit)
   }
 
   chooseNo (): void {
+    I.waitForText(heading.text)
     I.checkOption('No')
     I.click(buttons.submit)
   }

--- a/src/integration-test/tests/citizen/directionsQuestionnaire/pages/self-witness.ts
+++ b/src/integration-test/tests/citizen/directionsQuestionnaire/pages/self-witness.ts
@@ -2,18 +2,23 @@ import I = CodeceptJS.I
 
 const I: I = actor()
 
+const heading = {
+  text: 'Do you want to give evidence?'
+}
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class SelfWitnessPage {
 
   chooseYes (): void {
+    I.waitForText(heading.text)
     I.checkOption('Yes')
     I.click(buttons.submit)
   }
 
   chooseNo (): void {
+    I.waitForText(heading.text)
     I.checkOption('No')
     I.click(buttons.submit)
   }

--- a/src/integration-test/tests/citizen/directionsQuestionnaire/pages/support-required.ts
+++ b/src/integration-test/tests/citizen/directionsQuestionnaire/pages/support-required.ts
@@ -4,22 +4,22 @@ const I: I = actor()
 
 const fields = {
   disabledAccess: {
-    input: 'input[id="disabledAccessSelectedtrue"]'
+    input: { css: 'input[id="disabledAccessSelectedtrue"]' }
   },
   hearingLoop: {
-    input: 'input[id="hearingLoopSelectedtrue"]'
+    input: { css: 'input[id="hearingLoopSelectedtrue"]' }
   },
   signLanguageInterpreter: {
-    input: 'input[id="signLanguageSelectedtrue"]',
-    details: 'input[id="signLanguageInterpreted"]'
+    input: { css: 'input[id="signLanguageSelectedtrue"]' },
+    details: { css: 'input[id="signLanguageInterpreted"]' }
   },
   languageInterpreter: {
-    input: 'input[id="languageSelectedtrue"]',
-    details: 'input[id="languageInterpreted"]'
+    input: { css: 'input[id="languageSelectedtrue"]' },
+    details: { css: 'input[id="languageInterpreted"]' }
   },
   otherSupport: {
-    input: 'input[id="otherSupportSelectedtrue"]',
-    details: 'textarea[id="otherSupport"]'
+    input: { css: 'input[id="otherSupportSelectedtrue"]' },
+    details: { css: 'textarea[id="otherSupport"]' }
   }
 }
 

--- a/src/integration-test/tests/citizen/directionsQuestionnaire/pages/using-expert.ts
+++ b/src/integration-test/tests/citizen/directionsQuestionnaire/pages/using-expert.ts
@@ -3,8 +3,8 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const buttons = {
-  submitExportNo: 'input[id="expertNo"]',
-  submitExpertYes: 'input[id="expertYes"]'
+  submitExportNo: { css: 'input[id="expertNo"]' },
+  submitExpertYes: { css: 'input[id="expertYes"]' }
 }
 
 export class UsingExpertPage {

--- a/src/integration-test/tests/citizen/endToEnd/steps/helper.ts
+++ b/src/integration-test/tests/citizen/endToEnd/steps/helper.ts
@@ -19,8 +19,11 @@ export class Helper {
   }
 
   startResponseFromDashboard (claimRef: string): void {
+    const text = 'Respond to claim'
+    I.waitForText(claimRef)
     I.click(claimRef)
-    I.click('Respond to claim')
+    I.waitForText(text)
+    I.click(text)
   }
 
   finishResponse (
@@ -32,8 +35,7 @@ export class Helper {
       testData.defenceType = DefenceType.FULL_REJECTION_WITH_DISPUTE
     }
     defenceSteps.loginAsDefendant(testData.defendantEmail)
-    I.click(testData.claimRef)
-    I.click('Respond to claim')
+    this.startResponseFromDashboard(testData.claimRef)
     defenceSteps.makeDefenceAndSubmit(
       testData.defendant,
       testData.defendantEmail,

--- a/src/integration-test/tests/citizen/home/pages/login.ts
+++ b/src/integration-test/tests/citizen/home/pages/login.ts
@@ -3,11 +3,11 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const fields = {
-  username: '#username',
-  password: '#password'
+  username: { css: '#username' },
+  password: { css: '#password' }
 }
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class LoginPage {

--- a/src/integration-test/tests/citizen/mediation/pages/can-we-use-company.ts
+++ b/src/integration-test/tests/citizen/mediation/pages/can-we-use-company.ts
@@ -3,22 +3,24 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 const fields = {
-  mediationPhoneNumber: 'input[id="mediationPhoneNumber"]',
-  mediationContactPerson: 'input[id="mediationContactPerson"]'
+  mediationPhoneNumber: { css: 'input[id="mediationPhoneNumber"]' },
+  mediationContactPerson: { css: 'input[id="mediationContactPerson"]' }
 }
 
 export class CanWeUseCompanyPage {
 
   chooseYes (): void {
+    I.waitForText('Yes')
     I.checkOption('Yes')
     I.click(buttons.submit)
   }
 
   chooseNo (mediationPhoneNumber: string, mediationContactPerson: string): void {
+    I.waitForText('No')
     I.checkOption('No')
     I.fillField(fields.mediationPhoneNumber, mediationPhoneNumber)
     I.fillField(fields.mediationContactPerson, mediationContactPerson)

--- a/src/integration-test/tests/citizen/mediation/pages/can-we-use.ts
+++ b/src/integration-test/tests/citizen/mediation/pages/can-we-use.ts
@@ -3,13 +3,13 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 const fields = {
-  mediationPhoneNumber: 'input[id="mediationPhoneNumber"]',
-  optionYes: 'input[id=optionyes]',
-  optionNo: 'input[id=optionno]'
+  mediationPhoneNumber: { css: 'input[id="mediationPhoneNumber"]' },
+  optionYes: { css: 'input[id=optionyes]' },
+  optionNo: { css: 'input[id=optionno]' }
 }
 
 export class CanWeUsePage {

--- a/src/integration-test/tests/citizen/mediation/pages/free-mediation.ts
+++ b/src/integration-test/tests/citizen/mediation/pages/free-mediation.ts
@@ -3,7 +3,7 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class FreeMediationPage {

--- a/src/integration-test/tests/citizen/mediation/pages/how-mediation-works.ts
+++ b/src/integration-test/tests/citizen/mediation/pages/how-mediation-works.ts
@@ -10,6 +10,7 @@ const buttons = {
 export class HowMediationWorksPage {
 
   chooseContinue (): void {
+    I.waitForText('How free mediation works')
     I.click('Continue')
   }
 

--- a/src/integration-test/tests/citizen/mediation/pages/mediation-agreement.ts
+++ b/src/integration-test/tests/citizen/mediation/pages/mediation-agreement.ts
@@ -2,13 +2,19 @@ import I = CodeceptJS.I
 
 const I: I = actor()
 
+const heading = {
+  text: 'You can only use free mediation if you'
+}
+
 export class MediationAgreementPage {
 
   chooseAgree (): void {
+    I.waitForText(heading.text)
     I.click('I agree')
   }
 
   chooseDoNotAgree (): void {
+    I.waitForText(heading.text)
     I.click('I don’t agree')
   }
 }

--- a/src/integration-test/tests/citizen/mediation/pages/try-free-mediation.ts
+++ b/src/integration-test/tests/citizen/mediation/pages/try-free-mediation.ts
@@ -2,18 +2,23 @@ import I = CodeceptJS.I
 
 const I: I = actor()
 
+const heading = {
+  text: 'Will you try free mediation?'
+}
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class TryFreeMediationPage {
 
   chooseYes (): void {
+    I.waitForText(heading.text)
     I.checkOption('Yes')
     I.click(buttons.submit)
   }
 
   chooseNo (): void {
+    I.waitForText(heading.text)
     I.checkOption('No')
     I.click(buttons.submit)
   }

--- a/src/integration-test/tests/citizen/mediation/pages/will-you-try-mediation.ts
+++ b/src/integration-test/tests/citizen/mediation/pages/will-you-try-mediation.ts
@@ -3,17 +3,19 @@ import I = CodeceptJS.I
 const I: I = actor()
 
 const buttons = {
-  submit: 'input[type=submit]'
+  submit: { css: 'input[type=submit]' }
 }
 
 export class WillYouTryMediationPage {
 
   chooseYes (): void {
+    I.waitForText('Yes')
     I.checkOption('Yes')
     I.click(buttons.submit)
   }
 
   chooseNo (): void {
+    I.waitForText('No')
     I.checkOption('No')
     I.click(buttons.submit)
   }

--- a/types/steps-override.d.ts
+++ b/types/steps-override.d.ts
@@ -9,6 +9,7 @@ declare namespace CodeceptJS {
     respondToClaim: (referenceNumber: string, ownerEmail: string, responseData: ResponseData, defendantEmail: string) => void
     retrievePin (letterHolderId: string): () => string
     amOnCitizenAppPage: (path: string) => void
+    waitIfOnSafari: () => any
     fillField: (locator: string | object, value: string) => any
     selectOption: (select: string | object, option: string) => any
     rejectAnsweringPCQ: () => any

--- a/types/steps-override.d.ts
+++ b/types/steps-override.d.ts
@@ -9,8 +9,8 @@ declare namespace CodeceptJS {
     respondToClaim: (referenceNumber: string, ownerEmail: string, responseData: ResponseData, defendantEmail: string) => void
     retrievePin (letterHolderId: string): () => string
     amOnCitizenAppPage: (path: string) => void
-    fillField: (locator: string, value: string) => any
-    selectOption: (select: string, option: string) => any
+    fillField: (locator: string | object, value: string) => any
+    selectOption: (select: string | object, option: string) => any
     rejectAnsweringPCQ: () => any
     bypassPCQ: () => Promise<any>
     checkPCQHealth: () => Promise<boolean>


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/TA-371
https://tools.hmcts.net/jira/browse/TA-373

### Change description

Run @CrossBrowser tagged e2e test in Safari and Edge (as well as the existing Firefox and Chrome) via an additional command in ./bin/run-crossbrowser-tests.sh runner.

Includes a number of test waiting improvements to allow for slower test runs in Saucelab's VRs, so now all of the crossbrowser test's steps will wait for the elements or pages they're about to check before continuing with those checks. This greatly improves stability in the nightly pipeline without a large overhead in the build pipeline.

Includes:
- IE11 commented out due to new IE11 bug that was discovered (https://tools.hmcts.net/jira/browse/ROC-8904)
- additional waiting at defendant-evidence.ts for Safari browser

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
