### PR TITLE
Fix title missing on cookies page

### DIFF
--- a/src/main/views/cookies.njk
+++ b/src/main/views/cookies.njk
@@ -1,5 +1,9 @@
 {% extends "layout.njk" %}
 
+{% set heading = 'Cookies' %}
+
+{% set headingVisible = false %}
+
 {% block content %}
   <div class="grid-row">
     <div class="govuk-!-margin-left-4">


### PR DESCRIPTION
Home page: <title>Your money claims account - Money Claims</title>

Cookies page: <title> - Money Claims</title>

Untested but should be fine