### PR TITLE
Partial paid amount is deducted twice and showing incorrect payment amount on Repayment plan screen

### DIFF
--- a/src/main/common/helpers/ccjHelper.ts
+++ b/src/main/common/helpers/ccjHelper.ts
@@ -36,7 +36,7 @@ export function isFullAdmissionAcceptation (claim: Claim): boolean {
 export function totalRemainingToPay (claim: Claim): number {
   let total: number = amountSettledFor(claim) + claimFeeInPennies(claim) / 100 - claim.amountPaid()
 
-  if (claim.countyCourtJudgment && claim.countyCourtJudgment.paidAmount) {
+  if (!claim.amountPaid() && claim.countyCourtJudgment && claim.countyCourtJudgment.paidAmount) {
     total -= claim.countyCourtJudgment.paidAmount
   }
 

--- a/src/test/features/ccj/routes/repayment-plan-summary.ts
+++ b/src/test/features/ccj/routes/repayment-plan-summary.ts
@@ -140,6 +140,7 @@ describe('CCJ - repayment plan summary page', () => {
             },
             respondedAt: MomentFactory.currentDateTime(),
             countyCourtJudgmentRequestedAt: '2017-10-10T22:45:51.785',
+            paidAmount: 2,
             countyCourtJudgment: {
               defendantDateOfBirth: '1990-11-01',
               paidAmount: 2,


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ROC-7513

In case of CCJ if paid amount is already updated we should not remove CCJ paid amount again  from the total amount.

1. If CCJ created from Part Admission pay by set date and claimant accepts the offer formalises CCJ --> Claim.paidAmount is updated with CCJ paid amount

2. If CCJ created from Part Admission pay immediately and claimant accepts the offer --> defendant does not pay within deadline --> claimant raises CCJ --> Claim.paidAmount is null and calculations are made from CCJ paidamount